### PR TITLE
RFC 0036 PR 2: std operators call the owners of REF transparency (stdlib-ref-dereference 67 -> 0)

### DIFF
--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -206,8 +206,7 @@ Each entry names the layer that owns the rule:
   schema;
 * two schemas compared as a paired ``dereference`` when
   ``time_series_value_equivalent`` (``endpoint_schema.h``) owns
-  reference-transparent equivalence (RFC 0036: the count is that owner plus
-  the std operator copies the RFC's second PR retires);
+  reference-transparent equivalence (RFC 0036; the count is that owner);
 * the runtime probing ``TSTypeKind::REF`` per tick, when a node's REF handling
   mode is fixed when the node is built;
 * Python wiring choosing a type carrier by operator name, or keeping a shadow

--- a/docs/source/developer_guide/writing_nodes.rst
+++ b/docs/source/developer_guide/writing_nodes.rst
@@ -186,8 +186,9 @@ dereference for itself either. It asks the owner of that question (RFC 0036,
   which is idempotent.
 
 The ``stdlib-ref-dereference`` and ``paired-dereference-comparisons``
-ratchets (``testing.rst``) hold the hand-written copies at their recorded
-counts while RFC 0036's remaining PRs retire them.
+ratchets (``testing.rst``) hold the std operators at zero copies and the
+comparison at its one owner; the runtime's and the Python wiring's copies
+are RFC 0036's remaining PRs.
 
 Guard overloads through one resolution point
 --------------------------------------------

--- a/docs/source/rfc/rfc_0036_reference_transparency_owners.rst
+++ b/docs/source/rfc/rfc_0036_reference_transparency_owners.rst
@@ -460,7 +460,52 @@ Implementation status
   chained adaptor's relay). The record covers both, so
   ``bound_target_is_reference()`` reads "the bound output can move", and PR
   3 replaces the probe with the accessor alone.
-* PR 2 (std operators), PR 3 (runtime), PR 4 (Python wiring): pending.
+* **PR 2 (std operators)** -- landed: ``stdlib-ref-dereference`` 67 → 0
+  over ``include/hgraph/lib/std`` and ``src/hgraph/lib/std`` (the ratchet
+  names the registry call, ``registry.dereference(`` /
+  ``TypeRegistry::instance().dereference(``; the ``dereference`` *operator*'s
+  own name and Python example are not copies of the rule) and
+  ``paired-dereference-comparisons`` 12 → 1. The five intents mapped as
+  planned: own-argument reads go through ``time_series_schema_at`` /
+  ``time_series_schema(arg)``, ``NamedPort::observed()``, or -- for a
+  ``VarIn`` element, which ``value_argument`` already observed -- the port's
+  schema as supplied; collection elements through
+  ``TypeRegistry::value_element_ts``; comparisons through
+  ``time_series_value_equivalent``; key sources and raw ``compose`` ports
+  through the argument helper's new **port** form
+  (``time_series_schema(const WiringPortRef &)``) and, for the bridge's
+  target-inference inputs (``convert_target.cpp``), its **schema** form;
+  ``ref(dereference(element))`` became ``ref(value_element_ts(collection))``.
+  The structural hop in ``resolve_indexed_reference_target`` is
+  ``TSOutputView::through_reference()``.
+
+  *Findings:* (1) two ``REF``-declared projections (``tsb_ref_field_node``
+  behind ``getitem_`` / ``getattr_`` on ``REF[TSB]``, and
+  ``dereference_tsb_ref`` / ``dereference_tsl_ref``) asked the registry on
+  every reference tick: the declared schema was dereferenced in ``eval``,
+  the dereference node re-interned its materialized output shape, and the
+  target and per-element validations were paired dereferences. They now
+  observe the referenced container and intern the output shape once in
+  ``start`` (``RefContainerState``); a target is validated by pointer or
+  structural equality first (no lookup) and, only when the shapes differ by
+  reference-ness, by ``time_series_value_equivalent`` -- and the validated
+  target schema is remembered in the state, so a reference retargeting
+  among outputs of one shape validates once; a child of a validated peered
+  target needs no check of its own. ``tests/cpp/test_ref_projection_locks.cpp``
+  pins both projections at zero locks per tick under a reference that
+  retargets every cycle. Still a lookup per retarget: a *descriptive-schema*
+  target (the data behind the reference is itself a ``REF`` output, the
+  ``Port::as`` / reference-service pattern) goes through
+  ``through_reference()``, which interns the dereferenced schema; a
+  published dereference on the schema record would remove it. (2) The
+  switch terminal check compared the branch's dereferenced output against
+  the *raw* switch output; it now uses ``time_series_value_equivalent``, so
+  interior references on the switch-output side are transparent too, as
+  they already are at the binding that follows. (3) The ``to_data_frame``
+  start hook and target resolver dereferenced schemas that binding had
+  already observed (a value input's schema, the ``time_series_schema_at``
+  argument); the dereferences were no-ops and are gone.
+* PR 3 (runtime), PR 4 (Python wiring): pending.
 
 References
 ----------

--- a/include/hgraph/lib/std/operators/impl/collection_impl.h
+++ b/include/hgraph/lib/std/operators/impl/collection_impl.h
@@ -1114,12 +1114,14 @@ namespace hgraph::stdlib
                                         std::vector<const ValueTypeMetaData *> &keys,
                                         const TSValueTypeMetaData *&leaf)
         {
+            // ``schema`` is the argument as a value consumer observes it; each
+            // level's element is observed by value too.
             auto &registry = TypeRegistry::instance();
-            const auto *current = registry.dereference(schema);
+            const auto *current = schema;
             while (const auto *tsd = time_series_schema_as<AnyTSD>(current))
             {
                 keys.push_back(tsd->key_type());
-                current = registry.dereference(tsd->element_ts());
+                current = registry.value_element_ts(tsd);
             }
             leaf = current;
         }
@@ -1145,7 +1147,7 @@ namespace hgraph::stdlib
                 if (resolution.find_ts("__out__") != nullptr) { return; }
                 std::vector<const ValueTypeMetaData *> keys;
                 const TSValueTypeMetaData             *leaf = nullptr;
-                nested_tsd_key_path(time_series_schema_at(context, 0, SchemaRefMode::Direct), keys, leaf);
+                nested_tsd_key_path(time_series_schema_at(context, 0), keys, leaf);
                 if (keys.size() < 2 || leaf == nullptr) { return; }
                 auto &registry = TypeRegistry::instance();
                 resolution.bind_ts("__out__", registry.tsd(registry.tuple(keys), registry.ref(leaf)));
@@ -1271,8 +1273,7 @@ namespace hgraph::stdlib
                 if (schema == nullptr) { return; }
                 const auto *key = schema->key_type();
                 if (key == nullptr || key->value_kind() != ValueTypeKind::Tuple || key->field_count < 2) { return; }
-                const TSValueTypeMetaData *out =
-                    registry.ref(registry.dereference(schema->element_ts()));
+                const TSValueTypeMetaData *out = registry.ref(registry.value_element_ts(schema));
                 for (std::size_t index = key->field_count; index-- > 0;)
                 {
                     out = registry.tsd(key->fields[index].type, out);
@@ -1375,7 +1376,7 @@ namespace hgraph::stdlib
                 auto &registry = TypeRegistry::instance();
                 const auto *schema = time_series_schema_at_as<AnyTSD>(context, 0);
                 if (schema == nullptr) { return; }
-                const auto *element = registry.dereference(schema->element_ts());
+                const auto *element = registry.value_element_ts(schema);
                 resolution.bind_ts("__out__", registry.tsd(schema->key_type(), registry.ref(element)));
             }
 
@@ -1421,7 +1422,7 @@ namespace hgraph::stdlib
                 if (schema == nullptr) { return; }
                 const auto *element = time_series_schema_as<AnyTSD>(schema->element_ts());
                 if (element == nullptr) { return; }
-                const auto *leaf = registry.dereference(element->element_ts());
+                const auto *leaf = registry.value_element_ts(element);
                 resolution.bind_ts("__out__", registry.tsd(element->key_type(),
                                                            registry.tsd(schema->key_type(), registry.ref(leaf))));
             }
@@ -2777,7 +2778,7 @@ namespace hgraph::stdlib
                                                           : nullptr;
                 if (keys == nullptr || values == nullptr || key_element == nullptr) { return; }
                 auto       &registry = TypeRegistry::instance();
-                const auto *element  = registry.dereference(values->element_ts());
+                const auto *element  = registry.value_element_ts(values);
                 bind_local_output(
                     resolution, registry.tsd(key_element->value_schema, registry.ref(element)), "O");
             }
@@ -2835,7 +2836,7 @@ namespace hgraph::stdlib
                 const auto *keys   = keys_meta(context);
                 if (values == nullptr || keys == nullptr) { return; }
                 auto       &registry = TypeRegistry::instance();
-                const auto *element  = registry.dereference(values->element_ts());
+                const auto *element  = registry.value_element_ts(values);
                 bind_local_output(
                     resolution, registry.tsd(keys->element_type, registry.ref(element)), "O");
             }
