### PR TITLE
RFC 0036 PR 1: the four owners of REF transparency (value_element_ts, time_series_value_equivalent, NamedPort::observed, through_reference / bound_target_is_reference, bridge value_port)

### DIFF
--- a/docs/source/developer_guide/operators.rst
+++ b/docs/source/developer_guide/operators.rst
@@ -174,6 +174,23 @@ computed schema — the result schema is **never rewritten**; consumers bind
 through the reference at runtime, and matching simply treats the two shapes as
 the same type.
 
+**The rule has four owners** (RFC 0036), and a site that reasons about a
+schema binding never rewrites calls one of them instead of dereferencing for
+itself: a ``NamedPort`` answers ``observed()`` -- the port as the declared
+parameter will observe it, dereferenced unless the declaration is a ``REF``
+(the argument helpers of ``operator_type_resolution.h`` already read this
+way); ``TypeRegistry::value_element_ts`` answers the element of a ``TSD`` /
+``TSL`` with every reference followed; ``time_series_value_equivalent``
+(``endpoint_schema.h``) compares two schemas through references on both
+sides -- ``REF[TS[int]]`` is value-equivalent to ``TS[int]`` and not to
+``TS[float]`` -- and is what ``input_accepts_output_schema`` and every
+alternative-shape check use; ``TSOutputView::through_reference()`` resolves
+a ``REF`` output to its referenced value before a structural hop, and
+``TSInputView::bound_target_is_reference()`` reads whether a link's bound
+output can move, recorded when the link binds. ``TypeRegistry::ref`` is
+idempotent (``ref(REF[X])`` is ``REF[X]``), so wrapping a possibly-referenced
+schema is ``ref(x)``, never ``ref(dereference(x))``.
+
 **SIGNAL input compatibility.** In input position, ``SIGNAL`` follows the same
 rule as ordinary node / graph wiring: an ``In<..., SIGNAL>`` or ``Port<SIGNAL>``
 overload accepts any time-series source and observes only its tick / modified

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -496,6 +496,14 @@ Value and reference crossings
   inserts the from-REF adaptation); a REF parameter receives the reference
   itself — ``bundle_port``'s reference-shape handling implements this and
   carries the ruling comment.
+- **The bridge exposes the owners of REF transparency** (RFC 0036) so the
+  wiring machinery never re-derives the rule: ``value_port(wiring, port)``
+  is the port as a value consumer observes it (the top-level reference
+  followed and, below it, the structural descent input binding installs, so
+  a structural ``TSB`` / fixed ``TSL`` of references becomes per-field /
+  per-element value projections); ``value_element_ts(ts_type)`` is the
+  element of a ``TSD`` / ``TSL`` with every reference followed. ``is_ref``
+  and ``ref_target`` remain for authors who ask for a reference explicitly.
 - **Set deltas are shaped by class identity**: a plain ``frozenset`` crossing
   into a TSS applies as the *full value*; a ``_SetDelta`` (registered with C++
   at import via ``_set_set_delta_class``) applies as a *delta*. Same duality

--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -204,6 +204,10 @@ Each entry names the layer that owns the rule:
   handling ``is_ref``/``dereferenced`` by hand, when binding inserts the
   from-REF adaptation and the type-pattern matcher binds the dereferenced
   schema;
