### PR TITLE
Parity campaign: the REF-producing source is a recipe axis, not one fixed TSL projection

### DIFF
--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -30,10 +30,16 @@ Prepare the two isolated runtime environments:
 
    .venv/bin/python -m tools.parity setup
 
-``setup`` also uninstalls any first-party extension wheel (``hgraph-persistence``
-and its siblings) that an earlier setup installed and the current invocation
-does not supply: an extension is built against one core and its native
-library breaks beside a rebuilt one.
+``setup`` builds the candidate core wheel and, against the core it just
+installed, the ``hgraph-persistence`` wheel the frame-recording recipes need
+(the same shape as the nightly: the SDK is the installed wheel's
+site-packages, the build runs without isolation in the candidate environment,
+and both are cached under ``.parity/wheels`` by their source fingerprints).
+``--no-extensions`` skips that; the nightly supplies its own via
+``--candidate-extra-wheel``, which also skips the build for that extension.
+``setup`` uninstalls any first-party extension an earlier setup installed that
+the current invocation neither supplies nor builds: an extension is built
+against one core and its native library breaks beside a rebuilt one.
 
 Run the bounded pull-request profile:
 

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -30,6 +30,11 @@ Prepare the two isolated runtime environments:
 
    .venv/bin/python -m tools.parity setup
 
+``setup`` also uninstalls any first-party extension wheel (``hgraph-persistence``
+and its siblings) that an earlier setup installed and the current invocation
+does not supply: an extension is built against one core and its native
+library breaks beside a rebuilt one.
+
 Run the bounded pull-request profile:
 
 .. code-block:: bash

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -228,7 +228,11 @@ ordinary operators and framework boundaries must consume REF-transparent
 sources however the reference was produced.  The ``feedback-accumulate-via-*``
 corpus recipes pin one deterministic case per source.  Templates whose
 parameter set is closed (``polymorphic_tsd_key``, ``value_consumer_reference``)
-keep the default projection.
+keep the default projection.  Coverage attributes the route's own tags (the
+shape it goes through, how the consumer binds to it, the operators it spells)
+to the recipe's source rather than to the template
+(``catalog.REFERENCE_SOURCE_FEATURES``), so a recipe routed through ``if_``
+counts ``if_`` and a ``TSB``, not a ``TSL`` projection.
 The scalar-expression and scalar-operator-argument families retain direct
 inputs to preserve an independent baseline and isolate public overload
 selection from reference projection behavior.

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -205,10 +205,19 @@ operator pipelines, and mesh lifecycle driven by a TSD key set.  TSD key-set
 recipes include value-only updates,
 same-cycle replacement, removal, repopulation, and empty transitions.
 
-Most generated framework families pass their inputs through a fixed structural
-``TSL`` projection before use.  This intentionally combines a
-non-peered container with a ``REF``-producing child projection, so ordinary
-operators and framework boundaries must consume REF-transparent sources.
+Most generated framework families pass their inputs through a ``REF``-producing
+source before use, chosen per recipe by the ``reference_source`` parameter
+(``catalog.REFERENCE_SOURCES``): the fixed structural ``TSL`` projection the
+catalogue always used (the default, so committed recipes keep their
+fingerprints), a ``TSD`` item lookup, a ``map_`` element, a ``switch_``
+branch, or the ``true`` arm of ``if_``.  These are the generic producers of
+the REF consumer sweep (:doc:`testing`, "Authoring-shape sweeps"), so the
+differential oracle sees every one of them under random tick sequences, and
+ordinary operators and framework boundaries must consume REF-transparent
+sources however the reference was produced.  The ``feedback-accumulate-via-*``
+corpus recipes pin one deterministic case per source.  Templates whose
+parameter set is closed (``polymorphic_tsd_key``, ``value_consumer_reference``)
+keep the default projection.
 The scalar-expression and scalar-operator-argument families retain direct
 inputs to preserve an independent baseline and isolate public overload
 selection from reference projection behavior.

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -2662,3 +2662,40 @@ def test_new_template_validators_reject_malformed_recipes():
         },
         "must not re-add removed keys",
     )
+
+
+def test_generated_projecting_recipes_draw_every_reference_source():
+    pytest.importorskip("hypothesis")
+    from tools.parity.catalog import REFERENCE_SOURCES, REFERENCE_SOURCE_TEMPLATES
+    from tools.parity.generate import generate_recipes
+
+    recipes = generate_recipes(
+        200, seed=43,
+        templates=("feedback_accumulate", "switch_arithmetic", "context_switch"),
+    )
+    assert {recipe.parameters["reference_source"] for recipe in recipes} == set(REFERENCE_SOURCES)
+    for recipe in recipes:
+        source = recipe.parameters["reference_source"]
+        assert f"reference-source:{source}" in recipe.features
+        assert recipe.template in REFERENCE_SOURCE_TEMPLATES
+    # A template with a closed parameter set draws none.
+    closed = generate_recipes(4, seed=43, templates=("polymorphic_tsd_key",))
+    assert all("reference_source" not in recipe.parameters for recipe in closed)
+
+
+def test_reference_source_parameter_is_validated():
+    import json
+    from tools.parity.catalog import validate_recipe
+    from tools.parity.model import Recipe, RecipeError
+
+    base = json.loads((CORPUS / "feedback-accumulate-sparse.json").read_text())
+    for source in ("tsl_projection", "tsd_getitem", "map_element", "switch_branch", "if_true"):
+        raw = {**base, "id": f"probe-{source}", "parameters": {**base["parameters"], "reference_source": source}}
+        validate_recipe(Recipe.from_dict(raw))
+    raw = {**base, "id": "probe-bogus", "parameters": {**base["parameters"], "reference_source": "bogus"}}
+    with pytest.raises(RecipeError, match="reference_source must be one of"):
+        validate_recipe(Recipe.from_dict(raw))
+    closed = json.loads((CORPUS / "regression-value-consumer-reference.json").read_text())
+    raw = {**closed, "id": "probe-closed", "parameters": {**closed["parameters"], "reference_source": "if_true"}}
+    with pytest.raises(RecipeError, match="does not take a reference_source"):
+        validate_recipe(Recipe.from_dict(raw))

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -786,12 +786,31 @@ def test_candidate_extra_wheels_install_beside_the_core_wheel(
             str(extra_wheel.resolve()),
         ],
     ]
+    # Without a supplied persistence wheel, setup builds one against the
+    # core it just installed and installs it the same way.
+    built_wheel = tmp_path / "built" / "hgraph_persistence-0.0.0-cp312-abi3-built.whl"
+    built_wheel.parent.mkdir()
+    built_wheel.write_bytes(b"built")
+    monkeypatch.setattr(
+        environments, "_built_extension_wheel",
+        lambda name, core_fingerprint, python: built_wheel,
+    )
+    commands.clear()
     _core_only_python, _identity, core_only_fingerprint = (
         environments.ensure_candidate_environment(candidate_wheel=core_wheel)
     )
     assert fingerprint != core_only_fingerprint
     marker = tmp_path / "envs" / "candidate-test" / ".wheel-fingerprint"
     assert marker.read_text().strip() == core_only_fingerprint
+    assert commands[-1] == [
+        "uv", "pip", "install", "--python", str(python), "--reinstall", "--no-deps",
+        str(built_wheel),
+    ]
+    # Opting out installs the core alone.
+    commands.clear()
+    marker.unlink()
+    environments.ensure_candidate_environment(candidate_wheel=core_wheel, build_extensions=False)
+    assert all("--no-deps" not in command for command in commands)
 
 
 def test_stale_cached_parity_environment_is_rebuilt(monkeypatch, tmp_path):
