### PR TITLE
RFC 0036 PR 4: the Python wiring reads what a consumer observes through the bridge's owners (wiring-ref-handling 22 -> 0)

### DIFF
--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -498,12 +498,13 @@ Value and reference crossings
   carries the ruling comment.
 - **The bridge exposes the owners of REF transparency** (RFC 0036) so the
   wiring machinery never re-derives the rule: ``value_port(wiring, port,
-  declared=None)`` is the port as a value consumer observes it (the
-  top-level reference followed and, below it, the structural descent input
-  binding installs, so a structural ``TSB`` / fixed ``TSL`` of references
-  becomes per-field / per-element value projections) -- with a declared
-  schema it is ``NamedPort::observed()``: the port as supplied when the
-  declaration is a ``REF``, else adapted to the declaration;
+  declared=None)`` is the port as a value consumer observes it -- the
+  top-level reference followed, and a peered ``TSB`` / fixed ``TSL`` whose
+  children hold references observed child by child as a structural port of
+  per-field / per-element projections, so a consumer sees each child's own
+  ticks; with a declared schema it is ``NamedPort::observed()``: the port
+  as supplied when the declaration is a ``REF``, else adapted to the
+  declaration (never the descent);
   ``value_ts(ts_type)`` is the schema a value consumer observes;
   ``value_element_ts(ts_type)`` the element of a ``TSD`` / ``TSL`` with
   every reference followed; ``contains_ref(ts_type)`` whether a declaration

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -497,13 +497,19 @@ Value and reference crossings
   itself — ``bundle_port``'s reference-shape handling implements this and
   carries the ruling comment.
 - **The bridge exposes the owners of REF transparency** (RFC 0036) so the
-  wiring machinery never re-derives the rule: ``value_port(wiring, port)``
-  is the port as a value consumer observes it (the top-level reference
-  followed and, below it, the structural descent input binding installs, so
-  a structural ``TSB`` / fixed ``TSL`` of references becomes per-field /
-  per-element value projections); ``value_element_ts(ts_type)`` is the
-  element of a ``TSD`` / ``TSL`` with every reference followed. ``is_ref``
-  and ``ref_target`` remain for authors who ask for a reference explicitly.
+  wiring machinery never re-derives the rule: ``value_port(wiring, port,
+  declared=None)`` is the port as a value consumer observes it (the
+  top-level reference followed and, below it, the structural descent input
+  binding installs, so a structural ``TSB`` / fixed ``TSL`` of references
+  becomes per-field / per-element value projections) -- with a declared
+  schema it is ``NamedPort::observed()``: the port as supplied when the
+  declaration is a ``REF``, else adapted to the declaration;
+  ``value_ts(ts_type)`` is the schema a value consumer observes;
+  ``value_element_ts(ts_type)`` the element of a ``TSD`` / ``TSL`` with
+  every reference followed; ``contains_ref(ts_type)`` whether a declaration
+  asks for references anywhere. ``is_ref`` and ``ref_target`` remain for
+  authors who ask for a reference explicitly; the wiring package itself
+  spells neither (ratchet ``wiring-ref-handling``, held at zero).
 - **Set deltas are shaped by class identity**: a plain ``frozenset`` crossing
   into a TSS applies as the *full value*; a ``_SetDelta`` (registered with C++
   at import via ``_set_set_delta_class``) applies as a *delta*. Same duality

--- a/docs/source/rfc/rfc_0036_reference_transparency_owners.rst
+++ b/docs/source/rfc/rfc_0036_reference_transparency_owners.rst
@@ -532,10 +532,19 @@ Implementation status
   ``value_ts`` / ``value_port``; ``_compose.py``'s reduce identity reads
   ``value_ts``; ``_runner.py``'s record port is ``value_port(w, raw)``, its
   pinned-annotation and producer-annotation rules ``value_ts``;
-  ``_node.py``'s reference-shape list asks ``contains_ref``. The unresolved
-  question on the dynamic ``TSL`` record descent is settled by the parity
-  pins: the record port is the observed port, structural or peered, with
-  no hand-built per-element descent.
+  ``_node.py``'s reference-shape list asks ``contains_ref``.
+
+  *Finding:* the parity pins (``if_`` / ``route_by_index`` under
+  ``eval_node``) require the per-field descent: a peered bundle of
+  references observed as one descriptive bundle records every field through
+  the shared target, where the harness expects each field's own ticks. So
+  ``value_port`` without a declaration observes a peered ``TSB`` / fixed
+  ``TSL`` whose children hold references *child by child* -- a structural
+  port of per-field / per-element observed projections (the descent the
+  runner used to build by hand) -- and everything else descriptively. The
+  dynamic ``TSL`` question is thereby settled: no fixed size, no descent; the
+  port is observed as supplied. A declared schema (the graph-output rule)
+  never descends: the port is adapted to its declaration.
 
 References
 ----------