+* two schemas compared as a paired ``dereference`` when
+  ``time_series_value_equivalent`` (``endpoint_schema.h``) owns
+  reference-transparent equivalence (RFC 0036: the count is that owner plus
+  the std operator copies the RFC's second PR retires);
 * the runtime probing ``TSTypeKind::REF`` per tick, when a node's REF handling
   mode is fixed when the node is built;
 * Python wiring choosing a type carrier by operator name, or keeping a shadow

--- a/docs/source/developer_guide/writing_nodes.rst
+++ b/docs/source/developer_guide/writing_nodes.rst
@@ -169,6 +169,26 @@ Structure-preserving packing is different: ``tsb_itemwise`` and the
 they route values rather than consuming them — so they are *not* covered by
 this rule.
 
+**The owners.** Binding applies the rule to the argument it binds; an
+operator that reasons about a schema binding never rewrites (a nested graph's
+output, a collection element, the raw ports a ``compose`` receives) does not
+dereference for itself either. It asks the owner of that question (RFC 0036,
+``operators.rst`` "REF transparency"):
+
+* what will this parameter observe -- ``NamedPort::observed()``, or the
+  ``Dereference``-mode argument helpers of ``operator_type_resolution.h``;
+* what is the element of this ``TSD`` / ``TSL`` -- ``TypeRegistry::value_element_ts``;
+* are these two schemas the same value -- ``time_series_value_equivalent``;
+* the referenced output behind a ``REF`` output, for a structural hop --
+  ``TSOutputView::through_reference()``; whether a link's bound output can
+  move -- ``TSInputView::bound_target_is_reference()``, recorded at bind;
+* a reference to a possibly-referenced schema -- ``TypeRegistry::ref``,
+  which is idempotent.
+
+The ``stdlib-ref-dereference`` and ``paired-dereference-comparisons``
+ratchets (``testing.rst``) hold the hand-written copies at their recorded
+counts while RFC 0036's remaining PRs retire them.
+
 Guard overloads through one resolution point
 --------------------------------------------
 

--- a/docs/source/rfc/rfc_0036_reference_transparency_owners.rst
+++ b/docs/source/rfc/rfc_0036_reference_transparency_owners.rst
@@ -436,7 +436,31 @@ Four PRs, each green on the full gate, each lowering its ratchet:
 Implementation status
 ---------------------
 
-Proposed.
+* **PR 1 (owners)** -- landed: ``TypeRegistry::value_element_ts``;
+  ``time_series_value_equivalent`` with every type-layer and runtime copy of
+  the rule migrated (``input_accepts_output_schema`` and the nominal-upcast
+  check of ``adapt_source_for_input``, the output-direction check of
+  ``ts_pattern_match``, the dispatch upcast check, the alternative binding
+  check of ``ts_output.cpp``, ``schema_equivalent_after_dereference`` and
+  its two callers, the ``static_node.h`` and ``shared_output_node.cpp``
+  target checks, the forwarding-tree check of ``nested_bindings.h``) and
+  the ``paired-dereference-comparisons`` ratchet introduced at 12 (the
+  owner plus eleven std operator copies for PR 2); ``NamedPort::observed()``
+  (``value-consumer-source-callers`` 3 → 4); ``TSOutputView::through_reference()``;
+  ``TSInputView::bound_target_is_reference()`` reading the record
+  ``TSInputTargetLinkState::target_is_reference`` that ``bind_impl`` writes
+  on every bind and rebind and ``detach_target`` / ``source_invalidated``
+  clear; the bridge's ``value_port`` and ``value_element_ts``; ``ref``
+  idempotence documented on the registry.
+
+  *Finding:* the shared-output capture's stability test has two halves, and
+  both are properties of the handle the link binds: the output's schema is a
+  ``REF``, *or* the output is itself reached through a target link (the
+  from-REF alternative a value input binds to a ``REF`` output through, a
+  chained adaptor's relay). The record covers both, so
+  ``bound_target_is_reference()`` reads "the bound output can move", and PR
+  3 replaces the probe with the accessor alone.
+* PR 2 (std operators), PR 3 (runtime), PR 4 (Python wiring): pending.
 
 References
 ----------

--- a/include/hgraph/runtime/nested_bindings.h
+++ b/include/hgraph/runtime/nested_bindings.h
@@ -417,10 +417,8 @@ inline bool bind_forwarding_output_tree_to_source(TSOutputView target,
   if (!effective_source.bound()) {
     return clear_forwarding_output_tree(std::move(target), sampled);
   }
-  auto &registry = TypeRegistry::instance();
-  if (!time_series_schema_equivalent(
-          registry.dereference(target.schema()),
-          registry.dereference(effective_source.schema()))) {
+  if (!time_series_value_equivalent(target.schema(),
+                                    effective_source.schema())) {
     throw std::logic_error("Forwarding output tree source schema '" +
                            (effective_source.schema() != nullptr
                                 ? std::string{effective_source.schema()->name()}

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -1527,6 +1527,39 @@ namespace hgraph
         return Port<S>{port.checked_wiring(), port.erased().with_arg_tag(WiringPortRef::ArgTag::Passive)};
     }
 
+    namespace graph_wiring_detail
+    {
+        /** True when a static schema declares a reference at its top level. */
+        template <typename S>
+        struct declares_reference : std::false_type
+        {
+        };
+        template <typename S>
+        struct declares_reference<REF<S>> : std::true_type
+        {
+        };
+        template <typename S>
+        inline constexpr bool declares_reference_v = declares_reference<S>::value;
+
+        /**
+         * Describe a source by the value a consumer should observe rather than
+         * by any REF token used to reach that value, so ordinary input binding
+         * installs the same REF-transparent adaptation as a typed ``In<T>``.
+         * Dereferencing is recursive for container schemas.
+         *
+         * Ordinary operator implementations do not call this themselves:
+         * ``operator_dispatch_detail::value_argument`` applies it from the
+         * declared parameter contract. Framework wiring surfaces that bypass
+         * operator dispatch must apply it explicitly when their contract
+         * consumes a value rather than a reference.
+         */
+        [[nodiscard]] inline WiringPortRef value_consumer_source(WiringPortRef source)
+        {
+            source.schema = TypeRegistry::instance().dereference(source.schema);
+            return source;
+        }
+    }  // namespace graph_wiring_detail
+
     template <fixed_string Name, typename S>
     struct NamedPort : Port<S>
     {
@@ -1534,6 +1567,21 @@ namespace hgraph
 
         using Port<S>::Port;
         NamedPort(Port<S> base) : Port<S>(std::move(base)) {}
+
+        /**
+         * The port as this parameter observes it (RFC 0036, "a declared port
+         * observes its declared shape"): its schema with every reference
+         * followed, unless ``S`` declares a ``REF`` at its top level, in which
+         * case the port as supplied. This is what ``value_argument`` binds for
+         * the parameter, readable before binding -- a ``compose`` that reasons
+         * about an argument's shape reads this, never the raw schema followed
+         * by a ``dereference``.
+         */
+        [[nodiscard]] WiringPortRef observed() const
+        {
+            if constexpr (graph_wiring_detail::declares_reference_v<S>) { return this->erased(); }
+            else { return graph_wiring_detail::value_consumer_source(this->erased()); }
+        }
     };
 
     namespace graph_wiring_detail
@@ -1832,10 +1880,10 @@ namespace hgraph
             if (input_schema == nullptr || output_schema == nullptr) { return false; }
             if (input_schema->kind == TSTypeKind::SIGNAL) { return true; }
 
+            if (time_series_value_equivalent(input_schema, output_schema)) { return true; }
             auto &registry = TypeRegistry::instance();
             const auto *input = registry.dereference(input_schema);
             const auto *output = registry.dereference(output_schema);
-            if (time_series_schema_equivalent(input, output)) { return true; }
             if (input_schema->kind == TSTypeKind::TSD &&
                 output_schema->kind == TSTypeKind::TSD &&
                 input_schema->key_type() == output_schema->key_type())
@@ -2187,24 +2235,6 @@ namespace hgraph
 
         [[nodiscard]] HGRAPH_EXPORT WiringPortRef adapt_source_for_input(
             Wiring &w, const TSValueTypeMetaData *input_schema, WiringPortRef source);
-
-        /**
-         * Describe a source by the value a consumer should observe rather than
-         * by any REF token used to reach that value, so ordinary input binding
-         * installs the same REF-transparent adaptation as a typed ``In<T>``.
-         * Dereferencing is recursive for container schemas.
-         *
-         * Ordinary operator implementations do not call this themselves:
-         * ``operator_dispatch_detail::value_argument`` applies it from the
-         * declared parameter contract. Framework wiring surfaces that bypass
-         * operator dispatch must apply it explicitly when their contract
-         * consumes a value rather than a reference.
-         */
-        [[nodiscard]] inline WiringPortRef value_consumer_source(WiringPortRef source)
-        {
-            source.schema = TypeRegistry::instance().dereference(source.schema);
-            return source;
-        }
 
         // ---- context scopes (see *Contexts* in services.rst) ----
         // The wiring-time context stack lives on the OperatorRegistry singleton

--- a/include/hgraph/types/metadata/type_registry.h
+++ b/include/hgraph/types/metadata/type_registry.h
@@ -382,7 +382,12 @@ namespace hgraph
          * ``name`` is not a named TSB. Lookup-only — does not synthesise.
          */
         [[nodiscard]] const TSValueTypeMetaData *named_tsb(std::string_view name) const;
-        /** Intern a ``REF`` to the supplied time-series. */
+        /**
+         * Intern a ``REF`` to the supplied time-series. Idempotent: the
+         * reference to a reference is that reference (``ref(REF[X])`` is
+         * ``REF[X]``), so a consumer wrapping a possibly-referenced schema
+         * writes ``ref(x)``, never ``ref(dereference(x))`` (RFC 0036).
+         */
         const TSValueTypeMetaData *ref(const TSValueTypeMetaData *referenced_ts);
 
         /** True when ``meta`` is a ``REF`` or contains a ``REF`` reachable through its structure. */
@@ -416,6 +421,14 @@ namespace hgraph
          * pointer. Results are cached for repeated lookups.
          */
         const TSValueTypeMetaData *dereference(const TSValueTypeMetaData *meta);
+        /**
+         * The element of a ``TSD`` / ``TSL`` as an access through the element
+         * link observes it: the element schema with every reference followed
+         * (RFC 0036, "elements are observed by value"). A reference to the
+         * collection itself is followed first. Throws for a schema with no
+         * element.
+         */
+        const TSValueTypeMetaData *value_element_ts(const TSValueTypeMetaData *collection);
 
     private:
         TypeRegistry() = default;

--- a/include/hgraph/types/static_node.h
+++ b/include/hgraph/types/static_node.h
@@ -1405,8 +1405,7 @@ namespace hgraph
                 throw std::invalid_argument("Out<REF<S>>::set reference has no target schema");
             }
 
-            auto &registry = TypeRegistry::instance();
-            if (!time_series_schema_equivalent(registry.dereference(actual), registry.dereference(expected)))
+            if (!time_series_value_equivalent(actual, expected))
             {
                 throw std::invalid_argument("Out<REF<S>>::set reference target schema does not match output schema");
             }

--- a/include/hgraph/types/time_series/endpoint_schema.h
+++ b/include/hgraph/types/time_series/endpoint_schema.h
@@ -111,6 +111,18 @@ namespace hgraph
         const TSValueTypeMetaData *lhs, const TSValueTypeMetaData *rhs) noexcept;
 
     /**
+     * ``time_series_schema_equivalent`` after following references on both
+     * sides: the REF transparency rule of ``operators.rst`` applied to two
+     * schemas (RFC 0036, "equivalence is reference-transparent").
+     * ``REF[TS[int]]`` and ``TS[int]`` are value-equivalent; ``REF[TS[int]]``
+     * and ``TS[float]`` are not. The one place the tree spells the paired
+     * dereference (ratchet ``paired-dereference-comparisons``); a site that
+     * compares two schemas through references calls this.
+     */
+    [[nodiscard]] HGRAPH_EXPORT bool time_series_value_equivalent(const TSValueTypeMetaData *lhs,
+                                                                  const TSValueTypeMetaData *rhs);
+
+    /**
      * A value schema with its STORAGE CATEGORY removed, for type comparison.
      *
      * ``Owned<>`` and ``Shared<>`` are hints to the layout factory and to

--- a/include/hgraph/types/time_series/ts_input/base_view.h
+++ b/include/hgraph/types/time_series/ts_input/base_view.h
@@ -163,6 +163,16 @@ namespace hgraph
         /** Bound output reached by this target-link view, or an empty handle when unbound. */
         [[nodiscard]] TSOutputView bound_output() const;
 
+        /**
+         * True when the output this input's link bound can retarget without
+         * the link rebinding: a ``REF`` output, or an output itself reached
+         * through a target link (a from-REF alternative, a chained adaptor's
+         * relay). The link records it when it binds or rebinds (RFC 0036);
+         * never a schema probe on the tick path. False when the input is not
+         * bindable or not bound.
+         */
+        [[nodiscard]] bool bound_target_is_reference() const noexcept;
+
         void bind_output(const TSOutputView &output);
         /**
          * Rebind a runtime-owned route without scheduling its active consumer.

--- a/include/hgraph/types/time_series/ts_input/target_link.h
+++ b/include/hgraph/types/time_series/ts_input/target_link.h
@@ -80,6 +80,10 @@ namespace hgraph::detail
 
         TSInputTargetLinkStorage *owner{nullptr};
         TSOutputHandle target{};
+        /** Recorded with ``target`` on every bind / rebind: the bound output
+            can retarget without this link rebinding (a REF output, or an
+            output itself reached through a target link). RFC 0036. */
+        bool target_is_reference{false};
         SchedulingNotifier  scheduling_notifier;
         std::unique_ptr<TSInputTargetActiveNode> active_root_node{};
     };
@@ -94,6 +98,9 @@ namespace hgraph::detail
         ~TSInputTargetLinkStorage() noexcept;
 
         [[nodiscard]] bool bound() const noexcept;
+        /** The bind-time record: true while bound to an output that can
+            retarget without this link rebinding (RFC 0036). */
+        [[nodiscard]] bool bound_target_is_reference() const noexcept;
         void bind(const TSValueTypeMetaData &schema, const TSOutputView &output);
         void bind_current_value(const TSValueTypeMetaData &schema, const TSOutputView &output,
                                 DateTime modified_time);

--- a/include/hgraph/types/time_series/ts_output/base_view.h
+++ b/include/hgraph/types/time_series/ts_output/base_view.h
@@ -161,6 +161,16 @@ namespace hgraph
          */
         [[nodiscard]] TSOutputHandle binding_for(const TSValueTypeMetaData &requested_schema) const;
 
+        /**
+         * The view of the referenced output when this view's schema is a
+         * ``REF`` (its from-REF alternative), otherwise this view (RFC 0036,
+         * "a structural hop through a reference resolves the reference
+         * first"). A structural hop (key set, field, element) through a
+         * reference goes through it. Edge-binding time: it interns the
+         * dereferenced schema.
+         */
+        [[nodiscard]] TSOutputView through_reference() const;
+
         /** Begin a mutation through this output endpoint view. */
         [[nodiscard]] TSDataMutationView begin_mutation(DateTime evaluation_time) const;
 

--- a/python/py_ports.cpp
+++ b/python/py_ports.cpp
@@ -210,6 +210,17 @@ void bind_ports(nb::module_ &m) {
         *wiring.raw, ref_schema, port.ref)};
   });
 
