### PR TITLE
Add the RFC 0035 standalone python-user-nodes conversion test

### DIFF
--- a/.github/workflows/native-cpp.yml
+++ b/.github/workflows/native-cpp.yml
@@ -199,6 +199,72 @@ jobs:
       - name: Run core-only C++ tests
         run: ctest --test-dir build-core-only --output-on-failure --parallel 2
 
+  native-cpp-python-user-nodes:
+    # The python-user-nodes preset compiles the bridge into the runtime for a
+    # host that embeds its own interpreter and never imports the _hgraph
+    # module. No other leg configures it, and RFC 0035's acceptance
+    # criterion 3 (the standalone conversion test) is built only under it.
+    name: Native C++ / Linux python-user-nodes (embedded interpreter)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Enable shared compiler cache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: v0.15.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - name: Configure GCC 14
+        shell: bash
+        run: |
+          cc_path="$(command -v "gcc-$GCC_VERSION")"
+          cxx_path="$(command -v "g++-$GCC_VERSION")"
+          test "$("$cxx_path" -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
+          echo "CC=$cc_path" >> "$GITHUB_ENV"
+          echo "CXX=$cxx_path" >> "$GITHUB_ENV"
+      - name: Install native build dependencies
+        # nanobind is the bridge's binding library; numpy is the Python
+        # surface of the dense scalar-list export the standalone test checks.
+        run: >-
+          python -m pip install --upgrade --only-binary=:all:
+          "cmake==4.4.2" "ninja==1.13.0" "pyarrow==25.0.0"
+          "nanobind==2.13.0" "numpy==2.5.2"
+      - name: Expose Arrow runtime libraries
+        shell: python
+        run: |
+          import os
+          from pathlib import Path
+          import pyarrow
+
+          with open(os.environ["GITHUB_PATH"], "a", encoding="utf-8") as path_file:
+              path_file.write(str(Path(pyarrow.__file__).resolve().parent) + "\n")
+      - name: Configure python-user-nodes C++ tests
+        shell: bash
+        run: >-
+          cmake -S . -B build-python-user-nodes -GNinja
+          -DCMAKE_BUILD_TYPE=Release
+          -DBUILD_TESTING=ON
+          -DHGRAPH_BUILD_PYTHON_BINDINGS=OFF
+          -DHGRAPH_ENABLE_PYTHON_USER_NODES=ON
+          -DHGRAPH_ENABLE_IDE_PYTHON_HEADER_HINTS=OFF
+          -DHGRAPH_USE_PYARROW_ARROW=ON
+          -DHGRAPH_FETCH_SIMDJSON=ON
+          -DHGRAPH_FETCH_DATE=ON
+          -DHGRAPH_WARNINGS_AS_ERRORS=ON
+          -DHGRAPH_BUILD_KAFKA_EXTENSION=OFF
+          -DHGRAPH_BUILD_ANALYTICS_EXTENSION=OFF
+          -DHGRAPH_BUILD_WEB_EXTENSION=OFF
+          -DHGRAPH_BUILD_PERSISTENCE_EXTENSION=OFF
+          -DHGRAPH_BUILD_FABRIC_EXTENSION=OFF
+          -DPython_EXECUTABLE="$(python -c 'import sys; print(sys.executable)')"
+      - name: Build python-user-nodes C++ tests
+        run: cmake --build build-python-user-nodes --parallel 2
+      - name: Run python-user-nodes C++ tests
+        run: ctest --test-dir build-python-user-nodes --output-on-failure --parallel 2
+
   native-shared-install:
     name: Native C++ / Linux shared install with IPO
     runs-on: ubuntu-24.04

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -530,8 +530,12 @@ Value and reference crossings
   ``struct _object``: borrowed in, one new reference out) and hold
   Python-free *forwarders* from ``include/hgraph/types/python_ops.h``. A
   forwarder reads the provider the bridge registered