@@ -2729,13 +2748,19 @@ def test_setup_drops_extension_wheels_an_earlier_setup_installed(monkeypatch, tm
     monkeypatch.setattr(environments, "_run", commands.append)
     monkeypatch.setattr(environments, "environment_identity", lambda _interpreter: {})
 
-    environments.ensure_candidate_environment(candidate_wheel=core_wheel)
+    environments.ensure_candidate_environment(
+        candidate_wheel=core_wheel, build_extensions=False
+    )
     assert ["uv", "pip", "uninstall", "--python", str(python), "hgraph-persistence"] in commands
 
     commands.clear()
     (venv / ".wheel-fingerprint").unlink()
     extra_wheel = tmp_path / "hgraph_persistence-0.0.0-cp312-abi3-test.whl"
     extra_wheel.write_bytes(b"persistence")
+    monkeypatch.setattr(
+        environments, "_built_extension_wheel",
+        lambda *_args: pytest.fail("a supplied extension is never rebuilt"),
+    )
     environments.ensure_candidate_environment(
         candidate_wheel=core_wheel, candidate_extra_wheels=(extra_wheel,)
     )

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -501,11 +501,13 @@ def test_generated_framework_recipes_prioritize_ref_and_non_peered_paths():
             "polymorphic_field_projection",
         }
     }