--- a/docs/source/rfc/rfc_0036_reference_transparency_owners.rst
+++ b/docs/source/rfc/rfc_0036_reference_transparency_owners.rst
@@ -521,7 +521,21 @@ Implementation status
   *dereferenced* element; it now declares ``REF[element]`` -- the element's
   interior references are part of the shape the reference resolves at its
   target, and consumers compare through ``time_series_value_equivalent``.
-* PR 4 (Python wiring): pending.
+* **PR 4 (Python wiring)** -- landed: ``wiring-ref-handling`` 22 → 0. The
+  bridge's ``value_port`` gains a ``declared`` schema (the port as supplied
+  when the declaration is a ``REF``, else adapted to it -- ``NamedPort::observed()``
+  for the DSL), and ``value_ts`` (the schema a value consumer observes) and
+  ``contains_ref`` (a declaration asks for references somewhere) join
+  ``value_element_ts``. ``_graph.py``'s graph-output rule is
+  ``value_port(wiring, raw, declared)``; ``_core.py``'s field-name lookup,
+  ``as_dict`` / ``as_scalar_ts`` / ``from_ts`` and the context match read
+  ``value_ts`` / ``value_port``; ``_compose.py``'s reduce identity reads
+  ``value_ts``; ``_runner.py``'s record port is ``value_port(w, raw)``, its
+  pinned-annotation and producer-annotation rules ``value_ts``;
+  ``_node.py``'s reference-shape list asks ``contains_ref``. The unresolved
+  question on the dynamic ``TSL`` record descent is settled by the parity
+  pins: the record port is the observed port, structural or peered, with
+  no hand-built per-element descent.
 
 References
 ----------

--- a/python/hgraph/_wiring/_compose.py
+++ b/python/hgraph/_wiring/_compose.py
@@ -135,9 +135,7 @@ def mesh_(func, *args, __name__=None, __keys__=None, __key_arg__=None, **kwargs)
 
 def _reduce_nothing(ts):
     """Create the typed invalid identity used by an explicit ``zero=None``."""
-    collection = _unwrap(ts).ts_type
-    if collection.is_ref:
-        collection = _hgraph.ref_target(collection)
+    collection = _hgraph.value_ts(_unwrap(ts).ts_type)
     if collection.is_tsd:
         element = _hgraph.tsd_element_ts(collection)
     elif collection.is_tsl:

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -775,15 +775,9 @@ WiringPort.__hash__ = object.__hash__  # __eq__ wires a node; identity hashing s
 
 def _port_bundle_field_names(self):
     """The TSB field names of a port (looking through REF), else None."""
-    ts_type = self._port.ts_type
-    if ts_type.is_tsb:
-        return _hgraph.tsb_field_names(ts_type)
-    try:
-        deref = self._port.dereferenced
-        if deref is not None and deref.ts_type.is_tsb:
-            return _hgraph.tsb_field_names(deref.ts_type)
-    except Exception:
-        pass
+    observed = _hgraph.value_ts(self._port.ts_type)
+    if observed.is_tsb:
+        return _hgraph.tsb_field_names(observed)
     return None
 
 
@@ -815,9 +809,7 @@ def _port_copy_with(self, **overrides):
     if unknown:
         raise TypeError(f"unknown TSB field(s): {', '.join(unknown)}")
 
-    target = self._port.ts_type
-    if not target.is_tsb:
-        target = self._port.dereferenced.ts_type
+    target = _hgraph.value_ts(self._port.ts_type)
     from .._types import _TsExpr
 
     fields = {name: getattr(self, name) for name in names}
@@ -831,14 +823,14 @@ def _port_as_dict(self):
     if names is None:
         raise TypeError("as_dict is only defined for TSB ports")
     raw = _unwrap(self)