@@ -2893,7 +2894,7 @@ namespace hgraph::stdlib
                 }
                 if (first_value == nullptr) { return; }
                 auto       &registry = TypeRegistry::instance();
-                const auto *element  = registry.dereference(first_value->port.schema);
+                const auto *element  = time_series_schema(*first_value);
                 if (element == nullptr) { return; }
                 bind_output(resolution, registry.tsd(keys->element_type, registry.ref(element)));
             }
@@ -2904,7 +2905,8 @@ namespace hgraph::stdlib
                 if (values.empty()) { throw std::invalid_argument("combine_tsd requires at least one value"); }
 
                 auto       &registry   = TypeRegistry::instance();
-                const auto *target     = registry.dereference(values[0].schema);
+                // A VarIn element is already observed by binding (value_argument).
+                const auto *target     = values[0].schema;
                 const auto *ref_schema = registry.ref(target);
                 std::vector<WiringPortRef> children;
                 children.reserve(values.size());

--- a/include/hgraph/lib/std/operators/impl/container_impl.h
+++ b/include/hgraph/lib/std/operators/impl/container_impl.h
@@ -40,6 +40,18 @@ struct FieldProjectionState {
   ValueTypeRef result{nullptr};
   Int field{-1};
 };
+
+/** A REF-declared container projection's state (lock-free per-tick ruling,
+    RFC 0036): the referenced container's shape, observed once in start (the
+    declared REF<S> as the value it refers to); the materialized output shape
+    the dereference node checks its output against; and the last target
+    schema validated against the container, so a reference that retargets
+    among outputs of one shape validates once, not per tick. */
+struct RefContainerState {
+  const TSValueTypeMetaData *container{nullptr};
+  const TSValueTypeMetaData *materialized{nullptr};
+  const TSValueTypeMetaData *validated_target{nullptr};
+};
 } // namespace container_impl_detail
 } // namespace hgraph::stdlib
 
@@ -52,6 +64,11 @@ struct scalar_name<stdlib::container_impl_detail::GetItemTsdKeyState> {
 template <>
 struct scalar_name<stdlib::container_impl_detail::FieldProjectionState> {
   static constexpr std::string_view value{"stdlib.field_projection_state"};
+};
+
+template <>
+struct scalar_name<stdlib::container_impl_detail::RefContainerState> {
+  static constexpr std::string_view value{"stdlib.ref_container_state"};
 };
 } // namespace hgraph::static_schema_detail
 
@@ -94,8 +111,7 @@ ref_indexed_schema(const WiringArg &arg, TSTypeKind kind) noexcept {
   if (surface == nullptr || surface->kind != TSTypeKind::REF) {
     return nullptr;
   }
-  const TSValueTypeMetaData *target =
-      TypeRegistry::instance().dereference(surface);
+  const TSValueTypeMetaData *target = time_series_schema(arg);
   return target != nullptr && target->kind == kind ? target : nullptr;
 }
 
@@ -191,16 +207,31 @@ materialized_indexed_reference_schema(const TSValueTypeMetaData &container) {
   return registry.un_named_tsb(fields);
 }
 
