### PR TITLE
RFC 0036 PR 3: the runtime's structural hops and shared-output stability call the owners (runtime-ref-kind-probes 7 -> 0)

### DIFF
--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -208,7 +208,9 @@ Each entry names the layer that owns the rule:
   ``time_series_value_equivalent`` (``endpoint_schema.h``) owns
   reference-transparent equivalence (RFC 0036; the count is that owner);
 * the runtime probing ``TSTypeKind::REF`` per tick, when a node's REF handling
-  mode is fixed when the node is built;
+  mode is fixed when the node is built (held at zero since RFC 0036: a
+  structural hop goes through ``TSOutputView::through_reference()`` and the
+  shared-output capture reads the record its link wrote at bind);
 * Python wiring choosing a type carrier by operator name, or keeping a shadow
   schema-to-Python-type dictionary, when the resolver and the registry own
   both (the dictionaries are gone since RFC 0033's PR C: the bridge's

--- a/docs/source/rfc/rfc_0036_reference_transparency_owners.rst
+++ b/docs/source/rfc/rfc_0036_reference_transparency_owners.rst
@@ -505,7 +505,23 @@ Implementation status
   start hook and target resolver dereferenced schemas that binding had
   already observed (a value input's schema, the ``time_series_schema_at``
   argument); the dereferences were no-ops and are gone.
-* PR 3 (runtime), PR 4 (Python wiring): pending.
+* **PR 3 (runtime)** -- landed: ``runtime-ref-kind-probes`` 7 → 0. The
+  structural hops of ``output_at_path`` (``graph.cpp``), ``walk_ts_path`` and
+  the key-set case of ``walk_source_to_output`` (``nested_bindings.h``) are
+  ``TSOutputView::through_reference()``; the forwarding tree's root-REF
+  adaptation asks whether the source *refers to* the target's shape
+  (``referenced_ts()`` is null for a non-reference) instead of probing the
+  kind first; ``make_race_tsd_node`` wraps the element with the idempotent
+  ``ref``; ``input_target_is_stable`` in ``shared_output_node.cpp`` is the
+  link's bind-time record (``bound_target_is_reference()``), and a test pins
+  a capture whose source reference retargets every cycle: the capture stays
+  active and republishes each target.
+
+  *Finding:* ``race_tsd`` declared its output as a reference to the
+  *dereferenced* element; it now declares ``REF[element]`` -- the element's
+  interior references are part of the shape the reference resolves at its
+  target, and consumers compare through ``time_series_value_equivalent``.
+* PR 4 (Python wiring): pending.
 
 References
 ----------

--- a/include/hgraph/runtime/nested_bindings.h
+++ b/include/hgraph/runtime/nested_bindings.h
@@ -71,13 +71,9 @@ template <typename View>
           "Nested graph path requires a typed time-series view");
     }
     if constexpr (std::is_same_v<View, TSOutputView>) {
-      if (view.schema()->kind == TSTypeKind::REF) {
-        // Boundary paths describe the value seen by the child graph. Resolve
-        // the physical REF endpoint before applying a structural projection.
-        const auto *target =
-            TypeRegistry::instance().dereference(view.schema());
-        view = view.binding_for(*target).view(view.evaluation_time());
-      }
+      // Boundary paths describe the value seen by the child graph. Resolve
+      // the physical REF endpoint before applying a structural projection.
+      view = view.through_reference();
       if (component == ts_key_set_path_component) {
         view = view.as_dict().key_set();
         continue;
@@ -381,14 +377,14 @@ inline bool bind_forwarding_output_tree_to_source(TSOutputView target,
                                                   ForwardingSourceMode source_mode =
                                                       ForwardingSourceMode::ResolveCurrentTarget) {
   TSOutputView effective_source = source.borrowed_ref();
-  // Adapt only the terminal's root REF. Interior REF fields are part of the
-  // structural endpoint contract and must remain visible to the forwarding
-  // tree (REF[TSB[REF[...]]] -> TSB[REF[...]]).
-  if (source.bound() && source.schema() != nullptr &&
-      source.schema()->kind == TSTypeKind::REF && target.schema() != nullptr &&
-      time_series_schema_equivalent(
-          source.schema()->referenced_ts(),
-          target.schema())) {
+  // Adapt only the terminal's root REF: a source that refers to the target's
+  // shape binds through its from-REF alternative (a non-reference has no
+  // referenced schema and is bound as it is). Interior REF fields are part
+  // of the structural endpoint contract and must remain visible to the
+  // forwarding tree (REF[TSB[REF[...]]] -> TSB[REF[...]]).
+  if (source.bound() && source.schema() != nullptr && target.schema() != nullptr &&
+      time_series_schema_equivalent(source.schema()->referenced_ts(),
+                                    target.schema())) {
     effective_source =
         source.binding_for(*target.schema()).view(source.evaluation_time());
   }
@@ -465,14 +461,10 @@ walk_source_to_output(TSInputView root, std::span<const std::size_t> path) {
     if (!bound.bound()) {
       return {};
     }
-    if (bound.schema() != nullptr &&
-        bound.schema()->kind == TSTypeKind::REF) {
-      const auto *target = TypeRegistry::instance().dereference(bound.schema());
-      if (target == nullptr || target->kind != TSTypeKind::TSD) {
-        throw std::logic_error(
-            "Nested graph key-set source must resolve to a TSD");
-      }
-      bound = bound.binding_for(*target).view(bound.evaluation_time());
+    bound = bound.through_reference();
+    if (bound.schema() == nullptr || bound.schema()->kind != TSTypeKind::TSD) {
+      throw std::logic_error(
+          "Nested graph key-set source must resolve to a TSD");
     }
     return bound.as_dict().key_set();
   }

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -102,12 +102,16 @@ RATCHETS: tuple[Ratchet, ...] = (
     # --- REF ownership at nested boundaries is a build-time property (family 2) ---
     Ratchet(
         id="runtime-ref-kind-probes",
-        baseline=7,
+        baseline=0,
         roots=("src/hgraph/runtime", "include/hgraph/runtime"),
         suffixes=(".cpp", ".h"),
         pattern=r"TSTypeKind::REF",
         owner="a node's REF handling mode is decided when the node is built "
-        "(nested_graphs.rst), not by probing the schema per tick",
+        "(nested_graphs.rst), not by probing the schema per tick: a structural "
+        "hop goes through TSOutputView::through_reference(), the shared-output "
+        "capture reads the link's bind-time record "
+        "(TSInputView::bound_target_is_reference()), a reference to a possibly "
+        "referenced schema is TypeRegistry::ref (idempotent) -- RFC 0036",
     ),
     # --- Type carriers are resolved by the resolver (family 3) ---
     Ratchet(

--- a/src/hgraph/runtime/graph.cpp
+++ b/src/hgraph/runtime/graph.cpp
@@ -113,13 +113,9 @@ output_at_path(TSOutputView view, const std::vector<std::size_t> &path) {
     if (view.schema() == nullptr) {
       throw std::logic_error("Graph output path requires a typed output view");
     }
-    if (view.schema()->kind == TSTypeKind::REF) {
-      // Any structural hop through a REF source resolves via
-      // its from-REF alternative first (key-set hops, field
-      // projections of REF[TSB], ...).
-      const auto *target = TypeRegistry::instance().dereference(view.schema());
-      view = view.binding_for(*target).view(view.evaluation_time());
-    }
+    // Any structural hop through a REF source resolves via its from-REF
+    // alternative first (key-set hops, field projections of REF[TSB], ...).
+    view = view.through_reference();
     if (component == ts_key_set_path_component) {
       view = view.as_dict().key_set();
       continue;

--- a/src/hgraph/runtime/race_tsd_node.cpp
+++ b/src/hgraph/runtime/race_tsd_node.cpp
@@ -518,11 +518,12 @@ namespace hgraph
 
         auto       &registry       = TypeRegistry::instance();
         const auto *element        = tsd_schema.element_ts();
-        const auto *out_target     = registry.dereference(element);
-        const auto *output_schema  = element->kind == TSTypeKind::REF
-                                         ? element
-                                         : registry.ref(out_target);
-        const auto *race_tsd_schema = element->kind == TSTypeKind::REF
+        const auto *out_target     = registry.value_element_ts(&tsd_schema);
+        // The race publishes a reference to one element. ref is idempotent
+        // (RFC 0036): a dict that already holds references is raced as
+        // declared; otherwise its elements are reached through references.
+        const auto *output_schema   = registry.ref(element);
+        const auto *race_tsd_schema = output_schema == element
                                           ? &tsd_schema
                                           : registry.tsd(tsd_schema.key_type(), output_schema);
         const auto *input_schema = registry.un_named_tsb({{"tsd", race_tsd_schema}});

--- a/src/hgraph/runtime/shared_output_node.cpp
+++ b/src/hgraph/runtime/shared_output_node.cpp
@@ -93,15 +93,12 @@ namespace hgraph
                 MemoryUtils::advance(view.data(), config.storage_offset));
         }
 
+        /** The bound output cannot move: the link recorded when it bound that
+            the output is neither a reference nor reached through another
+            link (RFC 0036); no schema probe on the tick path. */
         [[nodiscard]] bool input_target_is_stable(const TSInputView &input)
         {
-            if (!input.is_bindable() || !input.bound()) { return false; }
-
-            auto target_view = input.bound_output();
-            const auto *target_schema = target_view.schema();
-            if (target_schema == nullptr || target_schema->kind == TSTypeKind::REF) { return false; }
-
-            return detail::target_link_storage(target_view.data_view()) == nullptr;
+            return input.is_bindable() && input.bound() && !input.bound_target_is_reference();
         }
 
         [[nodiscard]] bool input_target_unchanged(

--- a/tests/cpp/test_shared_output_node.cpp
+++ b/tests/cpp/test_shared_output_node.cpp
@@ -194,3 +194,98 @@ TEST_CASE("shared output capture does not republish the same reference on target
     CHECK_FALSE(view.node_at(1).output(t2).modified());
     CHECK(view.node_at(0).output(t2).modified());
 }
+
+namespace
+{
+    using namespace hgraph;
+
+    template <std::int32_t Value>
+    struct SharedOutputConstant
+    {
+        static constexpr auto name              = Value == 101 ? "shared_output_constant_101" : "shared_output_constant_202";
+        static constexpr bool schedule_on_start = true;
+        static void eval(Out<TS<std::int32_t>> out) { out.set(Value); }
+    };
+
+    /** A reference that retargets every cycle: the first source on odd ticks,
+        the second on even ticks. */
+    /** A consumer of the shared output that also depends on the retargeting
+        source, so it ranks after the capture (the wiring-time same-cycle
+        pairing the mock harness does not apply). */
+    struct SharedOutputRankedConsumer
+    {
+        static constexpr auto name = "shared_output_ranked_consumer";
+        static void eval(In<"value", TS<std::int32_t>> value, In<"after", REF<TS<std::int32_t>>> after,
+                         Out<TS<std::int32_t>> out)
+        {
+            static_cast<void>(after);
+            if (value.valid()) { out.set(value.value()); }
+        }
+    };
+
+    struct SharedOutputRetargetingSource
+    {
+        static constexpr auto name              = "shared_output_retargeting_source";
+        static constexpr bool schedule_on_start = true;
+        static void eval(NodeScheduler sched, State<std::int32_t> count, In<"a", REF<TS<std::int32_t>>> a,
+                         In<"b", REF<TS<std::int32_t>>> b, Out<REF<TS<std::int32_t>>> out)
+        {
+            const auto next = count.get() + 1;
+            count.set(next);
+            out.set(next % 2 == 1 ? a.value() : b.value());
+            if (next < 3) { sched.schedule(MIN_TD); }
+        }
+    };
+}  // namespace
+
+TEST_CASE("shared output capture follows a source reference that retargets every cycle")
+{
+    // RFC 0036: the capture decides at bind that its target can move (the
+    // link's record) and stays active, so a consumer of the shared output
+    // always sees the reference's current target.
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int   = registry.ts(int_meta);
+    const auto  path     = std::string{"svc://prices/retargeting"};
+
+    GraphBuilder builder;
+    // Node order: constants, retargeting source, capture (3), shared source
+    // (4, ranked after its capture as the wiring proves), consumer (5).
+    builder.add_node(NodeBuilder{}.implementation<SharedOutputConstant<101>>());
+    builder.add_node(NodeBuilder{}.implementation<SharedOutputConstant<202>>());
+    builder.add_node(NodeBuilder{}.implementation<SharedOutputRetargetingSource>());
+    builder.add_node(make_shared_output_capture_node(path, *ts_int));
+    builder.add_node(make_shared_output_source_node(path, *ts_int));
+    builder.add_node(NodeBuilder{}.implementation<SharedOutputRankedConsumer>());
+    builder.add_edge(GraphEdge{.source_node = 0, .target_node = 2, .target_path = {0}});
+    builder.add_edge(GraphEdge{.source_node = 1, .target_node = 2, .target_path = {1}});
+    builder.add_edge(GraphEdge{.source_node = 2, .target_node = 3, .target_path = {0}});
+    builder.add_edge(GraphEdge{.source_node = 4, .target_node = 3, .target_path = {1}});
+    builder.add_edge(GraphEdge{.source_node = 4, .target_node = 5, .target_path = {0}});
+    builder.add_edge(GraphEdge{.source_node = 2, .target_node = 5, .target_path = {1}});
+
+    testing::MockRootGraph graph{builder};
+    auto                   view = graph.graph();
+    const auto             t1   = MIN_ST;
+    const auto             t2   = t1 + MIN_TD;
+    const auto             t3   = t2 + MIN_TD;
+
+    view.start(t1);
+    view.evaluate(t1);
+    auto capture_input  = view.node_at(3).input(t1);
+    auto capture_bundle = capture_input.as_bundle();
+    CHECK(capture_bundle.at(0).active());
+    REQUIRE(view.node_at(5).output(t1).valid());
+    CHECK(view.node_at(5).output(t1).value().checked_as<std::int32_t>() == 101);
+
+    view.evaluate(t2);
+    CHECK(view.node_at(5).output(t2).value().checked_as<std::int32_t>() == 202);
+
+    view.evaluate(t3);
+    CHECK(view.node_at(5).output(t3).value().checked_as<std::int32_t>() == 101);
+    auto capture_input_later  = view.node_at(3).input(t3);
+    auto capture_bundle_later = capture_input_later.as_bundle();
+    CHECK(capture_bundle_later.at(0).active());
+}


### PR DESCRIPTION
Implements RFC 0036, PR 3 of 4 (`docs/source/rfc/rfc_0036_reference_transparency_owners.rst`, "Implementation plan"): the runtime's seven `TSTypeKind::REF` probes become calls to the owners. Stacked on #759; merge order #758 → #759 → this.

**What changes**

- *Structural hops* (`output_at_path` in `graph.cpp`; `walk_ts_path` and the key-set case of `walk_source_to_output` in `nested_bindings.h`): `view = view.through_reference()` replaces the probe-then-`dereference`-then-`binding_for` sequence; a non-reference is returned as is.
- *Forwarding tree root-REF adaptation* (`bind_forwarding_output_tree_to_source`): asks whether the source *refers to* the target's shape, `time_series_schema_equivalent(source.schema()->referenced_ts(), target.schema())`, which is false for a non-reference, so the kind probe in front of it was redundant. Interior REF fields stay visible to the tree as before.
- *`make_race_tsd_node`*: the output is `registry.ref(element)`, idempotent for a dict that already holds references. **Finding**: the output was declared as a reference to the *dereferenced* element; it is now `REF[element]`. The difference is interior references only, which the reference resolves at its target and consumers compare through `time_series_value_equivalent`.
- *Shared-output stability* (`input_target_is_stable`): `input.is_bindable() && input.bound() && !input.bound_target_is_reference()`, the record the link wrote when it bound (PR 1), replacing the per-tick schema-kind probe and the `target_link_storage` check.

**Tests**: `test_shared_output_node.cpp` gains "shared output capture follows a source reference that retargets every cycle": the capture's input is bound to a `REF[TS[int]]` output that alternates between two constants; the capture stays active and a consumer of the shared output sees 101, 202, 101 across three cycles. (The mock harness has no wiring-time same-cycle pairing, so the test orders the capture before its source and ranks the consumer after the capture, as the wiring proof would.)

**Ratchet**: `runtime-ref-kind-probes` 7 → 0. **Docs**: `testing.rst` bullet, RFC 0036 implementation status (PR 3 + finding).

**Validation (macOS, local gate)**

- C++ core-only suite: all tests passed (257436 assertions in 1715 test cases)
- Python gate (`python/tests` incl. adaptors + all extension suites): 3622 passed, 10 skipped
- `sphinx -W`: clean
- Consumer checks (`python_extension_consumer`, `install_consumer`, fabric test package): passed
- Architecture ratchets: 18 passed with `runtime-ref-kind-probes` at 0

Linux (GCC 14, warnings-as-errors) and Windows (MSVC) results follow as comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