-    source = self if raw.ts_type.is_tsb else WiringPort(raw.dereferenced)
+    source = self if raw.ts_type.is_tsb else WiringPort(_hgraph.value_port(_current_wiring(), raw))
     return {name: getattr(source, name) for name in names}
 
 
 def _port_as_scalar_ts(self):
     """Convert a lifted CompoundScalar TSB (or REF[TSB]) to its scalar TS."""
     raw = _unwrap(self)
-    source = raw if raw.ts_type.is_tsb else raw.dereferenced
+    source = raw if raw.ts_type.is_tsb else _hgraph.value_port(_current_wiring(), raw)
     if source is None or not source.ts_type.is_tsb:
         raise TypeError("as_scalar_ts is only defined for TSB ports")
 
@@ -1003,7 +995,7 @@ def _resolve_context(ctx_expr, name=None, resolution_scope=None):
         if not matches:
             requested_class = getattr(ctx_expr.ts, "_py_class", None)
             published_class = None
-            candidate = _hgraph.ref_target(ts_type) if ts_type.is_ref else ts_type
+            candidate = _hgraph.value_ts(ts_type)
             if candidate.is_ts:
                 published_class = _hgraph.python_type_for_value(
                     _hgraph.ts_value_vt(candidate))

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -104,10 +104,11 @@ def _wrap_graph_fn(gfn, *, input_names=None, scalar_bindings=None,
                 # Python graph outputs expose referenced values unless the
                 # author explicitly declares a REF return: the output is
                 # observed as its declaration would observe it (RFC 0036,
-                # value_port). The projected endpoint path is preserved while
-                # map_/mesh_ get the plain child schema used by equivalent
-                # C++ wiring.
-                declared = out_tp.handle if isinstance(out_tp, _TsExpr) else None
+                # value_port), an undeclared one as its own observed schema.
+                # The projected endpoint path is preserved while map_/mesh_
+                # get the plain child schema used by equivalent C++ wiring.
+                declared = (out_tp.handle if isinstance(out_tp, _TsExpr)
+                            else _hgraph.value_ts(raw.ts_type))
                 raw = _hgraph.value_port(_current_wiring(), raw, declared)
             return raw
         finally:

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -100,13 +100,15 @@ def _wrap_graph_fn(gfn, *, input_names=None, scalar_bindings=None,
             # into its zero-copy REF terminal. Leaving the structural port
             # intact here keeps Python and native graph functions on the same
             # wiring path and preserves partially-bound field references.
-            if not raw.is_structural and raw.has_path and not (
-                    isinstance(out_tp, _TsExpr) and out_tp.is_ref):
+            if not raw.is_structural and raw.has_path:
                 # Python graph outputs expose referenced values unless the
-                # author explicitly declares a REF return. Preserve the
-                # projected endpoint path while giving map_/mesh_ the plain
-                # child schema used by equivalent C++ wiring.
-                raw = raw.dereferenced
+                # author explicitly declares a REF return: the output is
+                # observed as its declaration would observe it (RFC 0036,
+                # value_port). The projected endpoint path is preserved while
+                # map_/mesh_ get the plain child schema used by equivalent
+                # C++ wiring.
+                declared = out_tp.handle if isinstance(out_tp, _TsExpr) else None
+                raw = _hgraph.value_port(_current_wiring(), raw, declared)
             return raw
         finally:
             _wiring_stack.pop()

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -946,7 +946,7 @@ class _PyNode:
                         scope, param.annotation, value)
                     reference_shapes.append(
                         requested
-                        if requested is not None and _hgraph.ref_target(requested) != requested
+                        if requested is not None and _hgraph.contains_ref(requested)
                         else False)
                     continue
                 required = valid_policy is None or param.name in valid_policy
@@ -958,7 +958,7 @@ class _PyNode:
                 requested = self._requested_input_shape(scope, param.annotation, value)
                 reference_shapes.append(
                     requested
-                    if requested is not None and _hgraph.ref_target(requested) != requested
+                    if requested is not None and _hgraph.contains_ref(requested)
                     else False)
             else:
                 layout.append("s")

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -338,7 +338,7 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
         if out is not None:
             w.wire(
                 "__harness_record",
-                (_unwrap(out).dereferenced, "__run_graph__"),
+                (_hgraph.value_port(w, _unwrap(out)), "__run_graph__"),
                 {"sparse": True},
             )
         config.graph_logger.debug(
@@ -613,7 +613,7 @@ def eval_node(node, *args, output_type=None, resolution_dict=None,
             if resolved is not None:
                 # eval_node replays ordinary producer values. REF-transparent
                 # input binding performs the reference adaptation at wiring.
-                resolved = _hgraph.ref_target(resolved)
+                resolved = _hgraph.value_ts(resolved)
                 annotations_by_name[name] = _PinnedTsExpr(resolved, repr(annotation))
 
     def _named_series_value(k, v):
@@ -693,8 +693,10 @@ def eval_node(node, *args, output_type=None, resolution_dict=None,
         w.configure_wiring_observers(__trace_wiring__, ())
         def _producer_annotation(annotation):
             """eval_node samples are values of the producer behind REF[T]."""
-            if isinstance(annotation, _TsExpr) and annotation.handle.is_ref:
-                return _TsExpr(_hgraph.ref_target(annotation.handle), repr(annotation))
+            if isinstance(annotation, _TsExpr):
+                observed = _hgraph.value_ts(annotation.handle)
+                if observed != annotation.handle:
+                    return _TsExpr(observed, repr(annotation))
             return annotation
 
         ports = []
@@ -826,24 +828,13 @@ def eval_node(node, *args, output_type=None, resolution_dict=None,
                         realtime=realtime, trace=trace,
                         observers=tuple(__observers__ or ()))
             return None
-        # hgraph parity: a REF graph output records its DEREFERENCED values.
-        # A TSB with REF fields records a STRUCTURAL bundle of per-field
-        # projections, each dereferenced.
+        # hgraph parity: a REF graph output records its DEREFERENCED values,
+        # and a structural TSB / TSL of references records per-field /
+        # per-element values: the output as a value consumer observes it
+        # (RFC 0036, value_port).
         raw = _unwrap(out)
         record_kwargs = {"sparse": True} if __elide__ else {}
-        record_port = raw.dereferenced
-        if raw.ts_type.is_tsb and _hgraph.tsb_has_ref_fields(raw.ts_type):
-            fields = {
-                name: _unwrap(wire("getitem_", WiringPort(raw), name)).dereferenced
-                for name, _ in _hgraph.ts_field_types(raw.ts_type)
-            }
-            record_port = _hgraph.tsb_port(record_port.ts_type, fields)
-        elif raw.ts_type.is_fixed_tsl and _hgraph.tsl_element(raw, 0).ts_type.is_ref:
-            # A TSL of REF elements: record a structural TSL of per-element
-            # projections, each dereferenced.
-            record_port = _hgraph.tsl_port(
-                [_hgraph.tsl_element(raw, i).dereferenced for i in range(raw.ts_type.fixed_size)]
-            )
+        record_port = _hgraph.value_port(w, raw)
         w.wire("__harness_record", (record_port, "eval_node::out"), record_kwargs)
         run = w.run(start_time=__start_time__, end_time=__end_time__,
                     realtime=realtime, trace=trace,

--- a/python/py_ports.cpp
+++ b/python/py_ports.cpp
@@ -14,6 +14,47 @@ using namespace hgraph;
 using namespace hgraph::python_bridge;
 
 namespace hgraph::python_bridge {
+namespace {
+/** RFC 0036: the port as a value consumer observes it, with no declaration
+    to adapt to. A peered bundle or fixed list whose children hold references
+    is observed child by child -- a structural port of per-field /
+    per-element observed projections, each reference followed where it is --
+    so a consumer sees each child's own ticks rather than one bundle-wide
+    reading through a shared target. Every other port is adapted to its
+    observed schema (the top-level reference followed). */
+WiringPortRef observed_value_port(Wiring &w, const WiringPortRef &port) {
+  const auto *schema = port.schema;
+  auto &registry = TypeRegistry::instance();
+  if (schema != nullptr && !port.is_structural_source() &&
+      TypeRegistry::contains_ref(schema)) {
+    if (schema->kind == TSTypeKind::TSB) {
+      std::vector<WiringPortRef> children;
+      children.reserve(schema->field_count());
+      for (std::size_t index = 0; index < schema->field_count(); ++index) {
+        children.push_back(observed_value_port(
+            w, subgraph_wiring_detail::tsb_field_ref(
+                   port, index, schema->fields()[index].type)));
+      }
+      return WiringPortRef::structural_source(registry.dereference(schema),
+                                              std::move(children));
+    }
+    if (schema->kind == TSTypeKind::TSL && schema->fixed_size() > 0) {
+      std::vector<WiringPortRef> children;
+      children.reserve(schema->fixed_size());
+      for (std::size_t index = 0; index < schema->fixed_size(); ++index) {
+        children.push_back(observed_value_port(
+            w, subgraph_wiring_detail::tsl_element_ref(port, index,
+                                                       schema->element_ts())));
+      }
+      return WiringPortRef::structural_source(registry.dereference(schema),
+                                              std::move(children));
+    }
+  }
+  return graph_wiring_detail::adapt_source_for_input(
+      w, registry.dereference(schema), port);
+}
+} // namespace
+
 void bind_ports(nb::module_ &m) {
   nb::class_<PyPort>(m, "Port")
       .def_prop_ro("ts_type",
@@ -213,26 +254,22 @@ void bind_ports(nb::module_ &m) {
   m.def(
       "value_port",
       [](PyWiring &wiring, const PyPort &port, nb::object declared) {
-        // The port as a value consumer observes it (RFC 0036): the top-level
-        // reference followed and, below it, the structural descent input
-        // binding installs for a declared input of the observed shape - a
-        // structural TSB / fixed TSL of references becomes per-field /
-        // per-element value projections. With a declared schema this is
-        // NamedPort::observed(): the port as supplied when the declaration is
-        // a REF, else adapted to the declaration. This is what the wiring
-        // machinery reconstructed by hand.
-        const TSValueTypeMetaData *target = nullptr;
+        // The port as a value consumer observes it (RFC 0036). With a
+        // declared schema this is NamedPort::observed(): the port as supplied
+        // when the declaration is a REF, else adapted to the declaration.
+        // Without one, the top-level reference is followed and a bundle or
+        // fixed list of references is observed child by child (see
+        // observed_value_port). This is what the wiring machinery
+        // reconstructed by hand.
         if (!declared.is_none()) {
-          target = nb::cast<PyTsType &>(declared).meta;
+          const auto *target = nb::cast<PyTsType &>(declared).meta;
           if (target != nullptr && target->kind == TSTypeKind::REF) {
             return port;
           }
+          return PyPort{graph_wiring_detail::adapt_source_for_input(
+              *wiring.raw, target, port.ref)};
         }
-        if (target == nullptr) {
-          target = TypeRegistry::instance().dereference(port.ref.schema);
-        }
-        return PyPort{graph_wiring_detail::adapt_source_for_input(
-            *wiring.raw, target, port.ref)};
+        return PyPort{observed_value_port(*wiring.raw, port.ref)};
       },
       nb::arg("wiring"), nb::arg("port"), nb::arg("declared") = nb::none());
 

--- a/python/py_ports.cpp
+++ b/python/py_ports.cpp
@@ -210,16 +210,31 @@ void bind_ports(nb::module_ &m) {
         *wiring.raw, ref_schema, port.ref)};
   });
 
-  m.def("value_port", [](PyWiring &wiring, const PyPort &port) {
-    // The port as a value consumer observes it (RFC 0036): the top-level
-    // reference followed and, below it, the structural descent input binding
-    // installs for a declared input of the observed shape - a structural
-    // TSB / fixed TSL of references becomes per-field / per-element value
-    // projections. This is what the wiring machinery reconstructed by hand.
-    const auto *observed = TypeRegistry::instance().dereference(port.ref.schema);
-    return PyPort{graph_wiring_detail::adapt_source_for_input(
-        *wiring.raw, observed, port.ref)};
-  });
+  m.def(
+      "value_port",
+      [](PyWiring &wiring, const PyPort &port, nb::object declared) {
+        // The port as a value consumer observes it (RFC 0036): the top-level
+        // reference followed and, below it, the structural descent input
+        // binding installs for a declared input of the observed shape - a
+        // structural TSB / fixed TSL of references becomes per-field /
+        // per-element value projections. With a declared schema this is
+        // NamedPort::observed(): the port as supplied when the declaration is
+        // a REF, else adapted to the declaration. This is what the wiring
+        // machinery reconstructed by hand.
+        const TSValueTypeMetaData *target = nullptr;
+        if (!declared.is_none()) {
+          target = nb::cast<PyTsType &>(declared).meta;
+          if (target != nullptr && target->kind == TSTypeKind::REF) {
+            return port;
+          }
+        }
+        if (target == nullptr) {
+          target = TypeRegistry::instance().dereference(port.ref.schema);
+        }
+        return PyPort{graph_wiring_detail::adapt_source_for_input(
+            *wiring.raw, target, port.ref)};
+      },
+      nb::arg("wiring"), nb::arg("port"), nb::arg("declared") = nb::none());
 
   m.def("un_named_tsb_type", [](nb::list fields) {
     std::vector<std::pair<std::string, const TSValueTypeMetaData *>>

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -1014,6 +1014,14 @@ namespace hgraph::python_bridge
     m.def("ref_ts", [](PyTsType target) { return PyTsType{TypeRegistry::instance().ref(target.meta)}; });
     m.def("ref_target", [](PyTsType ref) { return PyTsType{TypeRegistry::instance().dereference(ref.meta)}; });
     m.def(
+        "contains_ref", [](PyTsType ts) { return TypeRegistry::contains_ref(ts.meta); },
+        "True when a time-series type declares a reference at any level: the declaration asks for "
+        "references, so its ports are bound as supplied (RFC 0036).");
+    m.def(
+        "value_ts", [](PyTsType ts) { return PyTsType{TypeRegistry::instance().dereference(ts.meta)}; },
+        "The schema a value consumer observes for a time-series type: every reference followed (RFC 0036). "
+        "ref_target is the same lookup asked of a reference explicitly.");
+    m.def(
         "value_element_ts",
         [](PyTsType collection) { return PyTsType{TypeRegistry::instance().value_element_ts(collection.meta)}; },
         "The element of a TSD / TSL as an access through the element link observes it: "

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -71,12 +71,15 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
     Ratchet(
         id="wiring-ref-handling",
-        baseline=22,
+        baseline=0,
         roots=("python/hgraph/_wiring",),
         suffixes=(".py",),
         pattern=r"\b(is_ref|dereferenced|ref_target)\b",
-        owner="binding inserts the from-REF adaptation "
-        "(python_bridge.rst, 'Value and reference crossings')",
+        owner="binding inserts the from-REF adaptation (python_bridge.rst, "
+        "'Value and reference crossings'); the wiring machinery reads what a "
+        "consumer observes through the bridge's owners -- value_port(wiring, "
+        "port, declared), value_ts, value_element_ts, contains_ref (RFC 0036) "
+        "-- and never dereferences or probes is_ref for itself",
     ),
     Ratchet(
         id="value-consumer-source-callers",

--- a/python/tests/test_reference_transparency_owners.py
+++ b/python/tests/test_reference_transparency_owners.py
@@ -66,3 +66,20 @@ def test_value_port_keeps_a_reference_the_declaration_asks_for():
     assert hg.value_port(w, ref, hg.ref_ts(bundle_type)).ts_type.is_ref
     assert hg.value_port(w, ref, bundle_type).ts_type == bundle_type
     assert hg.value_port(w, ref, None).ts_type == bundle_type
+
+
+def test_value_port_observes_a_bundle_of_references_child_by_child():
+    # if_ publishes TSB[BoolResult] whose fields are references; observed
+    # without a declaration, it is a structural bundle of per-field value
+    # projections, so a consumer sees each field's own ticks.
+    w = hg.Wiring()
+    condition = w.wire("const", (True,), {}, output_type=hg.ts(hg.value_type("bool")))
+    ts = w.wire("const", (1,), {}, output_type=TS_INT)
+    routed = w.wire("if_", (condition, ts), {})
+    assert routed.ts_type.is_tsb and hg.tsb_has_ref_fields(routed.ts_type)
+    assert not routed.is_structural
+
+    observed = hg.value_port(w, routed)
+    assert observed.is_structural
+    assert observed.ts_type == hg.value_ts(routed.ts_type)
+    assert not hg.tsb_has_ref_fields(observed.ts_type)

--- a/python/tests/test_reference_transparency_owners.py
+++ b/python/tests/test_reference_transparency_owners.py
@@ -43,3 +43,26 @@ def test_value_port_observes_the_referenced_value():
     assert not observed.ts_type.is_ref
     # A plain port is observed as it is.
     assert hg.value_port(w, src).ts_type == TS_INT
+
+
+def test_value_ts_and_contains_ref_follow_the_declaration():
+    assert hg.value_ts(REF_INT) == TS_INT
+    assert hg.value_ts(TS_INT) == TS_INT
+    assert hg.value_ts(hg.tsd(STR, REF_INT)) == hg.tsd(STR, TS_INT)
+    assert hg.contains_ref(REF_INT)
+    assert hg.contains_ref(hg.tsd(STR, REF_INT))
+    assert not hg.contains_ref(hg.tsd(STR, TS_INT))
+    assert not hg.contains_ref(TS_INT)
+
+
+def test_value_port_keeps_a_reference_the_declaration_asks_for():
+    w = hg.Wiring()
+    src = w.wire("const", (1,), {}, output_type=TS_INT)
+    bundle_type = hg.un_named_tsb_type([("a", TS_INT)])
+    ref = hg.ref_port(w, hg.tsb_port(bundle_type, {"a": src}))
+    assert ref.ts_type.is_ref
+
+    # Declared REF: the reference as supplied. Declared value: observed.
+    assert hg.value_port(w, ref, hg.ref_ts(bundle_type)).ts_type.is_ref
+    assert hg.value_port(w, ref, bundle_type).ts_type == bundle_type
+    assert hg.value_port(w, ref, None).ts_type == bundle_type


### PR DESCRIPTION
Implements RFC 0036, PR 4 of 4 (`docs/source/rfc/rfc_0036_reference_transparency_owners.rst`, "Implementation plan"): the Python wiring stops spelling `is_ref` / `dereferenced` / `ref_target` and reads what a consumer observes through the bridge's owners. Stacked on #760; merge order #758 → #759 → #760 → this.

**Bridge**

- `value_port(wiring, port, declared=None)`: with a declared schema it is `NamedPort::observed()` for the DSL, the port as supplied when the declaration is a `REF`, else adapted to the declaration; without one, the port as a value consumer observes it: the top-level reference followed, and a peered `TSB` / fixed `TSL` whose children hold references observed **child by child** as a structural port of per-field / per-element projections (the descent `_runner.py` used to build by hand), so a consumer sees each child's own ticks.
- `value_ts(ts_type)`: the schema a value consumer observes (every reference followed). `ref_target` is the same lookup asked of a reference explicitly and stays for that use outside the wiring package.
- `contains_ref(ts_type)`: whether a declaration asks for references anywhere (`TypeRegistry::contains_ref`).

**Wiring sites (22 → 0)**

- `_graph.py`: the graph-output rule ("a Python graph output exposes referenced values unless the author declares a REF return") is `value_port(wiring, raw, declared)`.
- `_core.py`: the TSB field-name lookup, `as_dict`, `as_scalar_ts`, `from_ts` and the context match read `value_ts` / `value_port`.
- `_compose.py`: the reduce identity reads `value_ts` of the collection.
- `_runner.py`: the record port is `value_port(w, raw)` (in place of the hand-built per-field / per-element dereferenced descent); the pinned-annotation and producer-annotation rules read `value_ts`.
- `_node.py`: the reference-shape list asks `contains_ref` of the requested shape instead of testing whether dereferencing changes it.

**Finding** (RFC implementation status): the parity pins (`if_` / `route_by_index` under `eval_node`) require the per-field descent: a peered bundle of references observed as one descriptive bundle records every field through the shared target, where the harness expects each field's own ticks. The descent therefore lives in `value_port` (no declaration), and the RFC's dynamic-`TSL` question is settled: no fixed size, no descent. A declared schema (the graph-output rule) never descends.

**Ratchet**: `wiring-ref-handling` 22 → 0. **Docs**: `python_bridge.rst` ("Value and reference crossings"), RFC 0036 implementation status. **Tests**: `python/tests/test_reference_transparency_owners.py` gains `value_ts` / `contains_ref` and the declared-`REF` `value_port` case; the REF consumer sweep, the ported operator and wiring suites and the eval_node harness are the behaviour pins.

**Validation (macOS, local gate)**

- C++ core-only suite: all tests passed (257436 assertions in 1715 test cases; unchanged by this PR)
- Python gate (`python/tests` incl. adaptors + all extension suites): 3625 passed, 10 skipped (the REF consumer sweep, the ported operator and wiring suites and `eval_node` all green)
- `sphinx -W`: clean
- Consumer checks (`python_extension_consumer`, `install_consumer`, fabric test package): passed
- Architecture ratchets: 18 passed with `wiring-ref-handling` at 0

Linux (GCC 14, warnings-as-errors) and Windows (MSVC) results follow as comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