+/** True when a reference's target schema is the expected one: the same
+    schema or a structurally equal one (no registry lookup), else
+    value-equivalent through references (a registry lookup, taken only for
+    shapes that differ by REF-ness). */
+[[nodiscard]] inline bool
+reference_target_matches(const TSValueTypeMetaData *actual,
+                         const TSValueTypeMetaData *expected) {
+  return actual == expected || time_series_schema_equivalent(actual, expected) ||
+         time_series_value_equivalent(actual, expected);
+}
+
 /** Follow and validate the peered target carried by an indexed-container
     reference. TSB and TSL projection share this path so forwarding,
-    descriptive-schema references, and schema errors behave identically. */
+    descriptive-schema references, and schema errors behave identically.
+    ``validated_target`` remembers the last target schema found to match
+    ``container``, so a reference retargeting among outputs of one shape is
+    validated once (the node keeps it in its state). */
 [[nodiscard]] inline std::optional<TSOutputView>
 resolve_indexed_reference_target(
     const TimeSeriesReference &reference,
     const TSValueTypeMetaData &container,
     DateTime evaluation_time,
     std::string_view operation,
-    std::string_view subject) {
+    std::string_view subject,
+    const TSValueTypeMetaData *&validated_target) {
   if (!reference.is_peered() || !reference.has_output()) {
     return std::nullopt;
   }
@@ -208,17 +239,12 @@ resolve_indexed_reference_target(
   auto target = resolve_forwarding_source(
       reference.target_output().view(evaluation_time));
 
-  const auto *data_schema = target.data_view().schema();
-  if (data_schema != nullptr && data_schema->kind == TSTypeKind::REF) {
-    // A descriptive-schema reference: the surface says TSB/TSL but the
-    // underlying DATA is itself a REF output (Port::as / reference-service
-    // pattern). Hop through its from-REF alternative before projection.
-    const auto *deref = TypeRegistry::instance().dereference(data_schema);
-    target = target.binding_for(*deref).view(evaluation_time);
-  }
-  auto &registry = TypeRegistry::instance();
-  if (!time_series_schema_equivalent(registry.dereference(&container),
-                                     registry.dereference(target.schema()))) {
+  // A descriptive-schema reference: the surface says TSB/TSL but the
+  // underlying DATA may itself be a REF output (Port::as / reference-service
+  // pattern). The structural projection goes through the reference first.
+  target = target.through_reference();
+  if (target.schema() != validated_target &&
+      !reference_target_matches(target.schema(), &container)) {
     const auto owner = target.owner_node();
     throw std::invalid_argument(
         std::string{operation} + ": " + std::string{subject} +
@@ -233,6 +259,7 @@ resolve_indexed_reference_target(
         (owner.valid() ? std::to_string(owner.node_index())
                        : std::string{"<unknown>"}));
   }
+  validated_target = target.schema();
   return target;
 }
 
@@ -281,9 +308,10 @@ resolve_indexed_reference_target(
         "' reference has no target schema");
   }
 
-  auto &registry = TypeRegistry::instance();
-  if (!time_series_schema_equivalent(registry.dereference(actual),
-                                     registry.dereference(element_type))) {
+  // A child of a validated peered target matches by construction (the whole
+  // target was value-equivalent to the container); a non-peered item is
+  // checked on its own.
+  if (target == nullptr && !reference_target_matches(actual, element_type)) {
     throw std::invalid_argument(
         std::string{operation} + ": " + std::string{subject} + " " +
         std::string{element_kind} + " '" + std::string{element_label} +
@@ -299,13 +327,15 @@ resolve_indexed_reference_target(
     std::size_t index,
     DateTime evaluation_time,
     std::string_view operation,
-    std::string_view field_label) {
+    std::string_view field_label,
+    const TSValueTypeMetaData *&validated_target) {
   if (index >= bundle.field_count()) {
     throw std::out_of_range(std::string{operation} + ": REF[TSB] field '" +
                             std::string{field_label} + "' is out of range");
   }
   auto target = resolve_indexed_reference_target(
-      reference, bundle, evaluation_time, operation, "REF[TSB]");
+      reference, bundle, evaluation_time, operation, "REF[TSB]",
+      validated_target);
   return project_indexed_reference_element(
       reference, target ? &*target : nullptr, bundle,
       bundle.fields()[index].type, index, operation, "REF[TSB]", "field",
@@ -1109,13 +1139,15 @@ struct getattr_tsd_nested {
   static constexpr auto name = "getattr_tsd_nested";
 
   [[nodiscard]] static const TSValueTypeMetaData *
-  nested_bundle_leaf(const TSValueTypeMetaData *schema, std::size_t &depth) {
+  nested_bundle_leaf(const TSValueTypeMetaData *observed, std::size_t &depth) {
+    // ``observed`` is the argument as a value consumer sees it; each level's
+    // element is observed by value too.
     auto &registry = TypeRegistry::instance();
-    const auto *current = registry.dereference(schema);
+    const auto *current = observed;
     depth = 0;
     while (const auto *tsd = time_series_schema_as<AnyTSD>(current)) {
       ++depth;
-      current = registry.dereference(tsd->element_ts());
+      current = registry.value_element_ts(tsd);
     }
     return time_series_schema_as<AnyTSB>(current);
   }
@@ -1126,7 +1158,7 @@ struct getattr_tsd_nested {
       return false;
     }
     std::size_t depth = 0;
-    const auto *bundle = nested_bundle_leaf(context.args[0].port.schema, depth);
+    const auto *bundle = nested_bundle_leaf(time_series_schema(context.args[0]), depth);
     const Str *attr = context.scalar_as<Str>("attr");
     return depth >= 2 && bundle != nullptr && attr != nullptr &&
            container_impl_detail::find_tsb_field_index(*bundle, *attr)
@@ -1142,7 +1174,7 @@ struct getattr_tsd_nested {
       return;
     }
     std::size_t depth = 0;
-    const auto *bundle = nested_bundle_leaf(context.args[0].port.schema, depth);
+    const auto *bundle = nested_bundle_leaf(time_series_schema(context.args[0]), depth);
     const Str *attr = context.scalar_as<Str>("attr");
     if (depth < 2 || bundle == nullptr || attr == nullptr) {
       return;
@@ -1156,11 +1188,11 @@ struct getattr_tsd_nested {
     const auto *field = bundle->fields()[*index].type;
     const TSValueTypeMetaData *out =
         field->kind == TSTypeKind::REF ? field : registry.ref(field);
-    const auto *level = registry.dereference(context.args[0].port.schema);
+    const auto *level = time_series_schema(context.args[0]);
     std::vector<const ValueTypeMetaData *> keys;
     while (const auto *tsd = time_series_schema_as<AnyTSD>(level)) {
       keys.push_back(tsd->key_type());
-      level = registry.dereference(tsd->element_ts());
+      level = registry.value_element_ts(tsd);
     }
     for (std::size_t i = keys.size(); i-- > 0;) {
       out = registry.tsd(keys[i], out);
@@ -1208,11 +1240,10 @@ struct getitem_tsd_by_key {
                        InputActivity::Structural, InputValidity::Unchecked>
                         ts,
                     State<container_impl_detail::GetItemTsdKeyState> state) {
-    // The dereference locks the registry; the element schema is wiring-fixed.
-    const auto *schema =
-        TypeRegistry::instance().dereference(ts.base().schema());
+    // The element schema is wiring-fixed: the registry answers it once here
+    // (a start-time lookup) with every reference followed.
     auto current = state.get();
-    current.target = schema != nullptr ? schema->element_ts() : nullptr;
+    current.target = TypeRegistry::instance().value_element_ts(ts.base().schema());
     current.ref_binding =
         TypeRegistry::instance().scalar_type<TimeSeriesReference>();
     state.set(current);
@@ -1311,7 +1342,7 @@ struct getitem_tsd_by_keys {
       return;
     }
     auto &registry = TypeRegistry::instance();
-    const auto *element = registry.dereference(tsd->element_ts());
+    const auto *element = registry.value_element_ts(tsd);
     resolution.bind_ts("__out__",
                        registry.tsd(tsd->key_type(), registry.ref(element)));
   }
@@ -1495,12 +1526,24 @@ struct tsb_ref_field_node {
     bind_output(resolution, TypeRegistry::instance().ref(field));
   }
 
+  static void start(In<"ts", REF<TsVar<"S">>, InputValidity::Unchecked> ts,
+                    State<container_impl_detail::RefContainerState> state) {
+    // The referenced bundle's shape is wiring-fixed: observe the declared
+    // reference once here (a start-time lookup), never per tick.
+    const auto *bundle = time_series_schema_as<AnyTSB>(ts.base().schema());
+    if (bundle == nullptr) {
+      throw std::logic_error(std::string{name} + ": input is not REF[TSB]");
+    }
+    state.set(container_impl_detail::RefContainerState{bundle});
+  }
+
   static void eval(In<"ts", REF<TsVar<"S">>, InputValidity::Unchecked> ts,
-                   Scalar<KeyName, KeyT> key, Out<TsVar<"__out__">> out) {
+                   Scalar<KeyName, KeyT> key,
+                   State<container_impl_detail::RefContainerState> state,
+                   Out<TsVar<"__out__">> out) {
     const auto &erased = static_cast<const TSOutputView &>(out);
     const auto reference = ts.base().reference();
-    const auto *bundle =
-        TypeRegistry::instance().dereference(ts.base().schema());
+    const auto *bundle = state.get().container;
     const auto index =
         container_impl_detail::find_tsb_field_index(*bundle, key.value());
     if (!index.has_value()) {
@@ -1515,9 +1558,14 @@ struct tsb_ref_field_node {
     }();
     const std::string_view operation =
         KeyName.sv() == std::string_view{"attr"} ? "getattr_" : "getitem_";
+    auto current = state.get();
+    const auto *validated = current.validated_target;
     auto result = container_impl_detail::project_tsb_reference_field(
         reference, *bundle, *index, erased.evaluation_time(), operation,
-        field_label);
+        field_label, current.validated_target);
+    if (current.validated_target != validated) {
+      state.set(current);
+    }
     container_impl_detail::set_reference_if_changed(erased,
                                                     std::move(result));
   }
@@ -1551,8 +1599,7 @@ struct dereference_indexed_ref_node {
     // explicit REF surfaces because eval() does the same before constructing
     // the materialized reference fields. This also prevents an interior REF
     // from becoming REF[REF[T]] during output resolution.
-    const TSValueTypeMetaData *target =
-        TypeRegistry::instance().dereference(surface);
+    const TSValueTypeMetaData *target = time_series_schema(context.args[0]);
     return target != nullptr && target->kind == ContainerKind ? target
                                                                : nullptr;
   }
@@ -1574,20 +1621,41 @@ struct dereference_indexed_ref_node {
     }
   }
 
+  static void start(In<"tsb", REF<TsVar<"S">>, InputValidity::Unchecked> ts,
+                    State<container_impl_detail::RefContainerState> state) {
+    // The referenced container's shape is wiring-fixed: observe the declared
+    // reference once here (a start-time lookup), never per tick.
+    const TSValueTypeMetaData *container = nullptr;
+    if constexpr (ContainerKind == TSTypeKind::TSB) {
+      container = time_series_schema_as<AnyTSB>(ts.base().schema());
+    } else {
+      container = time_series_schema_as<AnyTSL>(ts.base().schema());
+    }
+    if (container == nullptr) {
+      throw std::logic_error(std::string{name} + ": input is not " +
+                             (ContainerKind == TSTypeKind::TSB ? "REF[TSB]" : "REF[TSL]"));
+    }
+    container_impl_detail::RefContainerState current;
+    current.container = container;
+    // The output shape is wiring-fixed too: intern it once here, not per tick.
+    current.materialized =
+        container_impl_detail::materialized_indexed_reference_schema(*container);
+    state.set(current);
+  }
+
   static void eval(In<"tsb", REF<TsVar<"S">>, InputValidity::Unchecked> ts,
+                   State<container_impl_detail::RefContainerState> state,
                    Out<TsVar<"__out__">> out) {
     const auto &erased = static_cast<const TSOutputView &>(out);
-    const auto *container =
-        TypeRegistry::instance().dereference(ts.base().schema());
+    auto current = state.get();
+    const auto *container = current.container;
     constexpr std::string_view subject =
         ContainerKind == TSTypeKind::TSB ? "REF[TSB]" : "REF[TSL]";
     if (container == nullptr || container->kind != ContainerKind) {
       throw std::logic_error("dereference: input is not " +
                              std::string{subject});
     }
-    const auto *expected_output =
-        container_impl_detail::materialized_indexed_reference_schema(
-            *container);
+    const auto *expected_output = current.materialized;
     if (!time_series_schema_equivalent(expected_output, erased.schema())) {
       throw std::logic_error(
           "dereference: resolved output does not match the referenced " +
@@ -1596,9 +1664,13 @@ struct dereference_indexed_ref_node {
     }
 
     const auto reference = ts.base().reference();
+    const auto *validated = current.validated_target;
     auto target = container_impl_detail::resolve_indexed_reference_target(
         reference, *container, erased.evaluation_time(), "dereference",
-        subject);
+        subject, current.validated_target);
+    if (current.validated_target != validated) {
+      state.set(current);
+    }
     const std::size_t source_count =
         target ? target->data_view().indexed_child_count()
                : reference.is_non_peered() ? reference.items().size() : 0;

--- a/include/hgraph/lib/std/operators/impl/control_impl.h
+++ b/include/hgraph/lib/std/operators/impl/control_impl.h
@@ -169,7 +169,7 @@ namespace hgraph::stdlib
                 if (element == nullptr) { return; }
                 bind_output(
                     resolution, registry.tsd(element->key_type(),
-                                             registry.ref(registry.dereference(element->element_ts()))));
+                                             registry.ref(registry.value_element_ts(element))));
             }
 
             static void eval(In<"tsl", TSL<TSD<ScalarVar<"K">, TsVar<"V">>, SIZE<"N">>,
@@ -231,7 +231,7 @@ namespace hgraph::stdlib
             auto &registry = TypeRegistry::instance();
             bind_output(
                 resolution,
-                registry.tsd(schema->key_type(), registry.ref(registry.dereference(schema->element_ts()))));
+                registry.tsd(schema->key_type(), registry.ref(registry.value_element_ts(schema))));
         }
 
         static WiringPortRef compose(Wiring &w, VarIn<"tsl", TSD<ScalarVar<"K">, TsVar<"V">>> ts,
@@ -239,7 +239,8 @@ namespace hgraph::stdlib
         {
             if (ts.empty()) { throw std::invalid_argument("merge requires at least one input"); }
             auto &registry = TypeRegistry::instance();
-            const auto *element = registry.dereference(ts[0].schema);
+            // A VarIn element is already observed by binding (value_argument).
+            const auto *element = ts[0].schema;
             std::vector<WiringPortRef> children;
             children.reserve(ts.size());
             for (const WiringPortRef &child : ts)
@@ -300,7 +301,7 @@ namespace hgraph::stdlib
 
         static WiringPortRef compose(Wiring &w, NamedPort<"tsl", TsVar<"S">> ts)
         {
-            const TSValueTypeMetaData *schema = TypeRegistry::instance().dereference(ts.erased().schema);
+            const TSValueTypeMetaData *schema = ts.observed().schema;
             std::vector<WiringPortRef> elements;
             elements.reserve(schema->fixed_size());
             for (std::size_t index = 0; index < schema->fixed_size(); ++index)
@@ -501,13 +502,12 @@ namespace hgraph::stdlib
         static bool requires_(const ResolutionMap &, OperatorCallContext context)
         {
             if (context.args.empty()) { return false; }
-            auto       &registry = TypeRegistry::instance();
-            const auto *schema   = registry.dereference(context.args[0].port.schema);
+            const auto *schema = time_series_schema_at(context, 0);
             if (schema == nullptr) { return false; }
             for (const WiringArg &arg : context.args)
             {
                 if (arg.kind != WiringArg::Kind::TimeSeries ||
-                    !time_series_schema_equivalent(schema, registry.dereference(arg.port.schema)))
+                    !time_series_schema_equivalent(schema, time_series_schema(arg)))
                 {
                     return false;
                 }
@@ -519,7 +519,7 @@ namespace hgraph::stdlib
         {
             if (context.args.empty() || context.args[0].kind != WiringArg::Kind::TimeSeries) { return; }
             auto       &registry = TypeRegistry::instance();
-            const auto *schema   = registry.dereference(context.args[0].port.schema);
+            const auto *schema   = time_series_schema_at(context, 0);
             resolution.bind_ts("S", schema);
             resolution.bind_size("N", context.args.size());
             resolution.bind_ts("__out__", registry.ref(schema));
@@ -530,7 +530,8 @@ namespace hgraph::stdlib
             if (ts.empty()) { throw std::invalid_argument("race requires at least one input"); }
 
             auto       &registry   = TypeRegistry::instance();
-            const auto *target     = registry.dereference(ts[0].schema);
+            // A VarIn element is already observed by binding (value_argument).
+            const auto *target     = ts[0].schema;
             const auto *ref_schema = registry.ref(target);
             std::vector<WiringPortRef> children;
             children.reserve(ts.size());
@@ -562,7 +563,7 @@ namespace hgraph::stdlib
                 if (schema == nullptr || schema->element_ts() == nullptr) { continue; }
                 const auto *element = schema->element_ts();
                 const auto *out     = element->kind == TSTypeKind::REF ? element
-                                                                       : registry.ref(registry.dereference(element));
+                                                                       : registry.ref(registry.value_element_ts(schema));
                 higher_order_impl_detail::bind_graph_output(resolution, out, "O");
                 return;
             }

--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -628,7 +628,6 @@ namespace hgraph::stdlib
             {
                 throw std::invalid_argument("reduce: the collection input must be a TSD or TSL");
             }
-            auto       &registry = TypeRegistry::instance();
 
             const std::array<const TSValueTypeMetaData *, 2> schemas{element, element};
             CompiledSubGraph combiner_graph = combiner.compile(
@@ -642,8 +641,7 @@ namespace hgraph::stdlib
             {
                 throw std::invalid_argument("reduce: the combiner must produce an output");
             }
-            if (!time_series_schema_equivalent(registry.dereference(combiner_graph.output_schema),
-                                               registry.dereference(element)))
+            if (!time_series_value_equivalent(combiner_graph.output_schema, element))
             {
                 throw std::invalid_argument(
                     "reduce: the combiner output schema must match the collection's element schema");
@@ -736,9 +734,7 @@ namespace hgraph::stdlib
             {
                 throw std::invalid_argument("ordered reduce combiner must produce an output");
             }
-            auto &registry = TypeRegistry::instance();
-            if (!time_series_schema_equivalent(registry.dereference(combiner_graph.output_schema),
-                                               registry.dereference(zero.schema)))
+            if (!time_series_value_equivalent(combiner_graph.output_schema, zero.schema))
             {
                 throw std::invalid_argument(
                     "ordered reduce combiner output schema must match the accumulator/zero schema");
@@ -754,7 +750,8 @@ namespace hgraph::stdlib
             spec.child.input_bindings = std::move(combiner_graph.input_bindings);
             spec.child.output_binding = combiner_graph.output_binding;
 
-            const auto *input_schema = registry.un_named_tsb({{"ts", ts.schema}, {"zero", zero.schema}});
+            const auto *input_schema =
+                TypeRegistry::instance().un_named_tsb({{"ts", ts.schema}, {"zero", zero.schema}});
             const std::array<WiringPortRef, 2> inputs{std::move(ts), std::move(zero)};
 
             WiringNodeSchema node_schema;
@@ -883,8 +880,7 @@ namespace hgraph::stdlib
                                          NamedPort<"ts", TSD<ScalarVar<"K">, TsVar<"V">>> ts,
                                          Scalar<"zero", ScalarVar<"Z">> zero_value)
             {
-                const auto *element =
-                    TypeRegistry::instance().dereference(ts.erased().schema)->element_ts();
+                const auto *element = TypeRegistry::instance().value_element_ts(ts.observed().schema);
 
                 WiringArg zero_arg;
                 zero_arg.kind         = WiringArg::Kind::Scalar;
@@ -1186,9 +1182,7 @@ namespace hgraph::stdlib
             if (switch_output_schema != nullptr &&
                 switch_output_schema->kind != TSTypeKind::REF &&
                 branch_output_schema->kind == TSTypeKind::REF &&
-                time_series_schema_equivalent(
-                    TypeRegistry::instance().dereference(branch_output_schema),
-                    switch_output_schema))
+                time_series_value_equivalent(branch_output_schema, switch_output_schema))
             {
                 return true;
             }
@@ -1327,9 +1321,7 @@ namespace hgraph::stdlib
                 // value, another the reference - hgraph parity): the switch
                 // output takes the REFERENCE shape; value branches adapt at
                 // the boundary binding.
-                auto &registry = TypeRegistry::instance();
-                if (time_series_schema_equivalent(registry.dereference(output_schema),
-                                                  registry.dereference(branch_output_schema)))
+                if (time_series_value_equivalent(output_schema, branch_output_schema))
                 {
                     if (branch_output_schema->kind == TSTypeKind::REF) { output_schema = branch_output_schema; }
                 }
@@ -1456,7 +1448,7 @@ namespace hgraph::stdlib
             SwitchNodeSpec spec, const TSValueTypeMetaData *output_schema,
             Value config, std::type_index definition, const char *display_name)
         {
-            const auto *key_schema = TypeRegistry::instance().dereference(key.schema);
+            const auto *key_schema = time_series_schema(key);
             std::vector<std::pair<std::string, const TSValueTypeMetaData *>> fields;
             fields.reserve(1 + ts.size());
             fields.emplace_back("key", key_schema);
@@ -1507,7 +1499,7 @@ namespace hgraph::stdlib
             // (keywords by each branch's own parameter names).
             const std::size_t positional_count = ts.size();
             WiringPortRef key_boundary = key;
-            key_boundary.schema = TypeRegistry::instance().dereference(key.schema);
+            key_boundary.schema = time_series_schema(key);
             std::vector<std::pair<std::string, std::size_t>> named_slots;
             named_slots.reserve(kwargs.size());
             for (std::size_t i = 0; i < kwargs.size(); ++i)
@@ -1594,7 +1586,7 @@ namespace hgraph::stdlib
             }
             if (!branch->has_output) { return false; }
             WiringPortRef key_source = context.args[0].port;
-            key_source.schema = TypeRegistry::instance().dereference(key_source.schema);
+            key_source.schema = time_series_schema_at(context, 0);
 
             std::vector<WiringPortRef> slot_sources;
             for (std::size_t i = 2; i < context.args.size(); ++i)
@@ -1966,10 +1958,8 @@ namespace hgraph::stdlib
         [[nodiscard]] inline const ValueTypeMetaData *dispatch_bundle_schema(
             const TSValueTypeMetaData *schema) noexcept
         {
-            const auto *value_schema = TypeRegistry::instance().dereference(schema);
-            return value_schema != nullptr && value_schema->kind == TSTypeKind::TS
-                       ? value_schema->value_schema
-                       : nullptr;
+            const auto *value_schema = time_series_schema_as<AnyTS>(schema);
+            return value_schema != nullptr ? value_schema->value_schema : nullptr;
         }
 
         [[nodiscard]] inline bool dispatch_case_more_specific(
@@ -1989,14 +1979,13 @@ namespace hgraph::stdlib
             std::span<WiringPortRef> slots,
             std::span<const std::size_t> dispatch_slots)
         {
-            auto &registry = TypeRegistry::instance();
             for (const std::size_t slot : dispatch_slots)
             {
                 if (slot >= slots.size())
                 {
                     throw std::out_of_range("dispatch_: dispatch argument index is out of range");
                 }
-                slots[slot].schema = registry.dereference(slots[slot].schema);
+                slots[slot].schema = time_series_schema(slots[slot]);
             }
         }
 
@@ -2354,9 +2343,7 @@ namespace hgraph::stdlib
             if (output_schema == nullptr) { output_schema = compiled.output_schema; }
             else if (!time_series_schema_equivalent(output_schema, compiled.output_schema))
             {
-                auto &registry = TypeRegistry::instance();
-                if (time_series_schema_equivalent(registry.dereference(output_schema),
-                                                  registry.dereference(compiled.output_schema)))
+                if (time_series_value_equivalent(output_schema, compiled.output_schema))
                 {
                     if (compiled.output_schema->kind == TSTypeKind::REF)
                     {
@@ -2677,9 +2664,8 @@ namespace hgraph::stdlib
             {
                 const bool exact_match = time_series_schema_equivalent(
                     declared, compiled.output_schema);
-                const bool ref_transparent_match = time_series_schema_equivalent(
-                    registry.dereference(declared),
-                    registry.dereference(compiled.output_schema));
+                const bool ref_transparent_match =
+                    time_series_value_equivalent(declared, compiled.output_schema);
                 if (!exact_match && !ref_transparent_match)
                 {
                     throw std::invalid_argument(fmt::format(
@@ -2715,12 +2701,7 @@ namespace hgraph::stdlib
                 return logical;
             }
 
-            auto &registry = TypeRegistry::instance();
-            return time_series_schema_equivalent(
-                       registry.dereference(logical),
-                       registry.dereference(terminal))
-                       ? terminal
-                       : logical;
+            return time_series_value_equivalent(logical, terminal) ? terminal : logical;
         }
 
         /** Configure a whole child terminal against one public container
@@ -2748,13 +2729,10 @@ namespace hgraph::stdlib
                     operation_name));
             }
 
-            auto &registry = TypeRegistry::instance();
             const bool exact_match = time_series_schema_equivalent(
                 output_schema, terminal_output_schema);
             if (!exact_match &&
-                !time_series_schema_equivalent(
-                    registry.dereference(output_schema),
-                    registry.dereference(terminal_output_schema)))
+                !time_series_value_equivalent(output_schema, terminal_output_schema))
             {
                 throw std::invalid_argument(fmt::format(
                     "{}: child terminal schema is incompatible with its public output",
@@ -2951,7 +2929,7 @@ namespace hgraph::stdlib
             }
 
             auto &registry = TypeRegistry::instance();
-            const auto *actual_keys_schema = registry.dereference(keys.schema);
+            const auto *actual_keys_schema = time_series_schema(keys);
             const auto *expected_keys_schema = registry.tss(classified.key_meta);
             if (actual_keys_schema != expected_keys_schema)
             {
@@ -3339,7 +3317,6 @@ namespace hgraph::stdlib
             // ``__keys__ = union(*key_sets)``); ``no_key``-tagged dicts are
             // excluded from the inference. The runtime is always keys-driven;
             // there is no in-node union scan.
-            auto &registry = TypeRegistry::instance();
             const auto passive_materializers = materialize_structural_broadcast_inputs(
                 w, ordered, ts_schemas,
                 {spec.multiplexed_inputs.data(),
@@ -3354,9 +3331,12 @@ namespace hgraph::stdlib
             fields.reserve(ts_schemas.size() + 1);
             for (std::size_t i = 0; i < ts_schemas.size(); ++i)
             {
+                // A multiplexed input is the dict classification observed
+                // (the same read that classified it), so its elements feed
+                // the child by value.
                 const auto *input_schema =
                     i < classified.is_multiplexed.size() && classified.is_multiplexed[i]
-                        ? registry.dereference(ts_schemas[i])
+                        ? time_series_schema_as<AnyTSD>(ts_schemas[i])
                         : ts_schemas[i];
                 fields.emplace_back(std::to_string(i), input_schema);
             }
@@ -3525,9 +3505,12 @@ namespace hgraph::stdlib
             fields.reserve(ts_schemas.size() + 1);
             for (std::size_t i = 0; i < ts_schemas.size(); ++i)
             {
+                // A multiplexed input is the dict classification observed
+                // (the same read that classified it), so its elements feed
+                // the child by value.
                 const auto *input_schema =
                     i < classified.is_multiplexed.size() && classified.is_multiplexed[i]
-                        ? registry.dereference(ts_schemas[i])
+                        ? time_series_schema_as<AnyTSD>(ts_schemas[i])
                         : ts_schemas[i];
                 fields.emplace_back(std::to_string(i), input_schema);
             }
@@ -3585,8 +3568,7 @@ namespace hgraph::stdlib
                 OperatorRegistry::instance().resolve_mesh_key_scope(name);
             const TSValueTypeMetaData *key_schema =
                 key_type != nullptr ? TypeRegistry::instance().ts(key_type) : nullptr;
-            if (key_schema == nullptr ||
-                TypeRegistry::instance().dereference(key.schema) != key_schema)
+            if (key_schema == nullptr || time_series_schema(key) != key_schema)
             {
                 throw std::invalid_argument(
                     "mesh lookup key type does not match the enclosing mesh key type");
@@ -3642,7 +3624,7 @@ namespace hgraph::stdlib
             }
 
             const auto *out_schema = TypeRegistry::instance().tss(key_type);
-            if (TypeRegistry::instance().dereference(value_placeholder.schema) != out_schema)
+            if (time_series_schema(value_placeholder) != out_schema)
             {
                 throw std::invalid_argument("mesh_keys_ref placeholder schema does not match the mesh key set");
             }
@@ -4286,8 +4268,7 @@ namespace hgraph::stdlib
                 WiringPortRef out = func.wire(w, {args.data(), args.size()});
                 if (!output_required) { continue; }
                 if (out.schema == nullptr) { throw std::invalid_argument("map_: 'func' must produce an output"); }
-                if (!children.empty() && !time_series_schema_equivalent(registry.dereference(out.schema),
-                                                                        registry.dereference(children.front().schema))) {
+                if (!children.empty() && !time_series_value_equivalent(out.schema, children.front().schema)) {
                     throw std::invalid_argument("map_: 'func' produced differing output schemas across the TSL indices");
                 }
                 children.push_back(std::move(out));

--- a/include/hgraph/lib/std/operators/impl/tsb_itemwise_impl.h
+++ b/include/hgraph/lib/std/operators/impl/tsb_itemwise_impl.h
@@ -127,7 +127,7 @@ namespace hgraph::stdlib::tsb_itemwise_impl_detail
     template <typename Op>
     [[nodiscard]] WiringPortRef wire_unary(Wiring &w, const WiringPortRef &input)
     {
-        const TSValueTypeMetaData *schema = TypeRegistry::instance().dereference(input.schema);
+        const TSValueTypeMetaData *schema = time_series_schema(input);
         if (schema == nullptr || schema->kind != TSTypeKind::TSB)
         {
             throw std::logic_error("TSB itemwise operator requires a TSB or REF[TSB] input");
@@ -162,8 +162,8 @@ namespace hgraph::stdlib::tsb_itemwise_impl_detail
     template <typename Op>
     [[nodiscard]] WiringPortRef wire_binary(Wiring &w, const WiringPortRef &lhs, const WiringPortRef &rhs)
     {
-        const TSValueTypeMetaData *schema = TypeRegistry::instance().dereference(lhs.schema);
-        const TSValueTypeMetaData *rhs_schema = TypeRegistry::instance().dereference(rhs.schema);
+        const TSValueTypeMetaData *schema = time_series_schema(lhs);
+        const TSValueTypeMetaData *rhs_schema = time_series_schema(rhs);
         if (schema == nullptr || rhs_schema == nullptr || schema->kind != TSTypeKind::TSB ||
             rhs_schema->kind != TSTypeKind::TSB || !same_field_layout(*schema, *rhs_schema))
         {

--- a/include/hgraph/types/operator_type_resolution.h
+++ b/include/hgraph/types/operator_type_resolution.h
@@ -128,6 +128,37 @@ namespace hgraph::operator_type_resolution
     }
 
     /**
+     * The schema a value consumer observes through ``port`` (references
+     * followed), or the port's own schema in ``Direct`` mode: the port form
+     * of the argument helper, for wiring code that holds raw ``WiringPortRef``s
+     * (a ``compose`` packing ports, a key source, a dispatch slot) rather
+     * than a call context. A ``VarIn`` element or a ``NamedPort`` is already
+     * observed by binding (``value_argument``, ``NamedPort::observed()``);
+     * this is for ports that never went through it (RFC 0036).
+     */
+    [[nodiscard]] inline const TSValueTypeMetaData *time_series_schema(
+        const WiringPortRef &port,
+        SchemaRefMode        mode = SchemaRefMode::Dereference) noexcept
+    {
+        if (port.schema == nullptr) { return nullptr; }
+        return mode == SchemaRefMode::Dereference ? TypeRegistry::instance().dereference(port.schema) : port.schema;
+    }
+
+    /**
+     * The schema a value consumer observes for a bare ``schema`` (references
+     * followed), or ``schema`` itself in ``Direct`` mode: the argument helper
+     * for code handed schemas rather than arguments or ports (target
+     * inference over the bridge's inputs). Prefer the argument, context and
+     * port forms, which name what is being observed.
+     */
+    [[nodiscard]] inline const TSValueTypeMetaData *time_series_schema(
+        const TSValueTypeMetaData *schema,
+        SchemaRefMode              mode = SchemaRefMode::Dereference) noexcept
+    {
+        return mode == SchemaRefMode::Dereference ? TypeRegistry::instance().dereference(schema) : schema;
+    }
+
+    /**
      * Return the effective time-series schema at ``index``. A plain value
      * matched to an input parameter is represented as ``TS[value_type]``;
      * overload resolution uses the same virtual schema before the winning

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -55,12 +55,19 @@ RATCHETS: tuple[Ratchet, ...] = (
     # --- REF transparency belongs to the binding (retrospective family 1) ---
     Ratchet(
         id="stdlib-ref-dereference",
-        baseline=64,
-        roots=("include/hgraph/lib/std/operators/impl",),
-        suffixes=(".h",),
-        pattern=r"\bdereference\(",
-        owner="type_pattern input matcher binds the recursively dereferenced "
-        "schema; an operator never dereferences its own input",
+        baseline=0,
+        roots=("include/hgraph/lib/std", "src/hgraph/lib/std"),
+        suffixes=(".h", ".cpp"),
+        # The registry call; the ``dereference`` operator's own name (its
+        # Python example in container.h) is not a copy of the rule.
+        pattern=r"\b(?:registry|TypeRegistry::instance\(\))\.dereference\(",
+        owner="binding observes an argument for the operator (the matcher binds "
+        "the dereferenced schema, value_argument follows the reference); a std "
+        "operator that reasons about a schema binding never rewrites asks the "
+        "owner (RFC 0036): the argument helpers of operator_type_resolution.h / "
+        "NamedPort::observed(), TypeRegistry::value_element_ts, "
+        "time_series_value_equivalent, TSOutputView::through_reference(), "
+        "TypeRegistry::ref (idempotent)",
     ),
     Ratchet(
         id="wiring-ref-handling",
@@ -84,14 +91,13 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
     Ratchet(
         id="paired-dereference-comparisons",
-        baseline=12,
+        baseline=1,
         roots=("src/hgraph", "include/hgraph", "python"),
         suffixes=(".cpp", ".h"),
         pattern=r"time_series_schema_equivalent\(\s*(?:registry|TypeRegistry::instance\(\))\.dereference\(",
         owner="time_series_value_equivalent (endpoint_schema.h) is the one "
         "place that compares two schemas after following references (RFC "
-        "0036); a comparison site calls it. The count is the owner plus the "
-        "std operator copies RFC 0036's second PR retires",
+        "0036); a comparison site calls it",
     ),
     # --- REF ownership at nested boundaries is a build-time property (family 2) ---
     Ratchet(

--- a/src/hgraph/lib/std/operators/convert_target.cpp
+++ b/src/hgraph/lib/std/operators/convert_target.cpp
@@ -21,6 +21,7 @@ namespace hgraph::stdlib
         using hgraph::operator_type_resolution::AnyTSD;
         using hgraph::operator_type_resolution::AnyTSL;
         using hgraph::operator_type_resolution::AnyTSS;
+        using hgraph::operator_type_resolution::time_series_schema;
         using hgraph::operator_type_resolution::time_series_schema_as;
         using hgraph::operator_type_resolution::ts_value_schema;
 
@@ -30,14 +31,9 @@ namespace hgraph::stdlib
                                                                         : std::string{"<null>"};
         }
 
-        [[nodiscard]] const TSValueTypeMetaData *deref(const TSValueTypeMetaData *schema)
-        {
-            return TypeRegistry::instance().dereference(schema);
-        }
-
         [[nodiscard]] const TSValueTypeMetaData *ts_element_value_as_ts(const TSValueTypeMetaData *schema)
         {
-            const ValueTypeMetaData *value = ts_value_schema(deref(schema));
+            const ValueTypeMetaData *value = ts_value_schema(time_series_schema(schema));
             const ValueTypeMetaData *element = collection_element_schema(value);
             return element != nullptr ? TypeRegistry::instance().ts(element) : schema;
         }
@@ -54,19 +50,19 @@ namespace hgraph::stdlib
         {
             schema = time_series_schema_as<AnyTSD>(schema);
             if (schema == nullptr) { return nullptr; }
-            return ts_value_schema(deref(schema->element_ts()));
+            return ts_value_schema(TypeRegistry::instance().value_element_ts(schema));
         }
 
         [[nodiscard]] const ValueTypeMetaData *tsl_element_scalar(const TSValueTypeMetaData *schema)
         {
             schema = time_series_schema_as<AnyTSL>(schema);
             if (schema == nullptr) { return nullptr; }
-            return ts_value_schema(deref(schema->element_ts()));
+            return ts_value_schema(TypeRegistry::instance().value_element_ts(schema));
         }
 
         [[nodiscard]] const ValueTypeMetaData *key_scalar_from_schema(const TSValueTypeMetaData *schema)
         {
-            schema = deref(schema);
+            schema = time_series_schema(schema);
             if (schema == nullptr) { return nullptr; }
             if (time_series_schema_as<AnyTSS>(schema) != nullptr) { return tss_element(schema); }
             return collection_element_or_self_schema(ts_value_schema(schema));
@@ -175,7 +171,7 @@ namespace hgraph::stdlib
             {
                 throw std::invalid_argument(fmt::format("{} target resolution requires at least one input", pattern));
             }
-            return deref(inputs[0]);
+            return time_series_schema(inputs[0]);
         }
 
         [[nodiscard]] const TSValueTypeMetaData *require_one_raw_input(
@@ -297,7 +293,7 @@ namespace hgraph::stdlib
             }
 
             const ValueTypeMetaData *key = key_scalar_from_schema(first);
-            const ValueTypeMetaData *value = ts_value_schema(deref(inputs[1]));
+            const ValueTypeMetaData *value = ts_value_schema(time_series_schema(inputs[1]));
             value = collection_element_or_self_schema(value);
             if (key == nullptr || value == nullptr)
             {
@@ -328,7 +324,7 @@ namespace hgraph::stdlib
                 }
                 if (const TSValueTypeMetaData *tsl = time_series_schema_as<AnyTSL>(first))
                 {
-                    const TSValueTypeMetaData *element = deref(tsl->element_ts());
+                    const TSValueTypeMetaData *element = registry.value_element_ts(tsl);
                     if (element != nullptr)
                     {
                         return registry.tsd(registry.value_type("int"), registry.ref(element));
@@ -338,7 +334,7 @@ namespace hgraph::stdlib
             }
 
             const ValueTypeMetaData *key = key_scalar_from_schema(first);
-            const TSValueTypeMetaData *value = ts_element_value_as_ts(deref(inputs[1]));
+            const TSValueTypeMetaData *value = ts_element_value_as_ts(time_series_schema(inputs[1]));
             if (key == nullptr || value == nullptr)
             {
                 throw std::invalid_argument("cannot infer TSD target from key/value inputs");
@@ -519,7 +515,7 @@ namespace hgraph::stdlib
             if (inputs.size() >= 2)
             {
                 const ValueTypeMetaData *key = key_scalar_from_schema(first);
-                const TSValueTypeMetaData *value = ts_element_value_as_ts(deref(inputs[1]));
+                const TSValueTypeMetaData *value = ts_element_value_as_ts(time_series_schema(inputs[1]));
                 if (key != nullptr && value != nullptr) { return registry.tsd(key, value); }
             }
             throw std::invalid_argument(fmt::format("cannot infer collect TSD target from {}", schema_name(first)));
@@ -603,12 +599,12 @@ namespace hgraph::stdlib
                 if (inputs.size() == 2)
                 {
                     // combine[TSD](keys, values) with ticking TSL pairs.
-                    const auto *first  = time_series_schema_as<AnyTSL>(deref(inputs[0]));
-                    const auto *second = time_series_schema_as<AnyTSL>(deref(inputs[1]));
+                    const auto *first  = time_series_schema_as<AnyTSL>(inputs[0]);
+                    const auto *second = time_series_schema_as<AnyTSL>(inputs[1]);
                     if (first != nullptr && second != nullptr)
                     {
                         const auto *key   = tsl_element_scalar(first);
-                        const auto *value = deref(second->element_ts());
+                        const auto *value = registry.value_element_ts(second);
                         if (key != nullptr && value != nullptr) { return registry.tsd(key, value); }
                     }
                 }
@@ -622,10 +618,10 @@ namespace hgraph::stdlib
                 {
                     throw std::invalid_argument("combine[TSL] requires at least one input");
                 }
-                const TSValueTypeMetaData *element = deref(inputs.front());
+                const TSValueTypeMetaData *element = time_series_schema(inputs.front());
                 for (const auto *raw : inputs)
                 {
-                    if (deref(raw) != element)
+                    if (time_series_schema(raw) != element)
                     {
                         throw std::invalid_argument("combine[TSL]: inputs have mixed element types");
                     }

--- a/src/hgraph/lib/std/operators/data_frame_impl.cpp
+++ b/src/hgraph/lib/std/operators/data_frame_impl.cpp
@@ -655,8 +655,10 @@ namespace hgraph::stdlib
                                                            std::string_view key_col,
                                                            std::string_view value_col)
         {
+            // ``ts`` is the argument as a value consumer observes it
+            // (``time_series_schema_at`` at the caller).
             auto       &registry = TypeRegistry::instance();
-            const auto *schema   = registry.dereference(ts);
+            const auto *schema   = ts;
             std::vector<std::pair<std::string, const ValueTypeMetaData *>> fields;
             fields.emplace_back(std::string{dt_col}, datetime_meta());
 
@@ -692,7 +694,9 @@ namespace hgraph::stdlib
         {
             auto        plan     = std::make_unique<ToFramePlan>();
             const auto *columns  = frame_columns_schema(out.schema()->value_schema, "to_data_frame");
-            const auto *schema   = TypeRegistry::instance().dereference(ts.schema());
+            // A value input's schema is the observed shape: binding follows
+            // references before the node sees it.
+            const auto *schema   = ts.schema();
             plan->row_meta       = columns;
             plan->converter      = &table_converter(columns);
             plan->dict           = schema->kind == TSTypeKind::TSD;

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -292,6 +292,7 @@ hgraph_add_test_objects(hgraph_value_test_objects
     test_type_pointer.cpp
     test_tsd_proxy.cpp
     test_python_ops.cpp
+    test_ref_projection_locks.cpp
     test_reference_transparency_owners.cpp
     test_type_registry.cpp
     test_value.cpp

--- a/tests/cpp/test_ref_projection_locks.cpp
+++ b/tests/cpp/test_ref_projection_locks.cpp
@@ -1,0 +1,133 @@
+// RFC 0036 PR 2 (docs/source/rfc/rfc_0036_reference_transparency_owners.rst,
+// implementation status, finding 1): the REF-declared container projections
+// (getattr_ / getitem_ over REF[TSB], dereference over REF[TSB] / REF[TSL])
+// observe their referenced container once in start, so a reference that
+// retargets every cycle costs no type-system lock per tick.
+#include <hgraph/lib/std/operators/container.h>
+#include <hgraph/lib/std/std_operators.h>
+#include <hgraph/lib/std/operators/impl/record_replay_memory_impl.h>
+#include <hgraph/lib/testing/record_replay.h>
+#include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/runtime/runtime.h>
+#include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/static_node.h>
+#include <hgraph/types/utils/counted_mutex.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace
+{
+    using namespace hgraph;
+    using namespace hgraph::testing;
+
+    using LockBundle = TSB<"RefProjectionLockBundle", Field<"a", TS<Int>>, Field<"b", TS<Int>>>;
+
+    std::uint64_t g_locks_before     = 0;
+    std::uint64_t g_projection_locks = 0;
+
+    /** Packs the replayed value into both fields of a bundle. */
+    template <int Offset>
+    struct PackBundle
+    {
+        static constexpr auto name = Offset == 0 ? "ref_projection_locks_pack_a" : "ref_projection_locks_pack_b";
+        static void           eval(In<"value", TS<Int>> value, Out<LockBundle> out)
+        {
+            out.field<"a">().set(value.value() + Int{Offset});
+            out.field<"b">().set(value.value() + Int{Offset + 1});
+        }
+    };
+
+    /** Publishes a reference that retargets every cycle (bundle A on odd
+        ticks, bundle B on even ticks) and records the lock count as the last
+        node evaluated before the projection under test. */
+    struct AlternatingReference
+    {
+        static constexpr auto name = "ref_projection_locks_alternating_ref";
+        static void           eval(In<"tick", TS<Int>> tick, In<"a", REF<LockBundle>> a, In<"b", REF<LockBundle>> b,
+                                   Out<REF<LockBundle>> out)
+        {
+            out.set(tick.value() % 2 == 1 ? a.value() : b.value());
+            g_locks_before = type_system_lock_count();
+        }
+    };
+
+    /** The first node evaluated after the projection: the locks taken between
+        the two readings are the projection's own. */
+    struct ProbeAfter
+    {
+        static constexpr auto name = "ref_projection_locks_probe";
+        static void           eval(In<"value", TsVar<"S">> value)
+        {
+            static_cast<void>(value);
+            g_projection_locks += type_system_lock_count() - g_locks_before;
+        }
+    };
+
+    [[nodiscard]] WiringPortRef alternating_reference(Wiring &w)
+    {
+        auto src = wire<stdlib::replay_impl, TS<Int>>(w, Str{"in"});
+        auto a   = wire<PackBundle<0>>(w, src);
+        auto b   = wire<PackBundle<10>>(w, src);
+        return wire<AlternatingReference>(w, src, a, b).erased();
+    }
+
+    struct FieldProjectionGraph
+    {
+        static constexpr auto name = "ref_projection_locks_field_graph";
+        static void           compose(Wiring &w)
+        {
+            auto field = wire<stdlib::getattr_>(w, Port<void>{w, alternating_reference(w)}, Str{"a"});
+            wire<ProbeAfter>(w, field);
+        }
+    };
+
+    struct DereferenceGraph
+    {
+        static constexpr auto name = "ref_projection_locks_dereference_graph";
+        static void           compose(Wiring &w)
+        {
+            auto materialized = wire<stdlib::dereference>(w, Port<void>{w, alternating_reference(w)});
+            wire<ProbeAfter>(w, materialized);
+        }
+    };
+
+    template <typename Graph>
+    std::uint64_t projection_locks_over(std::size_t cycles)
+    {
+        std::vector<std::optional<Value>> ticks;
+        for (std::size_t i = 1; i <= cycles; ++i) { ticks.emplace_back(Value{Int{static_cast<Int>(i)}}); }
+        g_projection_locks = 0;
+        GraphBuilder gb = build_graph<Graph>();
+        set_replay_deltas(gb.global_state(), "in", ticks);
+        GraphExecutorBuilder eb;
+        eb.graph_builder(std::move(gb))
+            .start_time(MIN_ST)
+            .end_time(MIN_ST + TimeDelta{static_cast<std::int64_t>(cycles) + 1});
+        GraphExecutorValue ex = eb.make_executor();
+        ex.view().run();
+        return g_projection_locks;
+    }
+}  // namespace
+
+TEST_CASE("RFC 0036: getattr_ over a retargeting REF[TSB] takes no type-system lock per tick")
+{
+    static_cast<void>(TypeRegistry::instance().register_scalar<Int>("int"));
+    stdlib::register_standard_operators();
+    static_cast<void>(projection_locks_over<FieldProjectionGraph>(4));  // warm: publications happen once
+    CHECK(projection_locks_over<FieldProjectionGraph>(4) == 0);
+    CHECK(projection_locks_over<FieldProjectionGraph>(8) == 0);
+}
+
+TEST_CASE("RFC 0036: dereference over a retargeting REF[TSB] takes no type-system lock per tick")
+{
+    static_cast<void>(TypeRegistry::instance().register_scalar<Int>("int"));
+    stdlib::register_standard_operators();
+    static_cast<void>(projection_locks_over<DereferenceGraph>(4));
+    CHECK(projection_locks_over<DereferenceGraph>(4) == 0);
+    CHECK(projection_locks_over<DereferenceGraph>(8) == 0);
+}


### PR DESCRIPTION
Implements RFC 0036, PR 2 of 4 (`docs/source/rfc/rfc_0036_reference_transparency_owners.rst`, "Implementation plan"): the std operators stop dereferencing for themselves and call the owners PR 1 (#758) introduced. Stacked on #758; merge order #758 → this.

**What changes**

The 67 `dereference(` sites under `include/hgraph/lib/std` and `src/hgraph/lib/std` map onto the five intents the RFC catalogued:

- *Own bound argument* (27): `time_series_schema_at(context, i)` / `time_series_schema(arg)` where a call context or `WiringArg` is at hand; `NamedPort::observed()` in a `compose`; a `VarIn` element is left as supplied, because `value_argument` already observed it for the parameter.
- *Collection element* (9): `TypeRegistry::value_element_ts(collection)`, including the four `ref(dereference(element_ts))` spellings, which become `ref(value_element_ts(collection))`.
- *Comparison through references* (17): `time_series_value_equivalent(a, b)`; `paired-dereference-comparisons` 12 → 1.
- *Key sources and raw `compose` ports* (7): the argument helper gains a **port** form, `time_series_schema(const WiringPortRef &, mode)`, for wiring code that holds ports rather than a call context (the switch key, dispatch slots, mesh keys, `tsb_itemwise`'s inputs); the bridge's target-inference inputs (`convert_target.cpp`) use its **schema** form. Both live beside the existing argument form in `operator_type_resolution.h`.
- The structural hop in `resolve_indexed_reference_target` is `TSOutputView::through_reference()`.

**Findings** (RFC implementation status)

1. `tsb_ref_field_node` (behind `getitem_` / `getattr_` on `REF[TSB]`) and `dereference_tsb_ref` / `dereference_tsl_ref` dereferenced their declared schema in `eval`: a registry lock every time the reference ticked. They now observe the referenced container once in `start` (`RefContainerState`), and `tests/cpp/test_ref_projection_locks.cpp` pins it: a reference retargeting every cycle through both projections costs no type-system lock per tick.
2. The switch terminal check compared the branch's dereferenced output against the raw switch output; it now uses `time_series_value_equivalent`, so interior references on the switch-output side are transparent too, as they already are at the binding that follows.
3. The `to_data_frame` start hook and target resolver dereferenced schemas binding had already observed; the no-ops are gone.

**Ratchets**

- `stdlib-ref-dereference` 67 → 0, roots `include/hgraph/lib/std` + `src/hgraph/lib/std`. The pattern now names the registry call (`registry.dereference(` / `TypeRegistry::instance().dereference(`): the `dereference` *operator*'s own name and its Python example in `container.h` are not copies of the rule.
- `paired-dereference-comparisons` 12 → 1 (the owner).

**Docs (same change)**: RFC 0036 implementation status (PR 2 + findings); `writing_nodes.rst` "The owners" and `testing.rst` ratchet bullet updated to the new counts.

**Validation (macOS, local gate)**

- C++ core-only suite: all tests passed (257430 assertions in 1714 test cases)
- Python gate (`python/tests` incl. adaptors + all extension suites): 3622 passed, 10 skipped
- `sphinx -W`: clean
- Consumer checks (`python_extension_consumer`, `install_consumer`, fabric test package): passed
- Architecture ratchets: 18 passed with the new baselines

Linux (GCC 14, warnings-as-errors) and Windows (MSVC) results follow as comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