+  m.def("value_port", [](PyWiring &wiring, const PyPort &port) {
+    // The port as a value consumer observes it (RFC 0036): the top-level
+    // reference followed and, below it, the structural descent input binding
+    // installs for a declared input of the observed shape - a structural
+    // TSB / fixed TSL of references becomes per-field / per-element value
+    // projections. This is what the wiring machinery reconstructed by hand.
+    const auto *observed = TypeRegistry::instance().dereference(port.ref.schema);
+    return PyPort{graph_wiring_detail::adapt_source_for_input(
+        *wiring.raw, observed, port.ref)};
+  });
+
   m.def("un_named_tsb_type", [](nb::list fields) {
     std::vector<std::pair<std::string, const TSValueTypeMetaData *>>
         field_metas;

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -1013,6 +1013,11 @@ namespace hgraph::python_bridge
     m.def("ts", [](PyValueType v) { return PyTsType{TypeRegistry::instance().ts(v.meta)}; });
     m.def("ref_ts", [](PyTsType target) { return PyTsType{TypeRegistry::instance().ref(target.meta)}; });
     m.def("ref_target", [](PyTsType ref) { return PyTsType{TypeRegistry::instance().dereference(ref.meta)}; });
+    m.def(
+        "value_element_ts",
+        [](PyTsType collection) { return PyTsType{TypeRegistry::instance().value_element_ts(collection.meta)}; },
+        "The element of a TSD / TSL as an access through the element link observes it: "
+        "every reference followed (RFC 0036).");
     m.def("set_vt", [](PyValueType e) { return PyValueType{TypeRegistry::instance().set(e.meta)}; });
     m.def("map_vt", [](PyValueType k, PyValueType v) {
         return PyValueType{TypeRegistry::instance().map(k.meta, v.meta)};

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -73,13 +73,25 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
     Ratchet(
         id="value-consumer-source-callers",
-        baseline=3,
+        baseline=4,
         roots=("src/hgraph", "include/hgraph", "python"),
         suffixes=(".cpp", ".h"),
         pattern=r"\bvalue_consumer_source\(",
-        owner="value_argument (variadic tails) and adapt_source_for_input "
-        "(ordinary inputs) are the two rule sites; declaration + those two "
-        "is the floor",
+        owner="value_argument (variadic tails), adapt_source_for_input "
+        "(ordinary inputs) and NamedPort::observed (what a compose reads "
+        "before binding, RFC 0036) are the three rule sites; declaration + "
+        "those three is the floor",
+    ),
+    Ratchet(
+        id="paired-dereference-comparisons",
+        baseline=12,
+        roots=("src/hgraph", "include/hgraph", "python"),
+        suffixes=(".cpp", ".h"),
+        pattern=r"time_series_schema_equivalent\(\s*(?:registry|TypeRegistry::instance\(\))\.dereference\(",
+        owner="time_series_value_equivalent (endpoint_schema.h) is the one "
+        "place that compares two schemas after following references (RFC "
+        "0036); a comparison site calls it. The count is the owner plus the "
+        "std operator copies RFC 0036's second PR retires",
     ),
     # --- REF ownership at nested boundaries is a build-time property (family 2) ---
     Ratchet(

--- a/python/tests/test_reference_transparency_owners.py
+++ b/python/tests/test_reference_transparency_owners.py
@@ -9,32 +9,37 @@ spelling ``is_ref`` / ``dereferenced`` (RFC 0036, PR 4).
 import _hgraph as hg
 import pytest
 
-
-def _ts(text: str):
-    return hg.ts_type(text)
+INT = hg.value_type("int")
+STR = hg.value_type("str")
+TS_INT = hg.ts(INT)
+REF_INT = hg.ref_ts(TS_INT)
 
 
 def test_value_element_ts_follows_every_reference():
-    assert hg.value_element_ts(_ts("TSD[str, REF[TS[int]]]")) == _ts("TS[int]")
-    assert hg.value_element_ts(_ts("TSD[str, TS[int]]")) == _ts("TS[int]")
-    assert hg.value_element_ts(_ts("TSL[REF[TS[int]], Size[2]]")) == _ts("TS[int]")
-    assert hg.value_element_ts(_ts("REF[TSD[str, REF[TS[int]]]]")) == _ts("TS[int]")
-    assert hg.value_element_ts(_ts("TSD[str, REF[TSD[str, REF[TS[int]]]]]")) == _ts("TSD[str, TS[int]]")
+    assert hg.value_element_ts(hg.tsd(STR, REF_INT)) == TS_INT
+    assert hg.value_element_ts(hg.tsd(STR, TS_INT)) == TS_INT
+    assert hg.value_element_ts(hg.tsl(REF_INT, 2)) == TS_INT
+    assert hg.value_element_ts(hg.ref_ts(hg.tsd(STR, REF_INT))) == TS_INT
+    nested = hg.tsd(STR, hg.ref_ts(hg.tsd(STR, REF_INT)))
+    assert hg.value_element_ts(nested) == hg.tsd(STR, TS_INT)
 
 
 def test_value_element_ts_refuses_a_schema_without_an_element():
     with pytest.raises(ValueError):
-        hg.value_element_ts(_ts("TS[int]"))
+        hg.value_element_ts(TS_INT)
 
 
 def test_value_port_observes_the_referenced_value():
     w = hg.Wiring()
-    src = w.wire("const", (1,), {}, output_type=_ts("TS[int]"))
-    ref = hg.ref_port(w, src)
+    src = w.wire("const", (1,), {}, output_type=TS_INT)
+    bundle_type = hg.un_named_tsb_type([("a", TS_INT)])
+    bundle = hg.tsb_port(bundle_type, {"a": src})
+    # A structural bundle materialized as a reference: REF[TSB[a: TS[int]]].
+    ref = hg.ref_port(w, bundle)
     assert ref.ts_type.is_ref
 
     observed = hg.value_port(w, ref)
-    assert observed.ts_type == _ts("TS[int]")
+    assert observed.ts_type == bundle_type
     assert not observed.ts_type.is_ref
     # A plain port is observed as it is.
-    assert hg.value_port(w, src).ts_type == _ts("TS[int]")
+    assert hg.value_port(w, src).ts_type == TS_INT

--- a/python/tests/test_reference_transparency_owners.py
+++ b/python/tests/test_reference_transparency_owners.py
@@ -1,0 +1,40 @@
+"""RFC 0036: the bridge exposes the owners of REF transparency.
+
+``value_element_ts`` mirrors ``TypeRegistry::value_element_ts``; ``value_port``
+is the port as a value consumer observes it (the top-level reference followed,
+the structural descent below). The wiring machinery calls these instead of
+spelling ``is_ref`` / ``dereferenced`` (RFC 0036, PR 4).
+"""
+
+import _hgraph as hg
+import pytest
+
+
+def _ts(text: str):
+    return hg.ts_type(text)
+
+
+def test_value_element_ts_follows_every_reference():
+    assert hg.value_element_ts(_ts("TSD[str, REF[TS[int]]]")) == _ts("TS[int]")
+    assert hg.value_element_ts(_ts("TSD[str, TS[int]]")) == _ts("TS[int]")
+    assert hg.value_element_ts(_ts("TSL[REF[TS[int]], Size[2]]")) == _ts("TS[int]")
+    assert hg.value_element_ts(_ts("REF[TSD[str, REF[TS[int]]]]")) == _ts("TS[int]")
+    assert hg.value_element_ts(_ts("TSD[str, REF[TSD[str, REF[TS[int]]]]]")) == _ts("TSD[str, TS[int]]")
+
+
+def test_value_element_ts_refuses_a_schema_without_an_element():
+    with pytest.raises(ValueError):
+        hg.value_element_ts(_ts("TS[int]"))
+
+
+def test_value_port_observes_the_referenced_value():
+    w = hg.Wiring()
+    src = w.wire("const", (1,), {}, output_type=_ts("TS[int]"))
+    ref = hg.ref_port(w, src)
+    assert ref.ts_type.is_ref
+
+    observed = hg.value_port(w, ref)
+    assert observed.ts_type == _ts("TS[int]")
+    assert not observed.ts_type.is_ref
+    # A plain port is observed as it is.
+    assert hg.value_port(w, src).ts_type == _ts("TS[int]")

--- a/src/hgraph/runtime/shared_output_node.cpp
+++ b/src/hgraph/runtime/shared_output_node.cpp
@@ -78,9 +78,7 @@ namespace hgraph
                 throw std::invalid_argument("shared output reference has no target schema");
             }
 
-            auto &registry = TypeRegistry::instance();
-            if (!time_series_schema_equivalent(registry.dereference(actual),
-                                               registry.dereference(config.target_schema)))
+            if (!time_series_value_equivalent(actual, config.target_schema))
             {
                 throw std::invalid_argument("shared output reference target schema does not match output schema");
             }

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -1026,7 +1026,7 @@ WiringPortRef adapt_source_for_input_impl(Wiring &w,
       input_accepts_output_schema(input_schema->element_ts(),
                                   source.schema->element_ts());
   if ((nominal_upcast || keyed_nominal_upcast) &&
-      !time_series_schema_equivalent(input, output)) {
+      !time_series_value_equivalent(input_schema, source.schema)) {
     WiringArg arg;
     arg.kind = WiringArg::Kind::TimeSeries;
     arg.port = std::move(source);

--- a/src/hgraph/types/metadata/type_registry.cpp
+++ b/src/hgraph/types/metadata/type_registry.cpp
@@ -2153,7 +2153,15 @@ namespace hgraph
             }
             throw std::invalid_argument(message);
         }
-        return value->element_ts();
+        const auto *element = value->element_ts();
+        if (element == nullptr)
+        {
+            std::string message{"TypeRegistry::value_element_ts: collection schema has no element"};
+            message += ": ";
+            message += value->name();
+            throw std::invalid_argument(message);
+        }
+        return element;
     }
 
     const TSValueTypeMetaData *TypeRegistry::dereference(const TSValueTypeMetaData *meta)

--- a/src/hgraph/types/metadata/type_registry.cpp
+++ b/src/hgraph/types/metadata/type_registry.cpp
@@ -2137,6 +2137,25 @@ namespace hgraph
         }
     }
 
+    const TSValueTypeMetaData *TypeRegistry::value_element_ts(const TSValueTypeMetaData *collection)
+    {
+        // dereference follows the collection's own reference and recurses into
+        // its element, so the dereferenced collection's element is the element
+        // with every reference followed.
+        const auto *value = dereference(collection);
+        if (value == nullptr || (value->kind != TSTypeKind::TSD && value->kind != TSTypeKind::TSL))
+        {
+            std::string message{"TypeRegistry::value_element_ts requires a TSD or TSL schema"};
+            if (collection != nullptr)
+            {
+                message += ": ";
+                message += collection->name();
+            }
+            throw std::invalid_argument(message);
+        }
+        return value->element_ts();
+    }
+
     const TSValueTypeMetaData *TypeRegistry::dereference(const TSValueTypeMetaData *meta)
     {
         const std::lock_guard lock(mutex_);

--- a/src/hgraph/types/operator_dispatch.cpp
+++ b/src/hgraph/types/operator_dispatch.cpp
@@ -366,11 +366,12 @@ namespace hgraph
                 return 0;
             }
 
+            const auto *resolved = ts_pattern_resolve(pattern, map);
             TypeRegistry &registry = TypeRegistry::instance();
-            const auto *expected = registry.dereference(ts_pattern_resolve(pattern, map));
+            const auto *expected = registry.dereference(resolved);
             const auto *actual = registry.dereference(concrete);
             if (expected == nullptr || actual == nullptr ||
-                time_series_schema_equivalent(expected, actual) ||
+                time_series_value_equivalent(resolved, concrete) ||
                 expected->kind != TSTypeKind::TS || actual->kind != TSTypeKind::TS)
             {
                 return 0;

--- a/src/hgraph/types/time_series/endpoint_schema.cpp
+++ b/src/hgraph/types/time_series/endpoint_schema.cpp
@@ -1,5 +1,7 @@
 #include <hgraph/types/time_series/endpoint_schema.h>
 
+#include <hgraph/types/metadata/type_registry.h>
+
 #include <stdexcept>
 #include <string_view>
 #include <utility>
@@ -104,6 +106,12 @@ namespace hgraph
             schema = schema->element_type;
         }
         return schema;
+    }
+
+    bool time_series_value_equivalent(const TSValueTypeMetaData *lhs, const TSValueTypeMetaData *rhs)
+    {
+        auto &registry = TypeRegistry::instance();
+        return time_series_schema_equivalent(registry.dereference(lhs), registry.dereference(rhs));
     }
 
     bool time_series_schema_equivalent(const TSValueTypeMetaData *lhs,

--- a/src/hgraph/types/time_series/ts_input/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_input/base_view.cpp
@@ -390,6 +390,13 @@ namespace hgraph
         return link->resolved_target_at_path(*schema, data_.target_path_node()).view(evaluation_time_);
     }
 