+    # Every recipe of a projecting template publishes a reference and says how
+    # the consumer binds to it; the route's tags come from the recipe's source.
     reference_templates = {
         recipe.template for recipe in recipes
         if recipe.template in reference_candidate_templates
         and "reference:REF" in recipe.features
-        and "binding:non-peered" in recipe.features
+        and any(feature.startswith("binding:") for feature in recipe.features)
     }
     assert len(reference_templates) >= len(reference_candidate_templates) * 0.8
     operator_pipelines = generate_recipes(
@@ -2714,6 +2716,10 @@ def test_reference_source_parameter_is_validated():
     raw = {**base, "id": "probe-bogus", "parameters": {**base["parameters"], "reference_source": "bogus"}}
     with pytest.raises(RecipeError, match="reference_source must be one of"):
         validate_recipe(Recipe.from_dict(raw))
+    # An explicit null is not an omission: the executor would read it back.
+    raw = {**base, "id": "probe-null", "parameters": {**base["parameters"], "reference_source": None}}
+    with pytest.raises(RecipeError, match="reference_source must be one of"):
+        validate_recipe(Recipe.from_dict(raw))
     closed = json.loads((CORPUS / "regression-value-consumer-reference.json").read_text())
     raw = {**closed, "id": "probe-closed", "parameters": {**closed["parameters"], "reference_source": "if_true"}}
     with pytest.raises(RecipeError, match="does not take a reference_source"):
@@ -2765,3 +2771,42 @@ def test_setup_drops_extension_wheels_an_earlier_setup_installed(monkeypatch, tm
         candidate_wheel=core_wheel, candidate_extra_wheels=(extra_wheel,)
     )
     assert not any(command[:3] == ["uv", "pip", "uninstall"] for command in commands)
+
+
+def test_coverage_attributes_the_route_to_the_reference_source():
+    from tools.parity.catalog import (DEFAULT_REFERENCE_SOURCE, REFERENCE_SOURCE_FEATURES,
+                                      REFERENCE_SOURCES)
+    from tools.parity.coverage import recipe_features
+    from tools.parity.model import Recipe
+
+    projection = set(recipe_features(Recipe.load(CORPUS / "feedback-accumulate-sparse.json")))
+    assert set(REFERENCE_SOURCE_FEATURES[DEFAULT_REFERENCE_SOURCE]) <= projection
+    via_if = set(recipe_features(Recipe.load(CORPUS / "feedback-accumulate-via-if-true.json")))
+    assert set(REFERENCE_SOURCE_FEATURES["if_true"]) <= via_if
+    # The TSL projection's tags are the projection's, not the template's.
+    assert not {"shape:TSL", "binding:non-peered", "operator:getitem_"} & via_if
+    assert "reference-source:if_true" in via_if
+    for source in REFERENCE_SOURCES:
+        assert "reference:REF" in REFERENCE_SOURCE_FEATURES[source]
+
+
+def test_projecting_templates_are_the_ones_that_route_through_a_reference():
+    import ast
+    import inspect
+    from tools.parity import catalog
+
+    source = inspect.getsource(catalog)
+    lines = source.splitlines()
+    routing = set()
+    for node in ast.parse(source).body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        body = "\n".join(lines[node.lineno - 1:node.end_lineno])
+        if "_via_reference(" in body and node.name != "_via_reference":
+            routing.add(node.name.lstrip("_"))
+    assert routing == set(catalog.PROJECTING_TEMPLATES)
+    # No projecting template carries the projection's tags statically.
+    for name in catalog.PROJECTING_TEMPLATES:
+        spec = catalog.CATALOG[name]
+        assert not {"shape:TSL", "binding:non-peered"} & set(spec.features), name
+        assert "getitem_" not in spec.operators, name

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -2699,3 +2699,37 @@ def test_reference_source_parameter_is_validated():
     raw = {**closed, "id": "probe-closed", "parameters": {**closed["parameters"], "reference_source": "if_true"}}
     with pytest.raises(RecipeError, match="does not take a reference_source"):
         validate_recipe(Recipe.from_dict(raw))
+
+
+def test_setup_drops_extension_wheels_an_earlier_setup_installed(monkeypatch, tmp_path):
+    # A stale hgraph-persistence beside a rebuilt core referenced a symbol the
+    # new core no longer exported and every data-frame recipe failed to import
+    # (2026-09-07): setup uninstalls the first-party extensions it does not
+    # supply, and keeps the ones it does.
+    import tools.parity.environments as environments
+
+    commands = []
+    venv = tmp_path / "envs" / "candidate-test"
+    site = venv / "lib" / "python3.14" / "site-packages"
+    (site / "hgraph_persistence-0.0.0.dist-info").mkdir(parents=True)
+    (site / "hgraph-0.0.0.dist-info").mkdir()
+    python = venv / "bin" / "python"
+    core_wheel = tmp_path / "hgraph-0.0.0-cp312-abi3-test.whl"
+    core_wheel.write_bytes(b"core")
+    monkeypatch.setattr(environments, "PARITY_ROOT", tmp_path)
+    monkeypatch.setattr(environments, "_environment_key", lambda _interpreter: "test")
+    monkeypatch.setattr(environments, "_ensure_venv", lambda _path, _interpreter: python)
+    monkeypatch.setattr(environments, "_run", commands.append)
+    monkeypatch.setattr(environments, "environment_identity", lambda _interpreter: {})
+
+    environments.ensure_candidate_environment(candidate_wheel=core_wheel)
+    assert ["uv", "pip", "uninstall", "--python", str(python), "hgraph-persistence"] in commands
+
+    commands.clear()
+    (venv / ".wheel-fingerprint").unlink()
+    extra_wheel = tmp_path / "hgraph_persistence-0.0.0-cp312-abi3-test.whl"
+    extra_wheel.write_bytes(b"persistence")
+    environments.ensure_candidate_environment(
+        candidate_wheel=core_wheel, candidate_extra_wheels=(extra_wheel,)
+    )
+    assert not any(command[:3] == ["uv", "pip", "uninstall"] for command in commands)

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -2714,6 +2714,13 @@ def test_setup_drops_extension_wheels_an_earlier_setup_installed(monkeypatch, tm
     (site / "hgraph_persistence-0.0.0.dist-info").mkdir(parents=True)
     (site / "hgraph-0.0.0.dist-info").mkdir()
     python = venv / "bin" / "python"
+    python.parent.mkdir()
+    try:
+        # A venv's bin/python is a symlink to the base interpreter; the scan
+        # must look in the venv, never in the resolved base installation.
+        python.symlink_to(sys.executable)
+    except OSError:
+        python.write_bytes(b"")
     core_wheel = tmp_path / "hgraph-0.0.0-cp312-abi3-test.whl"
     core_wheel.write_bytes(b"core")
     monkeypatch.setattr(environments, "PARITY_ROOT", tmp_path)

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -127,9 +127,87 @@ def decoded_inputs(hg, recipe):
     }
 
 
-def _via_non_peered_ref(hg, value):
-    """Project a structural TSL child, producing a REF-transparent source."""
-    return hg.getitem_(hg.TSL.from_ts(value, value), 0)
+#: The REF-producing sources a recipe may route its inputs through: the
+#: ``reference_source`` parameter of every projecting template. The default
+#: is the fixed structural ``TSL`` projection the catalogue always used (so
+#: the committed corpus keeps its fingerprints); the others are the generic
+#: sources of the REF consumer sweep (``python/tests/test_ref_consumer_sweep.py``),
+#: so the differential campaign exercises the same producers under random ticks.
+REFERENCE_SOURCES = (
+    "tsl_projection",
+    "tsd_getitem",
+    "map_element",
+    "switch_branch",
+    "if_true",
+)
+DEFAULT_REFERENCE_SOURCE = "tsl_projection"
+
+#: The templates whose validators accept the ``reference_source`` parameter
+#: beside their own (every projecting template except the two whose parameter
+#: set is closed: ``polymorphic_tsd_key`` and ``value_consumer_reference``).
+REFERENCE_SOURCE_TEMPLATES = frozenset({
+    "adaptor_loopback",
+    "collection_size",
+    "context_switch",
+    "feedback_accumulate",
+    "mesh_key_set",
+    "nested_higher_order",
+    "operator_pipeline",
+    "service_adaptor_roundtrip",
+    "service_reference",
+    "service_request_reply",
+    "service_subscription",
+    "switch_arithmetic",
+    "tsd_key_set_pipeline",
+    "tsd_map_reduce",
+})
+
+_KEYED_NODES: dict[int, object] = {}
+
+
+def _keyed_node(hg):
+    """A compute node publishing its REF input under one TSD key (per runtime module)."""
+    node = _KEYED_NODES.get(id(hg))
+    if node is None:
+
+        @hg.compute_node
+        def _parity_keyed(ts: hg.REF[hg.TIME_SERIES_TYPE]) -> hg.TSD[str, hg.REF[hg.TIME_SERIES_TYPE]]:
+            return {"k": ts.value}
+
+        node = _KEYED_NODES[id(hg)] = _parity_keyed
+    return node
+
+
+def _via_reference(hg, value, recipe):
+    """Route ``value`` through the recipe's REF-producing source.
+
+    Every source publishes a reference the consumer must see through: a
+    structural ``TSL`` child projection, a ``TSD`` item lookup, a ``map_``
+    element, a ``switch_`` branch, or the ``true`` arm of ``if_``.
+    """
+    source = recipe.parameters.get("reference_source", DEFAULT_REFERENCE_SOURCE)
+    if source == "tsl_projection":
+        return hg.getitem_(hg.TSL.from_ts(value, value), 0)
+    if source == "tsd_getitem":
+        return _keyed_node(hg)(value)[hg.const("k")]
+    if source == "map_element":
+        return hg.map_(lambda v: v, _keyed_node(hg)(value))[hg.const("k")]
+    if source == "switch_branch":
+        return hg.switch_(hg.const("a"), {"a": lambda t: t}, value)
+    if source == "if_true":
+        return hg.if_(hg.const(True), value).true
+    raise RecipeError(f"unknown reference_source {source!r}")
+
+
+def _validate_reference_source(recipe):
+    source = recipe.parameters.get("reference_source")
+    if source is None:
+        return
+    if recipe.template not in REFERENCE_SOURCE_TEMPLATES:
+        raise RecipeError(f"{recipe.template} does not take a reference_source")
+    if source not in REFERENCE_SOURCES:
+        raise RecipeError(
+            f"reference_source must be one of {REFERENCE_SOURCES}, got {source!r}")
 
 
 def _expression_type(expression, input_types):
@@ -592,7 +670,7 @@ def _collection_size(hg, recipe):
     if shape == "tsl":
         @hg.graph
         def parity_graph(a: hg.TS[int], b: hg.TS[int]) -> hg.TS[int]:
-            result = hg.len_(hg.TSL.from_ts(_via_non_peered_ref(hg, a), b))
+            result = hg.len_(hg.TSL.from_ts(_via_reference(hg, a, recipe), b))
             return hg.dedup(result) if normalize_output else result
 
         return eval_node(parity_graph, inputs["a"], inputs["b"])
@@ -606,17 +684,17 @@ def _collection_size(hg, recipe):
     if operation == "len":
         @hg.graph
         def parity_graph(ts: annotation) -> hg.TS[int]:
-            result = hg.len_(_via_non_peered_ref(hg, ts))
+            result = hg.len_(_via_reference(hg, ts, recipe))
             return hg.dedup(result) if normalize_output else result
     elif operation == "is_empty":
         @hg.graph
         def parity_graph(ts: annotation) -> hg.TS[bool]:
-            result = hg.is_empty(_via_non_peered_ref(hg, ts))
+            result = hg.is_empty(_via_reference(hg, ts, recipe))
             return hg.dedup(result) if normalize_output else result
     else:
         @hg.graph
         def parity_graph(ts: annotation) -> hg.TS[bool]:
-            result = hg.contains_(_via_non_peered_ref(hg, ts), probe)
+            result = hg.contains_(_via_reference(hg, ts, recipe), probe)
             return hg.dedup(result) if normalize_output else result
 
     return eval_node(parity_graph, inputs["ts"])
@@ -958,7 +1036,7 @@ def _nested_higher_order(hg, recipe):
         def parity_graph(values: hg.TSD[str, hg.TS[int]], selector: hg.TS[str],
                          outer_selector: hg.TS[str]) -> hg.TS[int]:
             register()
-            values = _via_non_peered_ref(hg, values)
+            values = _via_reference(hg, values, recipe)
             result = hg.switch_(
                 outer_selector,
                 {
@@ -974,7 +1052,7 @@ def _nested_higher_order(hg, recipe):
         def parity_graph(values: hg.TSD[str, hg.TS[int]],
                          selector: hg.TS[str]) -> hg.TS[int]:
             register()
-            values = _via_non_peered_ref(hg, values)
+            values = _via_reference(hg, values, recipe)
             result = pipeline(values, selector)
             return hg.dedup(result) if normalize_output else result
     else:
@@ -982,7 +1060,7 @@ def _nested_higher_order(hg, recipe):
         def parity_graph(values: hg.TSD[str, hg.TS[int]],
                          selector: hg.TS[str]) -> hg.TSD[str, hg.TS[int]]:
             register()
-            values = _via_non_peered_ref(hg, values)
+            values = _via_reference(hg, values, recipe)
             return pipeline(values, selector)
 
     inputs = decoded_inputs(hg, recipe)
@@ -1077,7 +1155,7 @@ def _feedback_accumulate(hg, recipe):
 
     @hg.graph
     def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
-        value = _via_non_peered_ref(hg, value)
+        value = _via_reference(hg, value, recipe)
         state = hg.feedback(hg.TS[int], initial)
         total = value + hg.passive(state())
         state(total)
@@ -1094,9 +1172,9 @@ def _switch_arithmetic(hg, recipe):
     def parity_graph(
         selector: hg.TS[str], lhs: hg.TS[int], rhs: hg.TS[int]
     ) -> hg.TS[int]:
-        selector = _via_non_peered_ref(hg, selector)
-        lhs = _via_non_peered_ref(hg, lhs)
-        rhs = _via_non_peered_ref(hg, rhs)
+        selector = _via_reference(hg, selector, recipe)
+        lhs = _via_reference(hg, lhs, recipe)
+        rhs = _via_reference(hg, rhs, recipe)
         return hg.switch_(
             selector,
             {
@@ -1124,7 +1202,7 @@ def _tsd_map_reduce(hg, recipe):
 
     @hg.graph
     def parity_graph(values: hg.TSD[str, hg.TS[int]]) -> hg.TS[int]:
-        values = _via_non_peered_ref(hg, values)
+        values = _via_reference(hg, values, recipe)
         mapped = hg.map_(lambda value: value + increment, values)
         return hg.reduce(lambda lhs, rhs: lhs + rhs, mapped, zero)
 
@@ -1148,7 +1226,7 @@ def _service_reference(hg, recipe):
     @hg.graph
     def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
         hg.register_service(path, configured_value_impl)
-        value = _via_non_peered_ref(hg, value)
+        value = _via_reference(hg, value, recipe)
         return value + hg.passive(configured_value(path=path))
 
     inputs = decoded_inputs(hg, recipe)
@@ -1173,7 +1251,7 @@ def _service_request_reply(hg, recipe):
     @hg.graph
     def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
         hg.register_service(path, adjust_impl)
-        value = _via_non_peered_ref(hg, value)
+        value = _via_reference(hg, value, recipe)
         return adjust(path, value)
 
     inputs = decoded_inputs(hg, recipe)
@@ -1240,7 +1318,7 @@ def _service_subscription(hg, recipe):
         if dependency:
             hg.register_service(dependency_path, offset_impl)
         hg.register_service(path, quote_values)
-        symbol = _via_non_peered_ref(hg, symbol)
+        symbol = _via_reference(hg, symbol, recipe)
         return quote(path, symbol)
 
     inputs = decoded_inputs(hg, recipe)
@@ -1267,7 +1345,7 @@ def _adaptor_loopback(hg, recipe):
     @hg.graph
     def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
         hg.register_adaptor(path, loopback_impl)
-        value = _via_non_peered_ref(hg, value)
+        value = _via_reference(hg, value, recipe)
         return loopback(path, value)
 
     inputs = decoded_inputs(hg, recipe)
@@ -1291,7 +1369,7 @@ def _service_adaptor_roundtrip(hg, recipe):
     @hg.graph
     def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
         hg.register_adaptor(None, echo_impl)
-        value = _via_non_peered_ref(hg, value)
+        value = _via_reference(hg, value, recipe)
         return echo(value)
 
     inputs = decoded_inputs(hg, recipe)
@@ -1375,9 +1453,9 @@ def _context_switch(hg, recipe):
         value: hg.TS[int],
         offset: hg.TS[int],
     ) -> hg.TS[int]:
-        selector = _via_non_peered_ref(hg, selector)
-        value = _via_non_peered_ref(hg, value)
-        offset = _via_non_peered_ref(hg, offset)
+        selector = _via_reference(hg, selector, recipe)
+        value = _via_reference(hg, value, recipe)
+        offset = _via_reference(hg, offset, recipe)
         with offset:
             return hg.switch_(
                 selector,
@@ -1419,9 +1497,9 @@ def _operator_pipeline(hg, recipe):
         rhs: hg.TS[int],
         choose_minimum: hg.TS[bool],
     ) -> hg.TSB[OperatorResult]:
-        lhs = _via_non_peered_ref(hg, lhs)
-        rhs = _via_non_peered_ref(hg, rhs)
-        choose_minimum = _via_non_peered_ref(hg, choose_minimum)
+        lhs = _via_reference(hg, lhs, recipe)
+        rhs = _via_reference(hg, rhs, recipe)
+        choose_minimum = _via_reference(hg, choose_minimum, recipe)
         quotient = lhs // rhs
         remainder = lhs % rhs
         minimum = hg.min_(lhs, rhs)
@@ -1466,9 +1544,9 @@ def _value_consumer_reference(hg, recipe):
         rhs: hg.TS[int],
         choose_rhs: hg.TS[bool],
     ) -> hg.TS[int]:
-        lhs = _via_non_peered_ref(hg, lhs)
-        rhs = _via_non_peered_ref(hg, rhs)
-        choose_rhs = _via_non_peered_ref(hg, choose_rhs)
+        lhs = _via_reference(hg, lhs, recipe)
+        rhs = _via_reference(hg, rhs, recipe)
+        choose_rhs = _via_reference(hg, choose_rhs, recipe)
         selected = hg.if_then_else(choose_rhs, rhs, lhs)
         return hg.apply(double, selected)
 
@@ -1499,8 +1577,8 @@ def _tsd_key_set_pipeline(hg, recipe):
     def parity_graph(
         values: hg.TSD[int, hg.TS[int]], probe: hg.TS[int]
     ) -> hg.TSB[SetOperatorResult]:
-        values = _via_non_peered_ref(hg, values)
-        probe = _via_non_peered_ref(hg, probe)
+        values = _via_reference(hg, values, recipe)
+        probe = _via_reference(hg, probe, recipe)
         keys = hg.keys_(values)
         size = hg.len_(keys)
         if dedup_size:
@@ -1532,7 +1610,7 @@ def _mesh_key_set(hg, recipe):
     def parity_graph(
         values: hg.TSD[int, hg.TS[int]],
     ) -> hg.TSD[int, hg.TS[int]]:
-        values = _via_non_peered_ref(hg, values)
+        values = _via_reference(hg, values, recipe)
         return hg.mesh_(
             keyed_value,
             __keys__=hg.keys_(values),
@@ -2631,7 +2709,7 @@ def _polymorphic_tsd_key(hg, recipe):
         def parity_graph(
             entries: hg.TSD[Key, hg.TS[int]],
         ) -> hg.TSD[Key, hg.TS[int]]:
-            return hg.map_(double, _via_non_peered_ref(hg, entries))
+            return hg.map_(double, _via_reference(hg, entries, recipe))
 
         return eval_node(parity_graph, ticks)
 
@@ -3837,6 +3915,7 @@ def validate_recipe(recipe):
             f"{recipe.template} requires inputs {spec.required_inputs}, "
             f"got {tuple(recipe.inputs)}"
         )
+    _validate_reference_source(recipe)
     if recipe.template == "scalar_expression":
         _validate_scalar_expression(recipe)
     elif recipe.template == "scalar_operator_arguments":

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -162,6 +162,48 @@ REFERENCE_SOURCE_TEMPLATES = frozenset({
     "tsd_map_reduce",
 })
 
+#: The templates that route an input through ``_via_reference``: the recipe's
+#: source, not the template, owns the shape / binding / operator tags of that
+#: route (``reference_source_features``). Kept in step with the catalogue by
+#: ``test_projecting_templates_are_the_ones_that_route_through_a_reference``.
+PROJECTING_TEMPLATES = frozenset({
+    *REFERENCE_SOURCE_TEMPLATES,
+    "polymorphic_tsd_key",
+    "value_consumer_reference",
+})
+
+#: What each REF-producing source contributes to a recipe's coverage
+#: features: the shape it goes through, how the consumer binds to it, the
+#: operators it spells. Every source publishes a reference.
+REFERENCE_SOURCE_FEATURES = {
+    "tsl_projection": (
+        "reference:REF", "shape:TSL", "binding:non-peered", "operator:getitem_",
+    ),
+    "tsd_getitem": (
+        "reference:REF", "shape:TSD", "binding:peered", "operator:getitem_",
+    ),
+    "map_element": (
+        "reference:REF", "shape:TSD", "binding:peered", "topology:map",
+        "operator:map_", "operator:getitem_",
+    ),
+    "switch_branch": (
+        "reference:REF", "binding:peered", "topology:switch", "operator:switch_",
+    ),
+    "if_true": (
+        "reference:REF", "shape:TSB", "binding:peered", "operator:if_",
+    ),
+}
+assert set(REFERENCE_SOURCE_FEATURES) == set(REFERENCE_SOURCES)
+
+
+def reference_source_features(recipe) -> tuple[str, ...]:
+    """The coverage features the recipe's REF-producing source contributes."""
+    if recipe.template not in PROJECTING_TEMPLATES:
+        return ()
+    source = recipe.parameters.get("reference_source", DEFAULT_REFERENCE_SOURCE)
+    return REFERENCE_SOURCE_FEATURES.get(source, ())
+
+
 _KEYED_NODES: dict[int, object] = {}
 
 
@@ -200,12 +242,13 @@ def _via_reference(hg, value, recipe):
 
 
 def _validate_reference_source(recipe):
-    source = recipe.parameters.get("reference_source")
-    if source is None:
+    if "reference_source" not in recipe.parameters:
         return
+    source = recipe.parameters["reference_source"]
     if recipe.template not in REFERENCE_SOURCE_TEMPLATES:
         raise RecipeError(f"{recipe.template} does not take a reference_source")
-    if source not in REFERENCE_SOURCES:
+    # An explicit null is not an omission: the executor would read it back.
+    if not isinstance(source, str) or source not in REFERENCE_SOURCES:
         raise RecipeError(
             f"reference_source must be one of {REFERENCE_SOURCES}, got {source!r}")
 
@@ -3268,13 +3311,11 @@ CATALOG = {
         required_inputs=("value",),
         features=(
             "shape:TS",
-            "shape:TSL",
             "topology:feedback",
             "lifecycle:multi-cycle",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=("add_", "feedback", "getitem_", "passive"),
+        operators=("add_", "feedback", "passive"),
         execute=_feedback_accumulate,
     ),
     "switch_arithmetic": TemplateSpec(
@@ -3282,13 +3323,11 @@ CATALOG = {
         required_inputs=("selector", "lhs", "rhs"),
         features=(
             "shape:TS",
-            "shape:TSL",
             "topology:switch",
             "lifecycle:branch-rebind",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=("add_", "getitem_", "sub_", "switch_"),
+        operators=("add_", "sub_", "switch_"),
         execute=_switch_arithmetic,
     ),
     "tsd_map_reduce": TemplateSpec(
@@ -3296,13 +3335,11 @@ CATALOG = {
         required_inputs=("values",),
         features=(
             "shape:TSD",
-            "shape:TSL",
             "topology:map",
             "lifecycle:keyed",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=("add_", "getitem_", "map_", "reduce"),
+        operators=("add_", "map_", "reduce"),
         execute=_tsd_map_reduce,
     ),
     "service_reference": TemplateSpec(
@@ -3313,11 +3350,9 @@ CATALOG = {
             "framework:service",
             "service:reference",
             "configuration:path",
-            "shape:TSL",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=("add_", "const", "getitem_", "passive"),
+        operators=("add_", "const", "passive"),
         execute=_service_reference,
     ),
     "service_request_reply": TemplateSpec(
@@ -3330,11 +3365,9 @@ CATALOG = {
             "service:request-reply",
             "lifecycle:transport-delay",
             "configuration:path",
-            "shape:TSL",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=("add_", "getitem_", "map_"),
+        operators=("add_", "map_"),
         execute=_service_request_reply,
     ),
     "service_subscription": TemplateSpec(
@@ -3348,11 +3381,9 @@ CATALOG = {
             "service:subscription",
             "lifecycle:keyed",
             "lifecycle:transport-delay",
-            "shape:TSL",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=("getitem_", "len_", "map_", "mul_"),
+        operators=("len_", "map_", "mul_"),
         execute=_service_subscription,
     ),
     "adaptor_loopback": TemplateSpec(
@@ -3364,11 +3395,9 @@ CATALOG = {
             "adaptor:automatic",
             "adaptor:explicit-path",
             "configuration:path",
-            "shape:TSL",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=("getitem_", "mul_"),
+        operators=("mul_"),
         execute=_adaptor_loopback,
     ),
     "service_adaptor_roundtrip": TemplateSpec(
@@ -3382,11 +3411,9 @@ CATALOG = {
             "adaptor:multi-client",
             "implementation:path-injection",
             "lifecycle:same-cycle",
-            "shape:TSL",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=("add_", "getitem_", "map_"),
+        operators=("add_", "map_"),
         execute=_service_adaptor_roundtrip,
     ),
     "service_adaptor_parameterized_clients": TemplateSpec(
@@ -3417,11 +3444,9 @@ CATALOG = {
             "topology:context",
             "topology:switch",
             "lifecycle:branch-rebind",
-            "shape:TSL",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=("add_", "getitem_", "sub_", "switch_"),
+        operators=("add_", "sub_", "switch_"),
         execute=_context_switch,
     ),
     "operator_pipeline": TemplateSpec(
@@ -3434,28 +3459,9 @@ CATALOG = {
             "type:int",
             "type:bool",
             "type:str",
-            "shape:TSL",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=(
-            "add_",
-            "and_",
-            "combine",
-            "floordiv_",
-            "format_",
-            "getitem_",
-            "gt_",
-            "if_then_else",
-            "len_",
-            "max_",
-            "min_",
-            "mod_",
-            "modified",
-            "not_",
-            "or_",
-            "valid",
-        ),
+        operators=("add_", "and_", "combine", "floordiv_", "format_", "gt_", "if_then_else", "len_", "max_", "min_", "mod_", "modified", "not_", "or_", "valid"),
         execute=_operator_pipeline,
     ),
     "value_consumer_reference": TemplateSpec(
@@ -3466,7 +3472,6 @@ CATALOG = {
             "type:int",
             "type:bool",
             "reference:REF",
-            "binding:non-peered",
             "topology:operator-composition",
             "compatibility:release-0.5",
         ),
@@ -3480,7 +3485,6 @@ CATALOG = {
             "shape:TSS",
             "shape:TSD",
             "shape:TSB",
-            "shape:TSL",
             "topology:operator-composition",
             "topology:key-set-projection",
             "lifecycle:keyed",
@@ -3488,21 +3492,8 @@ CATALOG = {
             "type:bool",
             "type:float",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=(
-            "combine",
-            "contains_",
-            "dedup",
-            "getitem_",
-            "is_empty",
-            "keys_",
-            "len_",
-            "max_",
-            "mean",
-            "min_",
-            "sum_",
-        ),
+        operators=("combine", "contains_", "dedup", "is_empty", "keys_", "len_", "max_", "mean", "min_", "sum_"),
         execute=_tsd_key_set_pipeline,
         float_abs_tolerance=1e-12,
     ),
@@ -3512,15 +3503,13 @@ CATALOG = {
         features=(
             "shape:TSD",
             "shape:TSS",
-            "shape:TSL",
             "topology:mesh",
             "topology:key-set-projection",
             "lifecycle:keyed",
             "lifecycle:nested-graph",
             "reference:REF",
-            "binding:non-peered",
         ),
-        operators=("getitem_", "keys_", "mesh_", "mul_"),
+        operators=("keys_", "mesh_", "mul_"),
         execute=_mesh_key_set,
     ),
     "issue_38_nested_tsd_feedback": TemplateSpec(
@@ -3765,7 +3754,6 @@ CATALOG = {
             "topology:expression",
             "domain:collection-size",
             "reference:REF",
-            "binding:non-peered",
         ),
         operators=("len_", "is_empty", "contains_", "dedup"),
         execute=_collection_size,
@@ -3805,7 +3793,6 @@ CATALOG = {
             "shape:TSD",
             "type:int",
             "reference:REF",
-            "binding:non-peered",
             "lifecycle:multi-cycle",
         ),
         operators=(

--- a/tools/parity/cli.py
+++ b/tools/parity/cli.py
@@ -108,6 +108,7 @@ def _prepare(args) -> object:
         candidate_extra_wheels=tuple(
             Path(raw) for raw in (getattr(args, "candidate_extra_wheel", None) or ())
         ),
+        build_extensions=not getattr(args, "no_extensions", False),
     )
 
 
@@ -500,6 +501,13 @@ def _environment_arguments(parser) -> None:
     parser.add_argument("--reference-python")
     parser.add_argument("--candidate-python")
     parser.add_argument("--candidate-wheel")
+    parser.add_argument(
+        "--no-extensions",
+        action="store_true",
+        help="do not build the first-party extensions (hgraph-persistence) "
+        "against the candidate core; the frame-recording recipes then need "
+        "--candidate-extra-wheel",
+    )
     parser.add_argument(
         "--candidate-extra-wheel",
         action="append",

--- a/tools/parity/corpus/feedback-accumulate-via-if-true.json
+++ b/tools/parity/corpus/feedback-accumulate-via-if-true.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "id": "feedback-accumulate-via-if-true",
+  "description": "Feedback accumulation whose input arrives as the true arm of if_ (reference_source=if_true): the same twelve sparse cycles as feedback-accumulate-sparse.",
+  "template": "feedback_accumulate",
+  "inputs": {
+    "value": [
+      1,
+      2,
+      null,
+      3,
+      -1,
+      null,
+      5,
+      0,
+      null,
+      4,
+      -2,
+      1
+    ]
+  },
+  "parameters": {
+    "initial": 7,
+    "reference_source": "if_true"
+  },
+  "features": [
+    "lifecycle:multi-cycle",
+    "operator:feedback",
+    "reference-source:if_true",
+    "shape:TS",
+    "ticks:medium",
+    "topology:feedback",
+    "type:int"
+  ]
+}

--- a/tools/parity/corpus/feedback-accumulate-via-map-element.json
+++ b/tools/parity/corpus/feedback-accumulate-via-map-element.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "id": "feedback-accumulate-via-map-element",
+  "description": "Feedback accumulation whose input arrives as a map_ element (reference_source=map_element): the same twelve sparse cycles as feedback-accumulate-sparse.",
+  "template": "feedback_accumulate",
+  "inputs": {
+    "value": [
+      1,
+      2,
+      null,
+      3,
+      -1,
+      null,
+      5,
+      0,
+      null,
+      4,
+      -2,
+      1
+    ]
+  },
+  "parameters": {
+    "initial": 7,
+    "reference_source": "map_element"
+  },
+  "features": [
+    "lifecycle:multi-cycle",
+    "operator:feedback",
+    "reference-source:map_element",
+    "shape:TS",
+    "ticks:medium",
+    "topology:feedback",
+    "type:int"
+  ]
+}

--- a/tools/parity/corpus/feedback-accumulate-via-switch-branch.json
+++ b/tools/parity/corpus/feedback-accumulate-via-switch-branch.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "id": "feedback-accumulate-via-switch-branch",
+  "description": "Feedback accumulation whose input arrives as a switch_ branch (reference_source=switch_branch): the same twelve sparse cycles as feedback-accumulate-sparse.",
+  "template": "feedback_accumulate",
+  "inputs": {
+    "value": [
+      1,
+      2,
+      null,
+      3,
+      -1,
+      null,
+      5,
+      0,
+      null,
+      4,
+      -2,
+      1
+    ]
+  },
+  "parameters": {
+    "initial": 7,
+    "reference_source": "switch_branch"
+  },
+  "features": [
+    "lifecycle:multi-cycle",
+    "operator:feedback",
+    "reference-source:switch_branch",
+    "shape:TS",
+    "ticks:medium",
+    "topology:feedback",
+    "type:int"
+  ]
+}

--- a/tools/parity/corpus/feedback-accumulate-via-tsd-getitem.json
+++ b/tools/parity/corpus/feedback-accumulate-via-tsd-getitem.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "id": "feedback-accumulate-via-tsd-getitem",
+  "description": "Feedback accumulation whose input arrives as a TSD item lookup (reference_source=tsd_getitem): the same twelve sparse cycles as feedback-accumulate-sparse.",
+  "template": "feedback_accumulate",
+  "inputs": {
+    "value": [
+      1,
+      2,
+      null,
+      3,
+      -1,
+      null,
+      5,
+      0,
+      null,
+      4,
+      -2,
+      1
+    ]
+  },
+  "parameters": {
+    "initial": 7,
+    "reference_source": "tsd_getitem"
+  },
+  "features": [
+    "lifecycle:multi-cycle",
+    "operator:feedback",
+    "reference-source:tsd_getitem",
+    "shape:TS",
+    "ticks:medium",
+    "topology:feedback",
+    "type:int"
+  ]
+}

--- a/tools/parity/coverage.py
+++ b/tools/parity/coverage.py
@@ -7,7 +7,7 @@ import json
 from collections import Counter
 from typing import Any, Iterable
 
-from .catalog import CATALOG
+from .catalog import CATALOG, reference_source_features
 from .model import Recipe
 
 
@@ -15,6 +15,9 @@ def recipe_features(recipe: Recipe) -> tuple[str, ...]:
     spec = CATALOG[recipe.template]
     values = set(recipe.features) | set(spec.features)
     values.update(f"operator:{name}" for name in spec.operators)
+    # The route an input takes to the consumer belongs to the recipe's
+    # REF-producing source, not to the template.
+    values.update(reference_source_features(recipe))
     values.add(f"template:{recipe.template}")
     values.add(
         "ticks:short"

--- a/tools/parity/environments.py
+++ b/tools/parity/environments.py
@@ -133,6 +133,37 @@ def _built_candidate_wheel(source_fingerprint: str) -> Path:
     return wheels[0]
 
 
+#: The first-party extension distributions that may ride a candidate
+#: environment beside the core wheel (the workspace's native members).
+FIRST_PARTY_EXTENSIONS = frozenset({
+    "hgraph-analytics",
+    "hgraph-fabric",
+    "hgraph-kafka",
+    "hgraph-persistence",
+    "hgraph-web",
+})
+
+
+def _distribution_name(filename: str) -> str:
+    """The normalized distribution name of a wheel or ``.dist-info`` filename."""
+    return filename.split("-", 1)[0].replace("_", "-").lower()
+
+
+def _installed_first_party_extensions(python: Path) -> list[str]:
+    """First-party extension distributions installed in the venv ``python`` runs."""
+    root = Path(python).resolve().parent.parent
+    sites = [root / "Lib" / "site-packages", *sorted(root.glob("lib/python*/site-packages"))]
+    found = set()
+    for site in sites:
+        if not site.is_dir():
+            continue
+        for info in site.glob("*.dist-info"):
+            name = _distribution_name(info.name)
+            if name in FIRST_PARTY_EXTENSIONS:
+                found.add(name)
+    return sorted(found)
+
+
 def ensure_candidate_environment(
     *,
     interpreter: Path | str = sys.executable,
@@ -172,6 +203,18 @@ def ensure_candidate_environment(
                 str(candidate_wheel),
             ]
         )
+        # An extension wheel an earlier setup installed was built against that
+        # setup's core; beside a rebuilt core its native library references
+        # symbols the new core may no longer export (a stale hgraph-persistence
+        # made every data-frame recipe fail to import locally, 2026-09-07).
+        # Drop every first-party extension this setup does not supply.
+        supplied = {_distribution_name(wheel.name) for wheel in extra_wheels}
+        stale = [
+            name for name in _installed_first_party_extensions(python)
+            if name not in supplied
+        ]
+        if stale:
+            _run(["uv", "pip", "uninstall", "--python", str(python), *stale])
         if extra_wheels:
             # --no-deps: an unreleased candidate carries version 0.0.0, which
             # can never satisfy the extension's released hgraph requirement

--- a/tools/parity/environments.py
+++ b/tools/parity/environments.py
@@ -24,8 +24,8 @@ def _python_in(venv: Path) -> Path:
     return venv / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
 
 
-def _run(command: list[str], *, cwd: Path = REPO_ROOT) -> None:
-    completed = subprocess.run(command, cwd=cwd)
+def _run(command: list[str], *, cwd: Path = REPO_ROOT, env: dict[str, str] | None = None) -> None:
+    completed = subprocess.run(command, cwd=cwd, env=env)
     if completed.returncode:
         raise RuntimeError(
             f"parity environment command failed ({completed.returncode}): "
@@ -149,16 +149,19 @@ def _distribution_name(filename: str) -> str:
     return filename.split("-", 1)[0].replace("_", "-").lower()
 
 
-def _installed_first_party_extensions(python: Path) -> list[str]:
-    """First-party extension distributions installed in the venv ``python`` runs."""
+def _venv_site_packages(python: Path) -> list[Path]:
+    """The site-packages directories of the venv ``python`` runs."""
     # The venv's bin/python is a symlink to the base interpreter: resolving it
     # would inspect the base installation's site-packages, not the venv's.
     root = Path(python).absolute().parent.parent
     sites = [root / "Lib" / "site-packages", *sorted(root.glob("lib/python*/site-packages"))]
+    return [site for site in sites if site.is_dir()]
+
+
+def _installed_first_party_extensions(python: Path) -> list[str]:
+    """First-party extension distributions installed in the venv ``python`` runs."""
     found = set()
-    for site in sites:
-        if not site.is_dir():
-            continue
+    for site in _venv_site_packages(python):
         for info in site.glob("*.dist-info"):
             name = _distribution_name(info.name)
             if name in FIRST_PARTY_EXTENSIONS:
@@ -166,11 +169,92 @@ def _installed_first_party_extensions(python: Path) -> list[str]:
     return sorted(found)
 
 
+#: The extensions setup builds against the candidate core when the caller
+#: supplies no wheel for them: hgraph-persistence serves the frame-recording
+#: recipes (RFC 0025). The nightly supplies its own via --candidate-extra-wheel.
+BUILT_EXTENSIONS = ("persistence",)
+
+#: The build backend an extension needs beside the core SDK (the nightly's pins).
+EXTENSION_BUILD_TOOLS = ("scikit-build-core==1.0.3", "nanobind==2.13.0", "ninja==1.13.0")
+
+
+def extension_source_fingerprint(name: str) -> str:
+    """Hash the inputs that can change the ``extensions/<name>`` wheel."""
+    root = REPO_ROOT / "extensions" / name
+    digest = hashlib.sha256()
+    files: list[Path] = []
+    for entry in ("CMakeLists.txt", "pyproject.toml", "cmake", "include", "src", "python"):
+        path = root / entry
+        if path.is_file():
+            files.append(path)
+        elif path.is_dir():
+            files.extend(
+                child for child in path.rglob("*")
+                if child.is_file() and "__pycache__" not in child.parts
+            )
+    for path in sorted(set(files)):
+        digest.update(path.relative_to(root).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _built_extension_wheel(name: str, core_fingerprint: str, python: Path) -> Path:
+    """Build ``extensions/<name>`` against the candidate core installed in the
+    venv ``python`` runs; cached by the core and extension source fingerprints.
+
+    The same shape as the nightly: the core SDK is the installed wheel's
+    site-packages (``lib/cmake/hgraph`` lives there), the build runs without
+    isolation in that environment so the extension resolves the candidate
+    core, not a released one, and links pyarrow's Arrow from the same
+    environment it will run in.
+    """
+    root = REPO_ROOT / "extensions" / name
+    fingerprint = hashlib.sha256(
+        (core_fingerprint + extension_source_fingerprint(name)).encode()
+    ).hexdigest()
+    wheel_dir = PARITY_ROOT / "wheels" / fingerprint
+    wheels = sorted(wheel_dir.glob(f"hgraph_{name}-*.whl"))
+    if len(wheels) == 1:
+        return wheels[0]
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    _run(["uv", "pip", "install", "--python", str(python), *EXTENSION_BUILD_TOOLS])
+    sites = _venv_site_packages(python)
+    if not sites:
+        raise RuntimeError(f"no site-packages found for the candidate environment {python}")
+    env = {**os.environ, "CMAKE_PREFIX_PATH": str(sites[0]), "CMAKE_GENERATOR": "Ninja"}
+    _run(
+        [
+            "uv",
+            "build",
+            "--wheel",
+            "--no-build-isolation",
+            "--python",
+            str(python),
+            "--config-setting",
+            "cmake.build-type=Release",
+            "--out-dir",
+            str(wheel_dir),
+            "--no-build-logs",
+            str(root),
+        ],
+        env=env,
+    )
+    wheels = sorted(wheel_dir.glob(f"hgraph_{name}-*.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(
+            f"expected one hgraph-{name} wheel in {wheel_dir}, found {len(wheels)}"
+        )
+    return wheels[0]
+
+
 def ensure_candidate_environment(
     *,
     interpreter: Path | str = sys.executable,
     candidate_wheel: Path | None = None,
     candidate_extra_wheels: tuple[Path, ...] = (),
+    build_extensions: bool = True,
 ) -> tuple[Path, dict, str]:
     key = _environment_key(interpreter)
     venv = PARITY_ROOT / "envs" / f"candidate-{key}"
@@ -191,6 +275,18 @@ def ensure_candidate_environment(
         fingerprint = hashlib.sha256(
             (fingerprint + _sha256(wheel)).encode()
         ).hexdigest()
+    core_fingerprint = fingerprint
+    supplied = {_distribution_name(wheel.name) for wheel in extra_wheels}
+    # The extensions this setup builds itself: every built extension not
+    # supplied as a wheel, fingerprinted by its own source too.
+    to_build = tuple(
+        name for name in BUILT_EXTENSIONS
+        if build_extensions and f"hgraph-{name}" not in supplied
+    )
+    for name in to_build:
+        fingerprint = hashlib.sha256(
+            (fingerprint + extension_source_fingerprint(name)).encode()
+        ).hexdigest()
     marker = venv / ".wheel-fingerprint"
     installed = marker.read_text().strip() if marker.exists() else ""
     if installed != fingerprint:
@@ -205,18 +301,23 @@ def ensure_candidate_environment(
                 str(candidate_wheel),
             ]
         )
+        # Built against the core just installed (its SDK is in site-packages).
+        built_wheels = tuple(
+            _built_extension_wheel(name, core_fingerprint, python) for name in to_build
+        )
+        supplied |= {f"hgraph-{name}" for name in to_build}
         # An extension wheel an earlier setup installed was built against that
         # setup's core; beside a rebuilt core its native library references
         # symbols the new core may no longer export (a stale hgraph-persistence
         # made every data-frame recipe fail to import locally, 2026-09-07).
-        # Drop every first-party extension this setup does not supply.
-        supplied = {_distribution_name(wheel.name) for wheel in extra_wheels}
+        # Drop every first-party extension this setup does not supply or build.
         stale = [
             name for name in _installed_first_party_extensions(python)
             if name not in supplied
         ]
         if stale:
             _run(["uv", "pip", "uninstall", "--python", str(python), *stale])
+        extra_wheels = (*extra_wheels, *built_wheels)
         if extra_wheels:
             # --no-deps: an unreleased candidate carries version 0.0.0, which
             # can never satisfy the extension's released hgraph requirement
@@ -244,6 +345,7 @@ def prepare_environments(
     candidate_python: Path | None = None,
     candidate_wheel: Path | None = None,
     candidate_extra_wheels: tuple[Path, ...] = (),
+    build_extensions: bool = True,
 ) -> ParityEnvironments:
     if reference_python is None:
         reference_python, reference_identity = ensure_reference_environment(
@@ -258,6 +360,7 @@ def prepare_environments(
                 interpreter=interpreter,
                 candidate_wheel=candidate_wheel,
                 candidate_extra_wheels=candidate_extra_wheels,
+                build_extensions=build_extensions,
             )
         )
     else:

--- a/tools/parity/environments.py
+++ b/tools/parity/environments.py
@@ -151,7 +151,9 @@ def _distribution_name(filename: str) -> str:
 
 def _installed_first_party_extensions(python: Path) -> list[str]:
     """First-party extension distributions installed in the venv ``python`` runs."""
-    root = Path(python).resolve().parent.parent
+    # The venv's bin/python is a symlink to the base interpreter: resolving it
+    # would inspect the base installation's site-packages, not the venv's.
+    root = Path(python).absolute().parent.parent
     sites = [root / "Lib" / "site-packages", *sorted(root.glob("lib/python*/site-packages"))]
     found = set()
     for site in sites:

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -11,6 +11,7 @@ import json
 from typing import Any
 
 from .catalog import (CATALOG, _POLYMORPHIC_KEY_OPERATIONS,
+                      REFERENCE_SOURCE_TEMPLATES, REFERENCE_SOURCES,
                       validate_recipe)
 from .model import Recipe, SCHEMA_VERSION
 
@@ -1225,9 +1226,33 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
         ("nested_higher_order", nested_higher_order),
         ("nested_higher_order", nested_higher_order),
     )
-    selectable = discovery_weighted
+    # Every projecting template draws its REF-producing source too: the
+    # reference_source parameter (catalog.REFERENCE_SOURCES) routes each input
+    # through a TSL projection, a TSD item, a map_ element, a switch_ branch
+    # or an if_ arm, so the differential oracle sees every producer of the
+    # REF consumer sweep under random ticks.
+    reference_sources = st.sampled_from(REFERENCE_SOURCES)
+
+    def with_reference_source(name, factory):
+        if name not in REFERENCE_SOURCE_TEMPLATES:
+            return factory
+
+        @st.composite
+        def wrapped(draw):
+            payload = draw(factory())
+            source = draw(reference_sources)
+            payload["parameters"] = {**payload.get("parameters", {}),
+                                     "reference_source": source}
+            payload["features"] = [*payload.get("features", ()),
+                                   f"reference-source:{source}"]
+            return payload
+
+        return wrapped
+
+    selectable = tuple((name, with_reference_source(name, factory))
+                       for name, factory in discovery_weighted)
     if templates is None:
-        return st.one_of(*(factory() for _, factory in discovery_weighted))
+        return st.one_of(*(factory() for _, factory in selectable))
     # A restricted profile draws ONLY the allowed strategies — selecting at
     # the source, never filtering the union (a post-hoc filter discards most
     # draws and trips hypothesis's filter_too_much health check).

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -11,8 +11,8 @@ import json
 from typing import Any
 
 from .catalog import (CATALOG, _POLYMORPHIC_KEY_OPERATIONS,
-                      REFERENCE_SOURCE_TEMPLATES, REFERENCE_SOURCES,
-                      validate_recipe)
+                      REFERENCE_SOURCE_FEATURES, REFERENCE_SOURCE_TEMPLATES,
+                      REFERENCE_SOURCES, validate_recipe)
 from .model import Recipe, SCHEMA_VERSION
 
 
@@ -1243,8 +1243,11 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
             source = draw(reference_sources)
             payload["parameters"] = {**payload.get("parameters", {}),
                                      "reference_source": source}
+            # The route's own tags come from the source, never from the
+            # template's static features.
             payload["features"] = [*payload.get("features", ()),
-                                   f"reference-source:{source}"]
+                                   f"reference-source:{source}",
+                                   *REFERENCE_SOURCE_FEATURES[source]]
             return payload
 
         return wrapped


### PR DESCRIPTION
Closes the last open campaign gap from the 2026-09-04 retrospective ("REF axis is one TSL projection", `docs/source/developer_guide/testing.rst`): the differential campaign now varies *how the reference is produced*, not only the tick sequences behind it.

**What changes**

- `tools/parity/catalog.py`: `REFERENCE_SOURCES` = `tsl_projection` (the fixed structural TSL child the catalogue always used; the default, so every committed recipe keeps its fingerprint), `tsd_getitem`, `map_element`, `switch_branch`, `if_true`; `_via_reference(hg, value, recipe)` replaces `_via_non_peered_ref` at its thirty call sites and builds the source the recipe's `reference_source` parameter names. These are the generic producers of the REF consumer sweep (`python/tests/test_ref_consumer_sweep.py`), so the released-hgraph oracle now sees each of them under random ticks. `REFERENCE_SOURCE_TEMPLATES` lists the fourteen projecting templates whose parameter set is open; `_validate_reference_source` rejects unknown sources and the parameter on a closed template (`polymorphic_tsd_key`, `value_consumer_reference`).
- `tools/parity/generate.py`: a `with_reference_source` wrapper draws the source for every whitelisted strategy and tags the recipe `reference-source:<s>` for the coverage report.
- Coverage attributes the route's own tags to the source, not the template: `REFERENCE_SOURCE_FEATURES` (shape, binding, topology, operators per source) is applied by `recipe_features` and written into generated recipes; the projection's `shape:TSL` / `binding:non-peered` / `getitem_` tags leave the sixteen projecting templates' static specs, so a default-source recipe keeps exactly its former features while a recipe routed through `if_` counts `if_` and a `TSB`.
- Corpus: `feedback-accumulate-via-{tsd-getitem,map-element,switch-branch,if-true}` pin one deterministic case per new source (105 recipes validate).
- Tests: `test_parity_harness.py` gains the draw/feature test and the validation test (70 pass).
- Docs: `parity_testing.rst`, "Generation and Coverage".

**Local differential run** (`tools.parity setup` + replay + `campaign --profile pr --seed 4242`, reference hgraph 0.5.41): the five `feedback-accumulate-*` corpus recipes match on both runtimes; the 96 generated PR cases exercised all five sources (if_true 1, map_element 9, switch_branch 8, tsd_getitem 2, tsl_projection 5) and every generated case matched (173 matched, 23 known mismatches, 0 quarantined). Two existing corpus recipes (`coverage-frame-recording*`) failed only in my local candidate environment: a stale `hgraph-persistence` wheel from 31 August still referenced a core symbol (`value_type_for_wiring`) that the rebuilt core no longer exports, so `hgraph.adaptors.data_frame` failed to import. Last night's nightly campaign on `main`, which supplies a freshly built persistence wheel, has them matching.

**Environment hygiene and a local build of the persistence wheel** (follow-up commits c2976c55b, eb2097f71, 4fa8249f9):

- When `setup` reinstalls the core it uninstalls every first-party extension distribution present in the environment that the invocation neither supplies nor builds; the scan reads the venv's own site-packages through the unresolved `bin/python` path (resolving that symlink lands in the base interpreter's prefix).
- A core-only local environment could never match the frame-recording recipes, so `setup` now builds `extensions/persistence` against the candidate core it just installed (the nightly's shape: SDK = the installed core's site-packages, `uv build --no-build-isolation` in the candidate environment with the nightly's pinned build backend), cached under `.parity/wheels` by core and extension source fingerprints and folded into the environment marker. `--no-extensions` opts out; the nightly's `--candidate-extra-wheel` skips the build for that extension.
- Verified on the stale environment: the old wheel is removed, the new one is built and installed, and both `coverage-frame-recording*` recipes replay `ok` / `ok` with no difference. Tested; documented in the quick start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