-  (``python_bridge::register_python_ops``, at unit load and again from the
-  module initializer) when the slot is called and passes the arguments to
+  (``python_bridge::register_python_ops``: at load from ``conversion.cpp``,
+  the unit every conversion entry point lives in, so a static archive that
+  links any entry links the registration; again from the module
+  initializer; and from ``attach_embedded_interpreter`` in a host that
+  embeds its own interpreter, *Python Integration > Standalone
+  conversions*) when the slot is called and passes the arguments to
   its family's entry unchanged; scalars resolve ``typeid(T)`` through
   ``scalars.conversion_for`` on their first conversion and cache the hit
   (the bridge keys that registry by the mangled type name, because the

--- a/docs/source/developer_guide/python_integration.rst
+++ b/docs/source/developer_guide/python_integration.rst
@@ -132,6 +132,51 @@ implementation registering as an ordinary candidate (see *Operators > The
 Python implementation path*), built only under
 ``HGRAPH_ENABLE_PYTHON_USER_NODES``.
 
+Standalone conversions
+----------------------
+
+The ``python-user-nodes`` preset (``-DHGRAPH_ENABLE_PYTHON_USER_NODES=ON``
+with the bindings off) compiles the bridge's conversion units into the
+runtime and links the embedding library, so a native program that embeds
+its own interpreter converts between ``Value`` / TSData and Python objects
+without the ``_hgraph`` module (RFC 0035, acceptance criterion 3). The
+host's contract:
+
+1. Initialise the interpreter (``Py_InitializeFromConfig`` or
+   ``Py_Initialize``) with the third-party modules the bridge's Python
+   surface uses reachable on ``sys.path``: ``numpy`` for the dense
+   scalar-list export, which is a ``numpy.ndarray`` exactly as it is from
+   the module.
+2. Call ``python_bridge::attach_embedded_interpreter()``
+   (``include/hgraph/python/bridge_state.h``) on the thread that holds the
+   GIL. It creates nanobind's per-process state, which a module
+   initializer would otherwise create and without which any conversion
+   that reaches nanobind's instance machinery dereferences null, and it
+   registers the provider table; repeating the call is harmless.
+3. Convert through the free functions of
+   ``include/hgraph/python/conversion.h``.
+
+The provider table is also registered at load, by ``conversion.cpp``: a
+static archive keeps only the units something names, so the registration
+sits with the entry points a host must call rather than with the table
+(``python_ops.cpp``), which nothing outside the bridge names. What the
+*module* supplies on top is Python-side identity: the CompoundScalar
+classes a TSB reads back as (a standalone host gets the plain field
+mapping), the stdlib enums' ``Enum`` classes (``DivideByZero``,
+``CmpResult``, ``ToTableMode``: a standalone host has no conversion for
+them and the forwarder throws the named missing-conversion error) and the
+``REMOVE`` sentinels.
+
+``tests/cpp/test_python_user_nodes_conversion.cpp`` is that host: an
+isolated interpreter (no environment, no ``site``; the configured
+interpreter's site-packages appended for numpy),
+``attach_embedded_interpreter``, then a scalar, a compact list, a TSB and
+a TSD through the table, each case ending with the check that neither
+``hgraph`` nor ``_hgraph`` was imported. It is compiled only under the
+preset, as the ``hgraph_python_test_objects`` domain of
+``hgraph_unit_tests`` (``tests/cpp/CMakeLists.txt``), and the "Linux
+python-user-nodes" job of ``native-cpp.yml`` builds and runs it.
+
 The Bridge (Slice 1 — Landed)
 -----------------------------
 

--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -17,6 +17,16 @@ C++ tests live under ``tests/cpp`` (add new files to
 - node lifecycle behavior,
 - graph execution behavior.
 
+The Catch2 suite is assembled from per-domain object libraries
+(``HGRAPH_TEST_OBJECT_LIBS`` in ``tests/cpp/CMakeLists.txt``): every domain
+is linked into ``hgraph_unit_tests`` and also built as its own
+``hgraph_unit_tests_<domain>`` executable. One domain is conditional:
+``hgraph_python_test_objects`` (``test_python_user_nodes_conversion.cpp``)
+exists only under ``HGRAPH_ENABLE_PYTHON_USER_NODES``, embeds an
+interpreter and converts through the bridge with no ``_hgraph`` module
+(*Python Integration > Standalone conversions*); the "Linux
+python-user-nodes" job of ``native-cpp.yml`` is the leg that builds it.
+
 The Catch2 unit-test executable links ``registry_test_listener.cpp``. The
 listener resets all process-wide registries/factories before and after each
 test case. Because ``reset()`` clears the singleton's normal auto-seeded state,

--- a/docs/source/rfc/rfc_0035_python_free_type_layer.rst
+++ b/docs/source/rfc/rfc_0035_python_free_type_layer.rst
@@ -304,7 +304,8 @@ Rules:
    conversion registered later is found by the next call). The per-tick
    cost is one predictable indirect call more than today, on the Python
    path only.
-2. **Registered whenever, before the first conversion.** The bridge unit
+2. **Registered whenever, before the first conversion.** The bridge's
+   entry unit (``conversion.cpp``, the one every conversion links)
    registers the table from a namespace-scope initializer, so a standalone
    ``python-user-nodes`` build has it without the ``_hgraph`` module; the
    module initializer registers it again, idempotently. Because slots
@@ -437,8 +438,8 @@ which registers ``nb::cast``-based slots for castable ``T`` and
 trait-based slots otherwise. ``register_native_scalar_type<T>`` calls it
 before ``register_scalar<T>``.
 
-Bridge units (``src/hgraph/python/impl/``): ``python_ops.cpp`` (the table,
-its load-time registration, the wrappers), ``scalar_conversions.cpp``,
+Bridge units (``src/hgraph/python/impl/``): ``python_ops.cpp`` (the table
+and the wrappers; the load-time registration is ``conversion.cpp``'s), ``scalar_conversions.cpp``,
 ``enum_conversions.cpp``, ``container_conversions.cpp`` (compact + mutable +
 proxies), ``plan_conversions.cpp`` (composite, array, owned/shared entries,
 closed bundle, polymorphic), ``ts_data_conversions.cpp`` (the five TS data
@@ -576,10 +577,12 @@ Unresolved questions
 --------------------
 
 * Where the stdlib enums' conversions (``DivideByZero``, ``CmpResult``,
-  ``ToTableMode``) are registered: by the module, as today's slots are, or
-  by a guarded stdlib unit at load so a standalone ``python-user-nodes``
-  program has them without the module. The first implementation PR keeps
-  the module; the standalone test in the acceptance criteria decides.
+  ``ToTableMode``) are registered. Resolved by the standalone test
+  (2026-09-07): with the module. Their Python values are the ``hgraph``
+  package's ``Enum`` classes, which a standalone program does not have, so
+  a guarded stdlib unit would have nothing to convert to; the standalone
+  table answers the named missing-conversion error for them
+  (``test_python_user_nodes_conversion.cpp``).
 * Whether ``PythonTSDataOps`` should fold into ``PythonOps::TSData`` as
   entries rather than remain a separate struct the entries point to. Kept
   separate here so the seven tables stay addressable as units.
@@ -636,6 +639,24 @@ Five PRs, each green on the full gate, each lowering the ratchet:
 
 Implementation status
 ---------------------
+
+Acceptance criterion 3's standalone test landed on 2026-09-07
+(``tests/cpp/test_python_user_nodes_conversion.cpp``, the
+``hgraph_python_test_objects`` domain of the Catch2 suite, built by the
+"Linux python-user-nodes" job of ``native-cpp.yml``; no earlier leg
+configured the preset). Writing it found two gaps in the standalone story,
+both fixed in the same change. A static archive keeps only the units
+something names, so ``python_ops.cpp``'s load-time registration never
+linked into a standalone program and the table was never registered: the
+initializer moved to ``conversion.cpp``, the unit every entry point lives
+in. And nanobind's per-process state is created by a module initializer,
+which a standalone program has none of, so the dense list export (an
+``ndarray``) dereferenced null: ``python_bridge::attach_embedded_interpreter``
+(``bridge_state.h``) is the host's one call after ``Py_Initialize``
+(*Python Integration > Standalone conversions*). The test embeds an
+isolated interpreter, attaches, converts a scalar, a compact list (both
+the ``ndarray`` and the element-wise export), a TSB and a TSD, and checks
+after each that neither ``hgraph`` nor ``_hgraph`` was imported.
 
 Accepted (2026-09-06). PR 5 (``hardening/python-ops-ts-input``) moves
 the last family: the non-peered TSB / TSL input bindings' endpoint-shape

--- a/include/hgraph/python/bridge_state.h
+++ b/include/hgraph/python/bridge_state.h
@@ -147,6 +147,19 @@ struct HGRAPH_LOCAL NB_EXPORT_SHARED PyBundleClassInfo {
 HGRAPH_EXPORT void clear_python_type_registry() noexcept;
 
 /**
+ * Attach the bridge to an interpreter the host initialised itself: a
+ * standalone ``python-user-nodes`` program, where no ``_hgraph`` module is
+ * ever imported. It does for the process what a nanobind module's
+ * initializer does (creates nanobind's per-process state, without which
+ * any conversion that reaches nanobind's instance machinery -- the dense
+ * list export's ``ndarray``, for one -- dereferences null) and registers
+ * the provider table. Call once after ``Py_Initialize`` on the thread that
+ * holds the GIL; repeating it is harmless. A process that imports the
+ * module needs no call: its initializer does both.
+ */
+HGRAPH_EXPORT void attach_embedded_interpreter();
+
+/**
  * The DSL's annotation-to-schema producer (``hgraph._types._value_type``),
  * registered at import through ``_hgraph.set_python_annotation_schema_resolver``
  * (RFC 0033, PR E). Schema-free conversion asks it for the schema of a

--- a/src/hgraph/python/bridge_state.cpp
+++ b/src/hgraph/python/bridge_state.cpp
@@ -691,6 +691,17 @@ void clear_python_type_registry() noexcept {
   python_type_registry().clear();
 }
 
+void attach_embedded_interpreter() {
+  if (Py_IsInitialized() == 0) {
+    throw std::logic_error(
+        "attach_embedded_interpreter requires an initialised interpreter");
+  }
+  // Exactly what NB_MODULE's exec slot runs before a module body: the
+  // module argument is unused, and a repeat only re-references the state.
+  nb::detail::nb_module_exec(NB_DOMAIN_STR, nullptr);
+  register_python_ops();
+}
+
 std::unordered_map<const void *, const void *> &tsb_compound_value_registry() {
   static auto *registry = new std::unordered_map<const void *, const void *>{};
   return *registry;

--- a/src/hgraph/python/impl/conversion.cpp
+++ b/src/hgraph/python/impl/conversion.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/python/conversion.h>
+#include <hgraph/python/native_scalar_registration.h>
 
 #include <hgraph/types/metadata/value_type_meta_data.h>
 #include <hgraph/types/time_series/ts_data/ops.h>
@@ -8,6 +9,22 @@
 
 namespace hgraph::python_bridge
 {
+    namespace
+    {
+        // Every conversion entry point is in this unit, so linking any of
+        // them links this initializer and, through it, the provider table
+        // (``python_ops.cpp``). That is what makes the conversions active in
+        // a standalone ``python-user-nodes`` build, where no module
+        // initializer runs and a static archive keeps only the units
+        // something names (RFC 0035, "Registered whenever, before the first
+        // conversion"; ``tests/cpp/test_python_user_nodes_conversion.cpp``).
+        // The module's explicit registration is idempotent.
+        [[maybe_unused]] const bool python_ops_registered_at_load = [] {
+            register_python_ops();
+            return true;
+        }();
+    }  // namespace
+
     nb::object take(PyNewRef result)
     {
         if (result.ptr == nullptr)

--- a/src/hgraph/python/impl/python_ops.cpp
+++ b/src/hgraph/python/impl/python_ops.cpp
@@ -21,10 +21,10 @@
 /**
  * The bridge's ``PythonOps`` table (RFC 0035): the scalar registry the
  * scalar forwarders resolve through, the enum and ``Any`` entries, and the
- * registration that makes the table active. This unit is compiled in
- * exactly when Python user nodes are enabled, with or without the
- * ``_hgraph`` module, so it registers at load; the module initializer
- * calls ``register_python_ops`` again, idempotently.
+ * registration that makes the table active. The load-time registration
+ * itself lives in ``conversion.cpp``, the unit every conversion entry point
+ * links (a static archive drops this unit when nothing names it); the
+ * module initializer calls ``register_python_ops`` again, idempotently.
  */
 namespace hgraph::python_bridge
 {
@@ -241,16 +241,4 @@ namespace hgraph::python_bridge
         static EnumFromPythonFn slot = nullptr;
         return slot;
     }
-
-    namespace
-    {
-        // Linking this unit is what makes the conversions active (the
-        // ``python-user-nodes`` preset embeds the bridge without the module's
-        // initializer), so it registers itself at load; the module's explicit
-        // registration is idempotent.
-        [[maybe_unused]] const bool python_ops_registered_at_load = [] {
-            register_python_ops();
-            return true;
-        }();
-    }  // namespace
 }  // namespace hgraph::python_bridge

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -320,6 +320,35 @@ set(HGRAPH_TEST_OBJECT_LIBS
     hgraph_record_test_objects
 )
 
+if(HGRAPH_ENABLE_PYTHON_USER_NODES)
+    # RFC 0035 acceptance criterion 3: the standalone ``python-user-nodes``
+    # preset converts through the table the bridge registers at load, with
+    # no ``_hgraph`` module. The test embeds an isolated interpreter and
+    # needs the home of the interpreter the build links (its stdlib).
+    execute_process(
+        COMMAND "${Python_EXECUTABLE}" -c "import sys; print(sys.base_prefix)"
+        OUTPUT_VARIABLE _hgraph_test_python_home
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    file(TO_CMAKE_PATH "${_hgraph_test_python_home}" _hgraph_test_python_home)
+    execute_process(
+        COMMAND "${Python_EXECUTABLE}" -c "import sysconfig; print(sysconfig.get_paths()['purelib'])"
+        OUTPUT_VARIABLE _hgraph_test_python_site
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    file(TO_CMAKE_PATH "${_hgraph_test_python_site}" _hgraph_test_python_site)
+    hgraph_add_test_objects(hgraph_python_test_objects
+        test_python_user_nodes_conversion.cpp
+    )
+    target_compile_definitions(hgraph_python_test_objects PRIVATE
+        HGRAPH_TEST_PYTHON_HOME="${_hgraph_test_python_home}"
+        HGRAPH_TEST_PYTHON_SITE="${_hgraph_test_python_site}"
+    )
+    list(APPEND HGRAPH_TEST_OBJECT_LIBS hgraph_python_test_objects)
+endif()
+
 function(hgraph_add_test_executable target_name)
     add_executable(${target_name}
         $<TARGET_OBJECTS:hgraph_test_listener_objects>
@@ -334,13 +363,11 @@ function(hgraph_add_test_executable target_name)
     hgraph_enable_private_pch(${target_name})
 endfunction()
 
-hgraph_add_test_executable(hgraph_unit_tests
-    $<TARGET_OBJECTS:hgraph_runtime_test_objects>
-    $<TARGET_OBJECTS:hgraph_wiring_test_objects>
-    $<TARGET_OBJECTS:hgraph_stdlib_test_objects>
-    $<TARGET_OBJECTS:hgraph_value_test_objects>
-    $<TARGET_OBJECTS:hgraph_record_test_objects>
-)
+set(_hgraph_unit_test_objects)
+foreach(_hgraph_test_domain IN LISTS HGRAPH_TEST_OBJECT_LIBS)
+    list(APPEND _hgraph_unit_test_objects $<TARGET_OBJECTS:${_hgraph_test_domain}>)
+endforeach()
+hgraph_add_test_executable(hgraph_unit_tests ${_hgraph_unit_test_objects})
 
 foreach(_hgraph_test_domain IN LISTS HGRAPH_TEST_OBJECT_LIBS)
     string(REPLACE "hgraph_" "" _hgraph_domain_name "${_hgraph_test_domain}")

--- a/tests/cpp/test_python_user_nodes_conversion.cpp
+++ b/tests/cpp/test_python_user_nodes_conversion.cpp
@@ -1,0 +1,290 @@
+/**
+ * RFC 0035 acceptance criterion 3: a standalone ``python-user-nodes`` build
+ * (``HGRAPH_ENABLE_PYTHON_USER_NODES=ON``, ``HGRAPH_BUILD_PYTHON_BINDINGS=OFF``)
+ * converts a scalar, a compact list, a TSB and a TSD through the provider
+ * table the bridge unit registers at load, with no ``_hgraph`` module.
+ *
+ * The executable embeds its own interpreter the way a standalone host
+ * does: an isolated configuration (no environment, no ``site``), the
+ * configured interpreter's site-packages appended for the third-party
+ * modules the bridge's Python surface uses (``numpy`` for the dense list
+ * export), then ``attach_embedded_interpreter``. Every case ends by
+ * checking that neither ``hgraph`` nor ``_hgraph`` was imported. This file
+ * is compiled only under the preset (``tests/cpp/CMakeLists.txt``); see
+ * ``python_integration.rst``, "Standalone conversions".
+ */
+#include <hgraph/lib/std/operators/arithmetic.h>
+#include <hgraph/lib/std/std_operators.h>
+#include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/primitive_types.h>
+#include <hgraph/types/python_ops.h>
+#include <hgraph/types/time_series/ts_output.h>
+#include <hgraph/types/value/value.h>
+#include <hgraph/util/date_time.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+
+#include <chrono>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+    namespace nb = nanobind;
+    using hgraph::DateTime;
+    using hgraph::Int;
+    using hgraph::MIN_ST;
+    using hgraph::Str;
+    using hgraph::TSOutput;
+    using hgraph::TypeRegistry;
+    using hgraph::Value;
+    using hgraph::ValuePlanFactory;
+    using hgraph::python_bridge::delta_value_to_python;
+    using hgraph::python_bridge::from_python;
+    using hgraph::python_bridge::to_python;
+    using hgraph::python_bridge::value_to_python;
+
+    /**
+     * The process's one embedded interpreter. Isolated: no environment
+     * variables, no ``site``, the stdlib located through the home the build
+     * configured from the interpreter it links; the configured interpreter's
+     * site-packages appended afterwards. Never finalised -- the runtime's
+     * registries outlive every test case.
+     */
+    void ensure_interpreter()
+    {
+        static const bool started = [] {
+            if (Py_IsInitialized() == 0)
+            {
+                PyConfig config;
+                PyConfig_InitIsolatedConfig(&config);
+                config.site_import             = 0;
+                config.install_signal_handlers = 0;
+#ifdef HGRAPH_TEST_PYTHON_HOME
+                PyConfig_SetBytesString(&config, &config.home, HGRAPH_TEST_PYTHON_HOME);
+#endif
+                const PyStatus status = Py_InitializeFromConfig(&config);
+                PyConfig_Clear(&config);
+                if (PyStatus_Exception(status) != 0)
+                {
+                    throw std::runtime_error(std::string{"the embedded interpreter failed to start: "} +
+                                             (status.err_msg != nullptr ? status.err_msg : "unknown error"));
+                }
+#ifdef HGRAPH_TEST_PYTHON_SITE
+                nb::module_::import_("sys").attr("path").attr("append")(HGRAPH_TEST_PYTHON_SITE);
+#endif
+            }
+            hgraph::python_bridge::attach_embedded_interpreter();
+            return true;
+        }();
+        REQUIRE(started);
+    }
+
+    bool module_loaded(const char *name) { return PyDict_GetItemString(PyImport_GetModuleDict(), name) != nullptr; }
+
+    bool importable(const char *name)
+    {
+        const nb::object module = nb::steal(PyImport_ImportModule(name));
+        if (module.is_valid()) { return true; }
+        PyErr_Clear();
+        return false;
+    }
+
+    DateTime tick(int count) { return MIN_ST + std::chrono::microseconds{count}; }
+
+    /** ``key in container`` for a dict, set or frozenset. */
+    bool contains(nb::handle container, nb::handle key)
+    {
+        const int result = PySequence_Contains(container.ptr(), key.ptr());
+        if (result < 0) { throw nb::python_error(); }
+        return result == 1;
+    }
+
+    const hgraph::ValueTypeMetaData *int_meta() { return TypeRegistry::instance().register_scalar<Int>("int"); }
+    const hgraph::ValueTypeMetaData *str_meta() { return TypeRegistry::instance().register_scalar<Str>("str"); }
+}  // namespace
+
+TEST_CASE("python-user-nodes: the provider is registered at load and the process has no _hgraph module",
+          "[python_user_nodes][rfc0035]")
+{
+    ensure_interpreter();
+
+    // Linking the bridge unit registered the table (RFC 0035, "Registered
+    // whenever, before the first conversion"); no module initializer ran.
+    REQUIRE(hgraph::python_ops() != nullptr);
+    CHECK_FALSE(module_loaded("_hgraph"));
+    CHECK_FALSE(module_loaded("hgraph"));
+    // Attaching again is harmless (a host cannot know whether it is first).
+    CHECK_NOTHROW(hgraph::python_bridge::attach_embedded_interpreter());
+    CHECK_FALSE(module_loaded("_hgraph"));
+    // The bridge's Python surface for a dense scalar list is a numpy array
+    // (same surface as the module); the host supplies numpy.
+    REQUIRE(importable("numpy"));
+}
+
+TEST_CASE("python-user-nodes: a scalar round-trips through the registered table",
+          "[python_user_nodes][rfc0035]")
+{
+    ensure_interpreter();
+
+    Value count{ValuePlanFactory::instance().type_for(int_meta())};
+    from_python(count, nb::int_{42});
+    CHECK(nb::cast<std::int64_t>(to_python(count)) == 42);
+
+    Value label{ValuePlanFactory::instance().type_for(str_meta())};
+    from_python(label, nb::str{"forty-two"});
+    CHECK(nb::cast<std::string>(to_python(label)) == "forty-two");
+
+    // ``None`` resets: an empty value reads back as ``None``.
+    from_python(count, nb::none());
+    CHECK(to_python(count).is_none());
+
+    CHECK_FALSE(module_loaded("_hgraph"));
+}
+
+TEST_CASE("python-user-nodes: a compact list round-trips through the registered table",
+          "[python_user_nodes][rfc0035]")
+{
+    ensure_interpreter();
+
+    Value numbers{ValuePlanFactory::instance().type_for(TypeRegistry::instance().list(int_meta()))};
+    nb::list source;
+    source.append(1);
+    source.append(2);
+    source.append(3);
+    from_python(numbers, source);
+
+    // Dense, buffer-compatible elements export as the array the module
+    // exports (nanobind's ndarray: the path that needs the attached state).
+    const nb::object exported = to_python(numbers);
+    CHECK(nb::cast<std::string>(exported.type().attr("__module__")) == "numpy");
+    CHECK(nb::cast<std::string>(exported.type().attr("__name__")) == "ndarray");
+    REQUIRE(nb::len(exported) == 3);
+    CHECK(nb::cast<std::int64_t>(exported[0]) == 1);
+    CHECK(nb::cast<std::int64_t>(exported[2]) == 3);
+
+    // Elements without a buffer form export element by element.
+    Value labels{ValuePlanFactory::instance().type_for(TypeRegistry::instance().list(str_meta()))};
+    nb::list words;
+    words.append("one");
+    words.append("two");
+    from_python(labels, words);
+    const nb::object exported_words = to_python(labels);
+    REQUIRE(nb::isinstance<nb::list>(exported_words));
+    REQUIRE(nb::len(exported_words) == 2);
+    CHECK(nb::cast<std::string>(exported_words[1]) == "two");
+
+    CHECK_FALSE(module_loaded("_hgraph"));
+}
+
+TEST_CASE("python-user-nodes: a TSB output converts through the registered table",
+          "[python_user_nodes][rfc0035]")
+{
+    ensure_interpreter();
+    auto       &registry = TypeRegistry::instance();
+    const auto *bundle =
+        registry.tsb("PythonUserNodesProbe", {{"count", registry.ts(int_meta())}, {"label", registry.ts(str_meta())}});
+    TSOutput output{*bundle};
+
+    const DateTime t1 = tick(1);
+    nb::dict       first;
+    first["count"] = 3;
+    first["label"] = "three";
+    {
+        auto mutation = output.view(t1).begin_mutation(t1);
+        REQUIRE(from_python(mutation, first));
+    }
+    // No CompoundScalar class is registered for the schema (that is the
+    // module's doing), so the value is the plain field mapping.
+    nb::object value = value_to_python(output.view(t1).data_view());
+    REQUIRE(nb::isinstance<nb::dict>(value));
+    CHECK(nb::cast<std::int64_t>(value["count"]) == 3);
+    CHECK(nb::cast<std::string>(value["label"]) == "three");
+
+    const DateTime t2 = tick(2);
+    nb::dict       partial;
+    partial["count"] = 4;
+    {
+        auto mutation = output.view(t2).begin_mutation(t2);
+        REQUIRE(from_python(mutation, partial));
+    }
+    const nb::object delta = delta_value_to_python(output.view(t2).data_view(), t2);
+    REQUIRE(nb::isinstance<nb::dict>(delta));
+    CHECK(nb::len(delta) == 1);
+    CHECK(nb::cast<std::int64_t>(delta["count"]) == 4);
+    value = value_to_python(output.view(t2).data_view());
+    CHECK(nb::cast<std::int64_t>(value["count"]) == 4);
+    CHECK(nb::cast<std::string>(value["label"]) == "three");
+
+    CHECK_FALSE(module_loaded("_hgraph"));
+}
+
+TEST_CASE("python-user-nodes: a TSD output converts through the registered table",
+          "[python_user_nodes][rfc0035]")
+{
+    ensure_interpreter();
+    auto    &registry = TypeRegistry::instance();
+    TSOutput output{*registry.tsd(int_meta(), registry.ts(str_meta()))};
+
+    const DateTime t1 = tick(1);
+    nb::dict       first;
+    first[nb::int_{1}] = "one";
+    first[nb::int_{2}] = "two";
+    {
+        auto mutation = output.view(t1).begin_mutation(t1);
+        REQUIRE(from_python(mutation, first));
+    }
+    nb::object value = value_to_python(output.view(t1).data_view());
+    REQUIRE(nb::isinstance<nb::dict>(value));
+    CHECK(nb::len(value) == 2);
+    CHECK(nb::cast<std::string>(value[nb::int_{2}]) == "two");
+
+    // A plain mapping is a replacement: key 1 leaves, key 3 arrives.
+    const DateTime t2 = tick(2);
+    nb::dict       replacement;
+    replacement[nb::int_{2}] = "two";
+    replacement[nb::int_{3}] = "three";
+    {
+        auto mutation = output.view(t2).begin_mutation(t2);
+        REQUIRE(from_python(mutation, replacement));
+    }
+    value = value_to_python(output.view(t2).data_view());
+    CHECK(nb::len(value) == 2);
+    CHECK(nb::cast<std::string>(value[nb::int_{3}]) == "three");
+    CHECK_FALSE(contains(value, nb::int_{1}));
+
+    const nb::object delta = delta_value_to_python(output.view(t2).data_view(), t2);
+    REQUIRE(nb::isinstance<nb::dict>(delta));
+    const nb::object removed  = delta["removed"];
+    const nb::object modified = delta["modified"];
+    CHECK(nb::len(removed) == 1);
+    CHECK(contains(removed, nb::int_{1}));
+    // A replacement writes every listed child, so both keys are modified.
+    CHECK(nb::len(modified) == 2);
+    CHECK(nb::cast<std::string>(modified[nb::int_{3}]) == "three");
+    CHECK(nb::cast<std::string>(modified[nb::int_{2}]) == "two");
+
+    CHECK_FALSE(module_loaded("_hgraph"));
+}
+
+TEST_CASE("python-user-nodes: the stdlib enums' conversions stay the module's", "[python_user_nodes][rfc0035]")
+{
+    ensure_interpreter();
+
+    // Their Python values are the hgraph package's Enum classes, which this
+    // process does not have, so the standalone table has no conversion for
+    // them and the forwarder says so (RFC 0035, "Unresolved questions").
+    // The operators register the enum scalars, as the module does.
+    hgraph::stdlib::register_standard_operators();
+    const Value policy{hgraph::stdlib::DivideByZero::Nan};
+    CHECK_THROWS_WITH(to_python(policy), Catch::Matchers::ContainsSubstring("no Python conversion is registered"));
+
+    CHECK_FALSE(module_loaded("_hgraph"));
+}


### PR DESCRIPTION
## Summary

RFC 0035 acceptance criterion 3, the one item deferred at acceptance: *a standalone `python-user-nodes` test converts a scalar, a compact list, a TSB and a TSD through the registered table with no `_hgraph` module.*

- `tests/cpp/test_python_user_nodes_conversion.cpp` embeds an isolated interpreter (no environment, no `site`; the configured interpreter's site-packages appended for numpy), calls the new `attach_embedded_interpreter`, and converts a scalar, a compact list (the `ndarray` export and the element-wise one), a TSB and a TSD through the bridge's entry points. Every case ends by checking that neither `hgraph` nor `_hgraph` was imported. A sixth case settles the RFC's open question on the stdlib enums: their conversions stay the module's (their Python values are the package's `Enum` classes, which a standalone host does not have), and the standalone table answers the named missing-conversion error.
- The test is a new Catch2 domain (`hgraph_python_test_objects`) that exists only under `HGRAPH_ENABLE_PYTHON_USER_NODES`; `hgraph_unit_tests` is now assembled from `HGRAPH_TEST_OBJECT_LIBS` instead of a duplicated list.
- A new `native-cpp.yml` job (*Linux python-user-nodes (embedded interpreter)*) configures the preset with GCC 14, `-Werror`, nanobind 2.13.0 and numpy. No CI leg built this preset before.

## What the test found (fixed here)

1. **The provider table was never registered in a standalone static build.** The load-time initializer lived in `python_ops.cpp`, which nothing outside the bridge names, so a static archive dropped the unit and `python_ops()` stayed null (`no Python conversion is registered for ...` on the first conversion). The initializer now lives in `conversion.cpp`, the unit every conversion entry point is in, so linking any entry links the registration.
2. **nanobind's per-process state was never created.** Only a module initializer (`NB_MODULE`) creates it; a standalone host has none, so the dense scalar-list export (`nb::ndarray`) dereferenced null and crashed. `python_bridge::attach_embedded_interpreter()` (`bridge_state.h`) is the host's one call after `Py_Initialize`: it runs what a module's exec slot runs and registers the table; repeating it is harmless.

Docs in the same change: `python_integration.rst` gains *Standalone conversions* (the host contract and what stays the module's); `python_bridge.rst` (registration sites), `testing.rst` (the conditional domain) and RFC 0035 (implementation status, the resolved question, the two design-text sentences that named `python_ops.cpp` as the registering unit).

## Evidence

- macOS, preset ON (`build-pun`, Clang, `BUILD_TESTING=ON`): full build with zero warnings; CTest 1724/1724, the six new cases running both inside `hgraph_unit_tests` and as `hgraph_unit_tests_python`.
- Architecture ratchets: 18 passed.
- The full local gate (preset-off C++ suite, wheel rebuild, Python suites including the extensions, `sphinx -W`, consumer checks), Linux (GCC 14, both presets) and Windows (MSVC) runs are posted as comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