+    bool TSInputView::bound_target_is_reference() const noexcept
+    {
+        if (!is_target_position()) { return false; }
+        const auto *link = data_.link_storage();
+        return link != nullptr && link->bound_target_is_reference();
+    }
+
     bool TSInputView::valid() const
     {
         const auto &data = data_view();

--- a/src/hgraph/types/time_series/ts_input/target_link.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link.cpp
@@ -62,6 +62,14 @@ namespace hgraph::detail
 
     namespace
     {
+        /** RFC 0036: the bound output can retarget without the link rebinding. */
+        [[nodiscard]] bool target_can_move(const TSOutputHandle &target) noexcept
+        {
+            const auto *schema = target.schema();
+            return (schema != nullptr && schema->kind == TSTypeKind::REF) ||
+                   target_link_storage(target.data_view()) != nullptr;
+        }
+
         [[nodiscard]] bool is_closed_union_narrowing(
             const TSValueTypeMetaData &requested,
             const TSValueTypeMetaData *source) noexcept
@@ -716,6 +724,7 @@ namespace hgraph::detail
         other.scheduling_notifier.set_target(nullptr);
 
         target = other.target;
+        target_is_reference = std::exchange(other.target_is_reference, false);
         if (target.bound())
         {
             replace_observer(target, &other, this);
@@ -975,6 +984,12 @@ namespace hgraph::detail
 
         auto &state = state_;
         state.target = target;
+        // RFC 0036: whether the bound endpoint can move is a property of the
+        // handle chosen here, so it is recorded once per bind / rebind and
+        // never probed on the tick path. A REF output retargets as its
+        // reference ticks; an output itself reached through a target link (a
+        // from-REF alternative, a chained adaptor's relay) retargets with it.
+        state.target_is_reference = target_can_move(target);
         auto rollback = make_scope_exit<true>([this] { unbind(); });
         state.target.data_view().subscribe(&state);
         // A sampled rebind represents the source's current value at
@@ -1025,6 +1040,7 @@ namespace hgraph::detail
         unsubscribe_active_target();
         if (state_.target.bound()) { state_.target.data_view().unsubscribe(&state_); }
         state_.target.reset();
+        state_.target_is_reference = false;
     }
 
     void TSInputTargetLinkStorage::unbind_noexcept() noexcept
@@ -1039,6 +1055,7 @@ namespace hgraph::detail
         static_cast<void>(source);
         state_.clear_active_observed();
         state_.target.reset();
+        state_.target_is_reference = false;
         structural_ops_->source_invalidated(*this);
     }
 
@@ -1197,6 +1214,11 @@ namespace hgraph::detail
     const TSInputTargetLinkState *TSInputTargetLinkStorage::state() const noexcept
     {
         return &state_;
+    }
+
+    bool TSInputTargetLinkStorage::bound_target_is_reference() const noexcept
+    {
+        return state_.target.bound() && state_.target_is_reference;
     }
 
     DynamicStorageMetrics TSInputTargetLinkStorage::dynamic_storage_metrics() const noexcept

--- a/src/hgraph/types/time_series/ts_output.cpp
+++ b/src/hgraph/types/time_series/ts_output.cpp
@@ -195,13 +195,11 @@ TSOutput::binding_for(const TSOutputView &source,
     return source.handle();
   }
 
-  auto &registry = TypeRegistry::instance();
   const bool signal_from_reference =
       requested_schema.kind == TSTypeKind::SIGNAL &&
       source_schema->kind == TSTypeKind::REF;
   if (!signal_from_reference &&
-      !time_series_schema_equivalent(registry.dereference(source_schema),
-                                     registry.dereference(&requested_schema))) {
+      !time_series_value_equivalent(source_schema, &requested_schema)) {
     throw std::invalid_argument("TSOutput alternative binding requires "
                                 "dereference-compatible schemas: source '" +
                                 std::string{source_schema->name()} +

--- a/src/hgraph/types/time_series/ts_output/alternative.cpp
+++ b/src/hgraph/types/time_series/ts_output/alternative.cpp
@@ -52,13 +52,6 @@ namespace hgraph::detail
             return time != MIN_DT ? time : MIN_ST;
         }
 
-        [[nodiscard]] bool schema_equivalent_after_dereference(const TSValueTypeMetaData *lhs,
-                                                               const TSValueTypeMetaData *rhs)
-        {
-            auto &registry = TypeRegistry::instance();
-            return time_series_schema_equivalent(registry.dereference(lhs), registry.dereference(rhs));
-        }
-
         [[nodiscard]] TSRoleTypeRef checked_endpoint_storage_type(const TSEndpointSchema &endpoint_schema)
         {
             const auto type = output_data_storage_type_for(endpoint_schema);
@@ -108,7 +101,7 @@ namespace hgraph::detail
         {
             const auto *target_schema = requested_schema->referenced_ts();
             return target_schema != nullptr && target_schema->kind != TSTypeKind::REF &&
-                   schema_equivalent_after_dereference(target_schema, source_schema);
+                   time_series_value_equivalent(target_schema, source_schema);
         }
 
         [[nodiscard]] bool to_ref_shape_matches_bundle(const TSValueTypeMetaData *source_schema,
@@ -275,7 +268,7 @@ namespace hgraph::detail
             if (time_series_schema_equivalent(source_schema, requested_schema)) { return true; }
             if (source_schema->kind == TSTypeKind::REF && requested_schema->kind != TSTypeKind::REF)
             {
-                return schema_equivalent_after_dereference(source_schema->referenced_ts(), requested_schema);
+                return time_series_value_equivalent(source_schema->referenced_ts(), requested_schema);
             }
             if (source_schema->kind != requested_schema->kind) { return false; }
             return from_ref_interior_shape_matcher_for(requested_schema->kind)(source_schema, requested_schema,

--- a/src/hgraph/types/time_series/ts_output/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_output/base_view.cpp
@@ -1,5 +1,7 @@
 #include <hgraph/types/time_series/ts_output/base_view.h>
 
+#include <hgraph/types/metadata/type_registry.h>
+
 #include <hgraph/runtime/graph.h>
 #include <hgraph/runtime/node.h>
 #include <hgraph/types/time_series/ts_input/detail.h>
@@ -192,6 +194,14 @@ namespace hgraph
             throw std::logic_error("TSOutputView::binding_for requires a bound output view");
         }
         return output_->binding_for(*this, requested_schema);
+    }
+
+    TSOutputView TSOutputView::through_reference() const
+    {
+        const auto *current = schema();
+        if (current == nullptr || current->kind != TSTypeKind::REF) { return borrowed_ref(); }
+        const auto *target = TypeRegistry::instance().dereference(current);
+        return binding_for(*target).view(evaluation_time_);
     }
 
     TSDataMutationView TSOutputView::begin_mutation(DateTime evaluation_time) const

--- a/src/hgraph/types/type_pattern.cpp
+++ b/src/hgraph/types/type_pattern.cpp
@@ -284,8 +284,7 @@ namespace hgraph
             // adapt at input binding.)
             if (const TSValueTypeMetaData *bound = map.find_ts(pattern.name))
             {
-                auto &registry = TypeRegistry::instance();
-                return time_series_schema_equivalent(registry.dereference(bound), registry.dereference(concrete));
+                return time_series_value_equivalent(bound, concrete);
             }
             if (!ts_allowed_by_constraints(pattern, concrete)) { return false; }
             map.bind_ts(pattern.name, concrete);

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -292,6 +292,7 @@ hgraph_add_test_objects(hgraph_value_test_objects
     test_type_pointer.cpp
     test_tsd_proxy.cpp
     test_python_ops.cpp
+    test_reference_transparency_owners.cpp
     test_type_registry.cpp
     test_value.cpp
     test_value_builder.cpp

--- a/tests/cpp/test_reference_transparency_owners.cpp
+++ b/tests/cpp/test_reference_transparency_owners.cpp
@@ -115,6 +115,8 @@ TEST_CASE("RFC 0036 owners: value_element_ts answers the element with every refe
     CHECK_THROWS_AS(registry.value_element_ts(f.ts_int), std::invalid_argument);
     CHECK_THROWS_AS(registry.value_element_ts(f.ref_int), std::invalid_argument);
     CHECK_THROWS_AS(registry.value_element_ts(nullptr), std::invalid_argument);
+    // A constructible collection with no element is refused, never answered as null.
+    CHECK_THROWS_AS(registry.value_element_ts(registry.tsl(nullptr, 2)), std::invalid_argument);
 }
 
 TEST_CASE("RFC 0036 owners: ref is idempotent so ref(dereference(x)) is ref(x)")

--- a/tests/cpp/test_reference_transparency_owners.cpp
+++ b/tests/cpp/test_reference_transparency_owners.cpp
@@ -1,0 +1,251 @@
+// RFC 0036 (docs/source/rfc/rfc_0036_reference_transparency_owners.rst):
+// the four owners of the REF transparency rule, exercised directly.
+#include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/time_series/endpoint_schema.h>
+#include <hgraph/types/time_series/ts_input.h>
+#include <hgraph/types/time_series/ts_output.h>
+#include <hgraph/types/time_series_reference.h>
+#include <hgraph/types/value/value.h>
+#include <hgraph/util/date_time.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <stdexcept>
+
+namespace
+{
+    using namespace hgraph;
+
+    struct OwnersFixture
+    {
+        TypeRegistry              &registry = TypeRegistry::instance();
+        const ValueTypeMetaData   *int_meta = registry.register_scalar<std::int32_t>("int32");
+        const ValueTypeMetaData   *float_meta = registry.register_scalar<double>("float64");
+        const TSValueTypeMetaData *ts_int   = registry.ts(int_meta);
+        const TSValueTypeMetaData *ts_float = registry.ts(float_meta);
+        const TSValueTypeMetaData *ref_int  = registry.ref(ts_int);
+    };
+
+    void set_int(TSOutput &output, std::int32_t value, DateTime time)
+    {
+        Value wrapped{value};
+        auto  mutation = output.view(time).begin_mutation(time);
+        REQUIRE(mutation.copy_value_from(wrapped.view()));
+    }
+
+    void set_reference(TSOutput &ref_output, const TSOutput &target, DateTime time)
+    {
+        Value wrapped{TimeSeriesReference{target.view(time)}};
+        auto  mutation = ref_output.view(time).begin_mutation(time);
+        REQUIRE(mutation.copy_value_from(wrapped.view()));
+    }
+
+    struct OwnersConstantSource
+    {
+        static constexpr auto name              = "rfc0036_constant_source";
+        static constexpr bool schedule_on_start = true;
+        static void           eval(Out<TS<Int>> out) { out.set(Int{41}); }
+    };
+
+    struct OwnersRefCopy
+    {
+        static constexpr auto name              = "rfc0036_ref_copy";
+        static constexpr bool schedule_on_start = true;
+        static void eval(In<"ref", REF<TS<Int>>> ref, Out<REF<TS<Int>>> out) { out.set(ref.value()); }
+    };
+
+    struct OwnersRefDeref
+    {
+        static constexpr auto name              = "rfc0036_ref_deref";
+        static constexpr bool schedule_on_start = true;
+        static void eval(In<"value", TS<Int>> value, Out<TS<Int>> out) { out.set(value.value()); }
+    };
+
+    /** A compose that reads what its named parameters will observe. */
+    struct ObservedProbeGraph
+    {
+        static constexpr auto name = "rfc0036_observed_probe_graph";
+        static void           compose(Wiring &w)
+        {
+            const auto *ts_int  = schema_descriptor<TS<Int>>::ts_meta();
+            auto        source  = wire<OwnersConstantSource>(w);
+            auto        ref     = wire<OwnersRefCopy>(w, source);
+            REQUIRE(ref.erased().schema->kind == TSTypeKind::REF);
+
+            // A generic parameter observes the value however it is reached.
+            NamedPort<"value", TsVar<"S">> generic{Port<TsVar<"S">>{w, ref.erased()}};
+            CHECK(generic.observed().schema == ts_int);
+            CHECK(generic.erased().schema->kind == TSTypeKind::REF);
+
+            // A REF-declared parameter observes the reference itself.
+            NamedPort<"token", REF<TS<Int>>> token{ref};
+            CHECK(token.observed().schema == ref.erased().schema);
+
+            // A concrete value parameter given a plain source observes it as is.
+            NamedPort<"plain", TS<Int>> plain{source};
+            CHECK(plain.observed().schema == ts_int);
+            CHECK(plain.observed().schema == plain.erased().schema);
+
+            wire<OwnersRefDeref>(w, ref);
+        }
+    };
+}  // namespace
+
+TEST_CASE("RFC 0036 owners: value_element_ts answers the element with every reference followed")
+{
+    OwnersFixture f;
+    auto         &registry = f.registry;
+
+    CHECK(registry.value_element_ts(registry.tsd(f.int_meta, f.ref_int)) == f.ts_int);
+    CHECK(registry.value_element_ts(registry.tsd(f.int_meta, f.ts_int)) == f.ts_int);
+    CHECK(registry.value_element_ts(registry.tsl(f.ref_int, 2)) == f.ts_int);
+    CHECK(registry.value_element_ts(registry.tsl(f.ref_int)) == f.ts_int);
+    CHECK(registry.value_element_ts(registry.tsl(f.ts_int, 3)) == f.ts_int);
+
+    // A reference to the collection is followed first; nested references are
+    // followed all the way down.
+    const auto *dict_of_ref = registry.tsd(f.int_meta, f.ref_int);
+    CHECK(registry.value_element_ts(registry.ref(dict_of_ref)) == f.ts_int);
+    CHECK(registry.value_element_ts(registry.tsd(f.int_meta, registry.ref(dict_of_ref))) ==
+          registry.tsd(f.int_meta, f.ts_int));
+
+    CHECK_THROWS_AS(registry.value_element_ts(f.ts_int), std::invalid_argument);
+    CHECK_THROWS_AS(registry.value_element_ts(f.ref_int), std::invalid_argument);
+    CHECK_THROWS_AS(registry.value_element_ts(nullptr), std::invalid_argument);
+}
+
+TEST_CASE("RFC 0036 owners: ref is idempotent so ref(dereference(x)) is ref(x)")
+{
+    OwnersFixture f;
+    CHECK(f.registry.ref(f.ref_int) == f.ref_int);
+    CHECK(f.registry.ref(f.registry.dereference(f.ref_int)) == f.ref_int);
+}
+
+TEST_CASE("RFC 0036 owners: time_series_value_equivalent compares through references on both sides")
+{
+    OwnersFixture f;
+    auto         &registry = f.registry;
+
+    CHECK(time_series_value_equivalent(f.ref_int, f.ts_int));
+    CHECK(time_series_value_equivalent(f.ts_int, f.ref_int));
+    CHECK(time_series_value_equivalent(f.ref_int, f.ref_int));
+    CHECK(time_series_value_equivalent(f.ts_int, f.ts_int));
+    CHECK_FALSE(time_series_value_equivalent(f.ref_int, f.ts_float));
+    CHECK_FALSE(time_series_value_equivalent(f.ts_int, registry.ref(f.ts_float)));
+
+    // Interior references are transparent too.
+    CHECK(time_series_value_equivalent(registry.tsd(f.int_meta, f.ref_int), registry.tsd(f.int_meta, f.ts_int)));
+    CHECK(time_series_value_equivalent(registry.ref(registry.tsd(f.int_meta, f.ref_int)),
+                                       registry.tsd(f.int_meta, f.ts_int)));
+    CHECK(time_series_value_equivalent(registry.tsl(f.ref_int, 2), registry.tsl(f.ts_int, 2)));
+    CHECK(time_series_value_equivalent(registry.un_named_tsb({{"v", f.ref_int}}),
+                                       registry.un_named_tsb({{"v", f.ts_int}})));
+    CHECK_FALSE(time_series_value_equivalent(registry.tsl(f.ref_int, 2), registry.tsl(f.ts_int, 3)));
+    CHECK_FALSE(time_series_value_equivalent(registry.tsd(f.int_meta, f.ref_int),
+                                             registry.tsd(f.int_meta, f.ts_float)));
+
+    // The equivalence the binding step applies is this one.
+    CHECK(graph_wiring_detail::input_accepts_output_schema(f.ts_int, f.ref_int));
+    CHECK(graph_wiring_detail::input_accepts_output_schema(f.ref_int, f.ts_int));
+    CHECK_FALSE(graph_wiring_detail::input_accepts_output_schema(f.ts_float, f.ref_int));
+}
+
+TEST_CASE("RFC 0036 owners: through_reference resolves a REF output and leaves a plain one alone")
+{
+    OwnersFixture f;
+    TSOutput      target{*f.ts_int};
+    TSOutput      ref_output{*f.ref_int};
+
+    const auto t1 = MIN_ST + TimeDelta{1};
+    set_int(target, 41, t1);
+    set_reference(ref_output, target, t1);
+
+    const auto plain = target.view(t1).through_reference();
+    REQUIRE(plain.schema() == f.ts_int);
+    CHECK(plain.handle().same_as(target.view(t1).handle()));
+    CHECK(plain.value().checked_as<std::int32_t>() == 41);
+
+    const auto resolved = ref_output.view(t1).through_reference();
+    REQUIRE(resolved.schema() == f.ts_int);
+    CHECK(resolved.value().checked_as<std::int32_t>() == 41);
+}
+
+TEST_CASE("RFC 0036 owners: a target link records at bind whether its bound output can move")
+{
+    OwnersFixture f;
+    auto         &registry = f.registry;
+
+    const auto *root_schema = registry.tsb("Rfc0036OwnersInputRoot", {{"value", f.ts_int}, {"token", f.ref_int}});
+    const auto  input_schema = TSEndpointSchema::non_peered(
+        root_schema, {TSEndpointSchema::peered(f.ts_int), TSEndpointSchema::peered(f.ref_int)});
+
+    TSOutput plain{*f.ts_int};
+    TSOutput other{*f.ts_int};
+    TSOutput ref_output{*f.ref_int};
+    TSInput  input{TSInputBuilderFactory::checked_builder_for(*root_schema, input_schema)};
+
+    const auto t1 = MIN_ST + TimeDelta{10};
+    const auto t2 = t1 + TimeDelta{1};
+    const auto t3 = t2 + TimeDelta{1};
+    set_int(plain, 1, t1);
+    set_int(other, 2, t1);
+    set_reference(ref_output, other, t1);
+
+    {
+        auto root   = input.view(nullptr, t1);
+        auto bundle = root.as_bundle();
+        auto value = bundle.field("value");
+        REQUIRE(value.is_bindable());
+        CHECK_FALSE(value.bound_target_is_reference());   // unbound
+
+        value.bind_output(plain.view(t1));
+        REQUIRE(value.bound());
+        CHECK_FALSE(value.bound_target_is_reference());   // a plain output cannot move
+        CHECK(value.value().checked_as<std::int32_t>() == 1);
+    }
+    {
+        // A value input bound to a REF output reads through a from-REF
+        // alternative, which retargets as the reference ticks.
+        auto root   = input.view(nullptr, t2);
+        auto bundle = root.as_bundle();
+        auto value = bundle.field("value");
+        value.bind_output(ref_output.view(t2));
+        REQUIRE(value.bound());
+        CHECK(value.bound_target_is_reference());
+        CHECK(value.value().checked_as<std::int32_t>() == 2);
+    }
+    {
+        // A rebind to a plain output clears the record.
+        auto root   = input.view(nullptr, t3);
+        auto bundle = root.as_bundle();
+        auto value = bundle.field("value");
+        value.bind_output(plain.view(t3));
+        CHECK_FALSE(value.bound_target_is_reference());
+        value.unbind_output();
+        CHECK_FALSE(value.bound_target_is_reference());
+    }
+    {
+        // A REF-declared input bound to a REF output observes the reference,
+        // whose target can move.
+        auto root   = input.view(nullptr, t1);
+        auto bundle = root.as_bundle();
+        auto token = bundle.field("token");
+        token.bind_output(ref_output.view(t1));
+        REQUIRE(token.bound());
+        CHECK(token.bound_target_is_reference());
+    }
+    // The root is non-peered: not bindable, so never a moving target.
+    const auto root = input.view(nullptr, t3);
+    CHECK_FALSE(root.bound_target_is_reference());
+}
+
+TEST_CASE("RFC 0036 owners: NamedPort::observed reads what the parameter will be bound to")
+{
+    OwnersFixture f;
+    static_cast<void>(f);
+    const auto executor = testing::run_graph(build_graph<ObservedProbeGraph>());
+    CHECK(executor.view().graph().node_at(2).output(MIN_ST).value().checked_as<Int>() == Int{41});
+}


### PR DESCRIPTION
Implements RFC 0036, PR 1 of 4 (`docs/source/rfc/rfc_0036_reference_transparency_owners.rst`, "Implementation plan"): the four owners of the REF transparency rule get their public spellings, every type-layer and runtime copy of the equivalence rule migrates to its owner, and the bridge exposes the owners to the DSL. No ratchet falls yet (the std, runtime and Python copies are PRs 2–4); this PR is what they will call.

**The owners**

- `TypeRegistry::value_element_ts(collection)`: the element of a `TSD` / `TSL` with every reference followed (a reference to the collection is followed first; throws for a schema with no element). `TypeRegistry::ref` is documented as idempotent (`ref(REF[X])` is `REF[X]`), so `ref(dereference(x))` has no reason to exist.
- `time_series_value_equivalent(a, b)` (`endpoint_schema.h`): `time_series_schema_equivalent` after following references on both sides, the one place the tree spells the paired dereference. Migrated to it: `input_accepts_output_schema` and the nominal-upcast check of `adapt_source_for_input`, the output-direction check of `ts_pattern_match`, the dispatch upcast check, the alternative-binding check of `ts_output.cpp`, `schema_equivalent_after_dereference` (deleted) and its two callers, the `static_node.h` `Out<REF<S>>::set` target check, the shared-output target check and the forwarding-tree check of `nested_bindings.h`.
- `NamedPort<Name, S>::observed()`: the port as the declared parameter observes it, dereferenced unless `S` declares a `REF` at its top level; what `value_argument` binds, readable in a `compose` before binding. `value_consumer_source` moves above the port so the member can call it without a second declaration.
- `TSOutputView::through_reference()`: the from-REF alternative view of a `REF` output, otherwise the view itself; the structural-hop probes of `graph.cpp` / `nested_bindings.h` become calls to it in PR 3.
- `TSInputView::bound_target_is_reference()`: reads `TSInputTargetLinkState::target_is_reference`, which `bind_impl` records on every bind and rebind from the handle it binds and `detach_target` / `source_invalidated` clear. Finding recorded in the RFC: the shared-output capture's stability test has two halves, both bind-time properties of the handle (the output's schema is a `REF`, or the output is itself reached through a target link such as the from-REF alternative a value input binds to a `REF` output through), so the record covers both and PR 3 can replace the per-tick probe with the accessor alone.
- Bridge: `_hgraph.value_element_ts(ts_type)` and `_hgraph.value_port(wiring, port)` (the port as a value consumer observes it: `adapt_source_for_input` with the dereferenced schema as the declared input, so a structural `TSB` / fixed `TSL` of references becomes per-field / per-element value projections).

**Ratchets** (`python/tests/test_architecture_ratchets.py`)

- `paired-dereference-comparisons` introduced at 12: the owner plus the eleven std operator copies (`container_impl.h` ×2, `higher_order_impl.h` ×9) PR 2 retires; target 1.
- `value-consumer-source-callers` 3 → 4 (`NamedPort::observed()`), recorded in the RFC as planned.

**Tests**

- `tests/cpp/test_reference_transparency_owners.cpp` (new): `value_element_ts` over `TSD[K, REF[TS[int]]]`, `TSD[K, TS[int]]`, `TSL[REF[TS[int]], 2]`, a dynamic `TSL`, `REF[TSD[...]]` and a nested reference, plus the refusals; `ref` idempotence; `time_series_value_equivalent` over the `operators.rst` cases (through interior references, and the negative cases) and through `input_accepts_output_schema`; `through_reference()` on a `REF` output (reads the referenced value) and a plain one (same handle); the link's record across bind → rebind to a `REF` output → rebind to a plain output → unbind, for a value-declared and a `REF`-declared input; `NamedPort::observed()` inside a `compose` for a generic, a `REF`-declared and a concrete parameter.
- `python/tests/test_reference_transparency_owners.py` (new): the two bridge functions.

**Docs (same change)**

- `operators.rst` "REF transparency" names the four owners and the `ref` idempotence; `writing_nodes.rst` gains "The owners" under the dereferenced-binding rule; `testing.rst` lists the new ratchet; `python_bridge.rst` ("Value and reference crossings") documents `value_port` / `value_element_ts`; RFC 0036 implementation status records PR 1 and the finding above.

**Validation (macOS, local gate)**

- C++ core-only suite: all tests passed (257425 assertions in 1712 test cases)
- Python gate (`python/tests` incl. adaptors + all extension suites): 3622 passed, 10 skipped
- `sphinx -W`: clean
- Consumer checks (`python_extension_consumer`, `install_consumer`, fabric test package): passed
- Architecture ratchets: 18 passed with the new baselines

Linux (GCC 14, warnings-as-errors) and Windows (MSVC) results follow as comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
