### PR TITLE
Fix Python operator and schema registration identities

### DIFF
--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -476,14 +476,17 @@ keeps the schema handle. ``ResolutionScope.materialise(pattern)`` resolves
 a deferred type argument's default in a scope -- a ``TypePattern``,
 ``ScalarPattern`` or ``SizePattern`` -- and projects it the same way.
 
-Python-authored ``TimeSeriesSchema`` classes register their named TSB under
-``{module}.{qualname}``, including enclosing class and function scopes. The
-expression still displays the short spelling, for example ``TSB[Pair]``.
+Python-authored ``TimeSeriesSchema`` classes register their named TSB with the
+semantic key ``(module, qualname)``, encoded as ``{module}::{qualname}`` because
+``::`` cannot occur in a Python identifier. This preserves the boundary even
+when the module and qualname both contain dots. The expression still displays
+the short spelling, for example ``TSB[Pair]``.
 Different modules may declare different shapes with the same short name;
 redeclaring one qualified name with a changed shape fails until an explicit
 test registry reset. An unchanged declaration reuses its nominal schema.
 ``CompoundScalar`` follows the same scoping rule through its native Bundle
-namespace. Native extension schemas can explicitly opt into their C++ identity
+namespace, placing the same ``::`` boundary before an enclosing scope. Native
+extension schemas can explicitly opt into their C++ identity
 with ``TimeSeriesSchema, namespace="extension.name"``, which binds
 ``extension.name::ClassName``. Do not infer a shared native identity from a
 Python class's short name.

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -476,10 +476,27 @@ keeps the schema handle. ``ResolutionScope.materialise(pattern)`` resolves
 a deferred type argument's default in a scope -- a ``TypePattern``,
 ``ScalarPattern`` or ``SizePattern`` -- and projects it the same way.
 
-Python-defined operators register under ``__pyop__{qualname}_{id:x}`` — the
-id-suffix exists because the C++ operator registry is process-global and
-Python may define two distinct operators with the same qualname (REPL,
-parametrised test fixtures). Do not "clean up" the id.
+Python-authored ``TimeSeriesSchema`` classes register their named TSB under
+``{module}.{qualname}``, including enclosing class and function scopes. The
+expression still displays the short spelling, for example ``TSB[Pair]``.
+Different modules may declare different shapes with the same short name;
+redeclaring one qualified name with a changed shape fails until an explicit
+test registry reset. An unchanged declaration reuses its nominal schema.
+``CompoundScalar`` follows the same scoping rule through its native Bundle
+namespace. Native extension schemas can explicitly opt into their C++ identity
+with ``TimeSeriesSchema, namespace="extension.name"``, which binds
+``extension.name::ClassName``. Do not infer a shared native identity from a
+Python class's short name.
+
+Python-defined operators register under
+``__pyop__{module}.{qualname}_{registration_id:x}``. The native bridge allocates
+each registration ID from a process-lifetime sequence, never an object's
+address. IDs are not recycled when a Python wrapper is collected, a Python
+module is reloaded, or the test registries are reset. Existing delegates
+therefore cannot bind a later declaration's overload family. Operator overloads
+are durable registry entries: collecting the wrapper does not deregister them.
+Repeated declarations remain isolated, including REPL and parametrised test
+fixtures; this identity rule does not introduce automatic module unloading.
 
 The ``hgraph`` package exposes every registered operator as a module-level
 attribute via PEP 562 (``__getattr__`` in ``__init__.py`` resolving through
@@ -750,7 +767,7 @@ Operator missing from ``dir(hgraph)``                 PEP 562 lazy surface; it a
 Missing Python graph ``log_`` output                  Capture/configure ``GraphConfiguration.graph_logger``.
 Python node gets ``None`` for an input                Unwired optional input: the null-source contract.
 ``frozenset`` set-delta replaced the whole TSS        Full-value vs ``_SetDelta`` class-identity shaping.
-Ugly ``__pyop__…_1f3a`` registry names                Deliberate: process-global registry, id disambiguates.
+Ugly ``__pyop__…_1f3a`` registry names                Durable registration IDs isolate overload families.
 Two identical register_overload lists (historical)    Now single ``register_python_overloads()`` — keep it so.
 Python tests fail right after C++ edits               Stale editable install; ``uv pip install -e . --reinstall``.
 No ``hgraph._runtime`` module                         Split into ``hgraph._wiring/`` (2026-07); import from there.

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -477,8 +477,10 @@ a deferred type argument's default in a scope -- a ``TypePattern``,
 ``ScalarPattern`` or ``SizePattern`` -- and projects it the same way.
 
 Python-authored ``TimeSeriesSchema`` classes register their named TSB with the
-semantic key ``(module, qualname)``, encoded as ``{module}::{qualname}`` because
-``::`` cannot occur in a Python identifier. This preserves the boundary even
+semantic key ``(tsb, module, qualname)``, encoded as
+``python::tsb::{module}::{qualname}``. The family component prevents its native
+Bundle value schema from colliding with a same-named ``CompoundScalar``;
+``::`` cannot occur in a Python identifier, so it also preserves the boundary
 when the module and qualname both contain dots. The expression still displays
 the short spelling, for example ``TSB[Pair]``.
 Different modules may declare different shapes with the same short name;

--- a/python/hgraph/_compat.py
+++ b/python/hgraph/_compat.py
@@ -180,7 +180,10 @@ class CompoundScalar:
         super().__init_subclass__()
         enclosing = cls.__qualname__.rsplit(".", 1)[0] if "." in cls.__qualname__ else ""
         if namespace is None:
-            namespace = cls.__module__ if not enclosing else f"{cls.__module__}.{enclosing}"
+            # ``::`` cannot occur in a Python module or qualified class name,
+            # so it preserves the boundary between them. A dotted join would
+            # merge ``pkg.models`` + ``Pair`` with ``pkg`` + ``models.Pair``.
+            namespace = cls.__module__ if not enclosing else f"{cls.__module__}::{enclosing}"
 
         # Release/0.5 described polymorphic JSON hierarchies with class-body
         # markers. Keep their historical child registry visible for code

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -2916,9 +2916,11 @@ class _TSBMeta(type):
             name = f"{time_series_namespace}::{origin.__name__}"
         qualname = getattr(origin, "__qualname__", origin.__name__)
         if compound_meta is None and time_series_namespace is None:
-            # ``::`` is not a legal Python identifier component, preserving
-            # the otherwise ambiguous module/qualname boundary.
-            name = f"{origin.__module__}::{qualname}"
+            # A plain TSB and a CompoundScalar both register a native Bundle
+            # value schema. Keep the family distinct, then preserve the
+            # otherwise ambiguous module/qualname boundary with ``::`` (not a
+            # legal Python identifier component).
+            name = f"python::tsb::{origin.__module__}::{qualname}"
         if compound_meta is None and type_args:
             name += "[" + ",".join(_compound_specialization_token(arg) for arg in type_args) + "]"
         expression = _TsExpr(_hgraph.tsb(name, fields), f"TSB[{origin.__name__}]")

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -2574,9 +2574,10 @@ class TimeSeriesSchema:
     def __init_subclass__(cls, *, namespace=None, **kwargs):
         """Optionally bind a Python schema to a native named-TSB namespace.
 
-        Plain Python-authored schemas retain their historical class-name
-        identity. Installed native extensions can supply ``namespace=`` to
-        resolve the same globally named TSB as their public C++ schema.
+        Python-authored schemas use their module and qualified class name
+        as their nominal identity. Installed native extensions can supply
+        ``namespace=`` to resolve the same globally named TSB as their public
+        C++ schema.
         """
         super().__init_subclass__(**kwargs)
         if namespace is not None:
@@ -2906,21 +2907,15 @@ class _TSBMeta(type):
                 variables=_type_variables_of(schema),
             )
 
-        # The registry's TSB namespace is GLOBAL; python classes are scoped
-        # (tests re-define same-named local schemas freely). Qualify with the
-        # module + qualname so distinct classes never collide; the plain
-        # __name__ stays for stable top-level classes (nicer diagnostics).
+        # Native registration is process-wide, while Python class names are
+        # scoped by module and enclosing classes/functions. Keep the short
+        # name only in the expression's display label, never as its identity.
         name = compound_meta.name if compound_meta is not None else origin.__name__
         time_series_namespace = origin.__dict__.get("__time_series_namespace__")
         if compound_meta is None and time_series_namespace is not None:
             name = f"{time_series_namespace}::{origin.__name__}"
         qualname = getattr(origin, "__qualname__", origin.__name__)
-        if (
-            compound_meta is None
-            and time_series_namespace is None
-            and "<locals>" in qualname
-        ):
-            # Function-local TimeSeriesSchema classes need nominal isolation.
+        if compound_meta is None and time_series_namespace is None:
             name = f"{origin.__module__}.{qualname}"
         if compound_meta is None and type_args:
             name += "[" + ",".join(_compound_specialization_token(arg) for arg in type_args) + "]"

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -2916,7 +2916,9 @@ class _TSBMeta(type):
             name = f"{time_series_namespace}::{origin.__name__}"
         qualname = getattr(origin, "__qualname__", origin.__name__)
         if compound_meta is None and time_series_namespace is None:
-            name = f"{origin.__module__}.{qualname}"
+            # ``::`` is not a legal Python identifier component, preserving
+            # the otherwise ambiguous module/qualname boundary.
+            name = f"{origin.__module__}::{qualname}"
         if compound_meta is None and type_args:
             name += "[" + ",".join(_compound_specialization_token(arg) for arg in type_args) + "]"
         expression = _TsExpr(_hgraph.tsb(name, fields), f"TSB[{origin.__name__}]")

--- a/python/hgraph/_wiring/_operator.py
+++ b/python/hgraph/_wiring/_operator.py
@@ -36,8 +36,9 @@ class _Operator:
     attach via ``@compute_node(overloads=op)`` / ``@graph(overloads=op)``;
     a call dispatches through the C++ registry (the standing ruling: the
     registry's pattern matching owns ALL dispatch). The registry name is
-    unique per operator OBJECT - tests re-declare same-named operators
-    freely against the process-global registry."""
+    allocated once per declaration and never reused, even after the Python
+    wrapper is collected. Registered overloads remain owned by the native
+    registry until explicit teardown."""
 
     def __init__(self, fn):
         self.fn = fn
@@ -55,7 +56,8 @@ class _Operator:
             self.__signature__ = inspect.signature(fn)
         except (ValueError, TypeError):
             pass
-        self._registry_name = f"__pyop__{self.__qualname__}_{id(self):x}"
+        registration_id = _hgraph._allocate_python_operator_id()
+        self._registry_name = f"__pyop__{fn.__module__}.{self.__qualname__}_{registration_id:x}"
         self._delegate = _OperatorFunction(self._registry_name)
         self._overloads = []   # (impl, wiring signature) - dispatch_ reads these
 

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -52,9 +52,12 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -65,6 +68,10 @@ using namespace hgraph::python_bridge;
 namespace
 {
     std::uint64_t python_registry_generation{0};
+    // Allocated with the GIL held. Unlike object addresses (or Python module
+    // globals), this sequence survives wrapper collection and module reloads.
+    // Never reset it: old operator delegates can outlive a registry reset.
+    std::uint64_t next_python_operator_id{0};
 
     /** The python RequirementsNotMetWiringError class (installed at import). */
     [[nodiscard]] nb::object &requirements_error_slot()
@@ -174,6 +181,12 @@ NB_MODULE(_hgraph, m)
     bind_state_and_services(m);
 
     m.def("_registry_generation", [] { return python_registry_generation; });
+    m.def("_allocate_python_operator_id", [] {
+        if (next_python_operator_id == std::numeric_limits<std::uint64_t>::max()) {
+            throw std::overflow_error("Python operator registration identities exhausted");
+        }
+        return next_python_operator_id++;
+    });
     // Rebuild the process logger (and its sinks) on demand: spdlog's Windows
     // stdout sinks cache the raw OS handle at construction, so tests that
     // redirect fds per-test (pytest capfd) must reset before logging.

--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -59,7 +59,7 @@ def test_compound_scalar_default_namespace_includes_enclosing_scope():
         value: int
 
     meta = _value_type(Local)
-    assert meta.namespace == f"{__name__}.test_compound_scalar_default_namespace_includes_enclosing_scope.<locals>"
+    assert meta.namespace == f"{__name__}::test_compound_scalar_default_namespace_includes_enclosing_scope.<locals>"
     assert meta.local_name == "Local"
 
 

--- a/python/tests/test_operator_identity.py
+++ b/python/tests/test_operator_identity.py
@@ -1,0 +1,50 @@
+"""Python declarations must never inherit an unrelated operator's overloads."""
+
+import gc
+import importlib
+import weakref
+
+import _hgraph
+
+from hgraph import TS, compute_node, operator
+from hgraph.test import eval_node
+
+
+def _declare_score(offset):
+    @operator
+    def score(value: TS[int]) -> TS[int]: ...
+
+    @compute_node(overloads=score)
+    def score_int(value: TS[int]) -> TS[int]:
+        return value.value + offset
+
+    return score
+
+
+def test_collected_operator_identity_is_never_reused(monkeypatch):
+    module = importlib.import_module("hgraph._wiring._operator")
+    # Force the former implementation's collision deterministically. Do not
+    # depend on CPython choosing a particular freed allocation for the wrapper.
+    monkeypatch.setattr(module, "id", lambda _: 0x661, raising=False)
+    first = _declare_score(1)
+    first_name = first._registry_name
+    reference = weakref.ref(first)
+    assert eval_node(first, [1, 2]) == [2, 3]
+    del first
+    gc.collect()
+    assert reference() is None
+    assert first_name in _hgraph.operator_names()  # no GC-driven deregistration
+
+    second = _declare_score(10)
+    assert second._registry_name != first_name
+    assert eval_node(second, [1, 2]) == [11, 12]
+
+
+def test_live_same_named_operators_keep_separate_overload_families(monkeypatch):
+    module = importlib.import_module("hgraph._wiring._operator")
+    monkeypatch.setattr(module, "id", lambda _: 0x662, raising=False)
+    first = _declare_score(2)
+    second = _declare_score(20)
+    assert first._registry_name != second._registry_name
+    assert eval_node(first, [1, 2]) == [3, 4]
+    assert eval_node(second, [1, 2]) == [21, 22]

--- a/python/tests/test_registry_reset_teardown.py
+++ b/python/tests/test_registry_reset_teardown.py
@@ -37,6 +37,69 @@ def _run(source):
     )
 
 
+def test_reset_allows_changed_named_time_series_schema():
+    result = _run(textwrap.dedent("""
+        import _hgraph
+        from hgraph import TS, TSB, TimeSeriesSchema, pass_through
+        from hgraph.test import eval_node
+
+        class Pair(TimeSeriesSchema):
+            value: TS[int]
+
+        assert eval_node(pass_through, [{"value": 1}],
+                         resolution_dict={"ts": TSB[Pair]}) == [{"value": 1}]
+        _hgraph.reset_registries()
+
+        class Pair(TimeSeriesSchema):
+            value: TS[str]
+
+        assert eval_node(pass_through, [{"value": "new"}],
+                         resolution_dict={"ts": TSB[Pair]}) == [{"value": "new"}]
+        print("ok")
+    """))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ok" in result.stdout
+
+
+def test_operator_ids_survive_python_module_reload_and_registry_reset():
+    result = _run(textwrap.dedent("""
+        import importlib
+        import _hgraph
+        from hgraph import TS, compute_node
+        from hgraph.test import eval_node
+
+        module = importlib.import_module("hgraph._wiring._operator")
+
+        def declare(offset):
+            @module.operator
+            def score(value: TS[int]) -> TS[int]: ...
+
+            @compute_node(overloads=score)
+            def score_int(value: TS[int]) -> TS[int]:
+                return value.value + offset
+
+            return score
+
+        first = declare(1)
+        assert eval_node(first, [1]) == [2]
+        importlib.reload(module)
+        second = declare(2)
+        assert first._registry_name != second._registry_name
+        assert eval_node(second, [1]) == [3]
+
+        _hgraph.reset_registries()
+        third = declare(3)
+        assert len({first._registry_name, second._registry_name,
+                    third._registry_name}) == 3
+        assert first._registry_name not in _hgraph.operator_names()
+        assert second._registry_name not in _hgraph.operator_names()
+        assert eval_node(third, [1]) == [4]
+        print("ok")
+    """))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ok" in result.stdout
+
+
 def test_reset_then_ordinary_exit_does_not_crash():
     result = _run(RESET_THEN_EXIT)
     assert result.returncode == 0, (

--- a/python/tests/test_schema_redeclaration.py
+++ b/python/tests/test_schema_redeclaration.py
@@ -1,6 +1,6 @@
 """Schema identity is process-wide; redeclaration is a duplicate, not a conflict.
 
-A schema is keyed by ``(module, name)``, so the same name in two modules is
+A schema is keyed by ``(module, qualname)``, so the same name in two modules is
 fine. Re-executing an *unchanged* declaration in one module - a notebook cell,
 an ``importlib.reload``, a doctest - produces a new class object for the same
 schema and rebinds. Redeclaring the same name with a different shape still
@@ -13,7 +13,60 @@ from dataclasses import dataclass
 
 import pytest
 
-from hgraph import TS, CompoundScalar
+from hgraph import TS, TSB, CompoundScalar, TimeSeriesSchema, pass_through
+from hgraph.test import eval_node
+
+
+def _schema_class(module, qualname, field_type, *, compound=False):
+    """Create independent declarations without relying on import order."""
+    base = CompoundScalar if compound else TimeSeriesSchema
+    schema = type(qualname.rsplit(".", 1)[-1], (base,), {
+        "__module__": module,
+        "__qualname__": qualname,
+        "__annotations__": {"value": field_type if compound else TS[field_type]},
+    })
+    return dataclass(frozen=True)(schema) if compound else schema
+
+
+@pytest.mark.parametrize("compound", [False, True], ids=["tsb", "compound"])
+@pytest.mark.parametrize("reverse", [False, True], ids=["forward", "reverse"])
+@pytest.mark.parametrize("same_shape", [False, True], ids=["different-shape", "same-shape"])
+def test_same_short_schema_name_in_different_modules(compound, reverse, same_shape):
+    prefix = f"{__name__}.modules_{compound}_{reverse}_{same_shape}"
+    left = _schema_class(f"{prefix}.left", "Pair", int, compound=compound)
+    right_type = int if same_shape else str
+    right = _schema_class(f"{prefix}.right", "Pair", right_type, compound=compound)
+    schemas = (right, left) if reverse else (left, right)
+    annotation = TS if compound else TSB
+    registered = {schema: annotation[schema] for schema in schemas}
+
+    assert registered[left].handle != registered[right].handle
+    for schema, value in ((left, 42), (right, 7 if same_shape else "seven")):
+        sample = schema(value) if compound else {"value": value}
+        assert eval_node(
+            pass_through, [sample], resolution_dict={"ts": registered[schema]}
+        ) == [sample]
+        assert repr(registered[schema]) == f"{'TS' if compound else 'TSB'}[Pair]"
+
+
+@pytest.mark.parametrize("compound", [False, True], ids=["tsb", "compound"])
+def test_same_short_schema_name_in_different_enclosing_classes(compound):
+    module = f"{__name__}.nested_{compound}"
+    left = _schema_class(module, "Left.Pair", int, compound=compound)
+    right = _schema_class(module, "Right.Pair", str, compound=compound)
+    annotation = TS if compound else TSB
+    assert annotation[left].handle != annotation[right].handle
+
+
+def test_time_series_schema_redeclaration_preserves_nominal_identity():
+    module = f"{__name__}.redeclare_tsb"
+    first = _schema_class(module, "Pair", int)
+    duplicate = _schema_class(module, "Pair", int)
+    changed = _schema_class(module, "Pair", str)
+    assert first is not duplicate
+    assert TSB[first].handle == TSB[duplicate].handle
+    with pytest.raises(ValueError, match="already registered with a different schema"):
+        TSB[changed]
 
 
 def _declare(*, defaulted=False, extra_field=False):

--- a/python/tests/test_schema_redeclaration.py
+++ b/python/tests/test_schema_redeclaration.py
@@ -58,6 +58,16 @@ def test_same_short_schema_name_in_different_enclosing_classes(compound):
     assert annotation[left].handle != annotation[right].handle
 
 
+@pytest.mark.parametrize("compound", [False, True], ids=["tsb", "compound"])
+def test_module_and_qualname_boundary_is_unambiguous(compound):
+    prefix = f"{__name__}.boundary_{compound}"
+    top_level = _schema_class(f"{prefix}.models", "Pair", int, compound=compound)
+    nested = _schema_class(prefix, "models.Pair", str, compound=compound)
+    annotation = TS if compound else TSB
+
+    assert annotation[top_level].handle != annotation[nested].handle
+
+
 def test_time_series_schema_redeclaration_preserves_nominal_identity():
     module = f"{__name__}.redeclare_tsb"
     first = _schema_class(module, "Pair", int)

--- a/python/tests/test_schema_redeclaration.py
+++ b/python/tests/test_schema_redeclaration.py
@@ -68,6 +68,16 @@ def test_module_and_qualname_boundary_is_unambiguous(compound):
     assert annotation[top_level].handle != annotation[nested].handle
 
 
+@pytest.mark.parametrize("reverse", [False, True], ids=["tsb-first", "compound-first"])
+def test_time_series_and_compound_schema_families_do_not_share_identity(reverse):
+    module = f"{__name__}.cross_family_{reverse}"
+    time_series = _schema_class(module, "Quote", str)
+    compound = _schema_class(module, "Quote", int, compound=True)
+    registrations = (TS[compound], TSB[time_series]) if reverse else (TSB[time_series], TS[compound])
+
+    assert registrations[0].handle != registrations[1].handle
+
+
 def test_time_series_schema_redeclaration_preserves_nominal_identity():
     module = f"{__name__}.redeclare_tsb"
     first = _schema_class(module, "Pair", int)

--- a/python/tests/test_type_carrier_sweep.py
+++ b/python/tests/test_type_carrier_sweep.py
@@ -315,11 +315,9 @@ class TestGraphCarriers:
         assert eval_node(schema_name, [1]) == ["SweepRow"]
 
 
-# One operator family for the whole module. An operator registers under a
-# name derived from ``id(self)``; a family built inside each test was garbage
-# collected between tests and its id reused, so the second build registered a
-# second candidate set under the first's registry name and every call became
-# "ambiguous overloads". Finding, not a sweep concern: keep the object alive.
+# One durable operator family for the whole module. Address reuse formerly
+# merged separate declarations here (#661); test_operator_identity.py now
+# covers that regression independently of these type-carrier checks.
 _TYPED_OBSERVED = []
 
 

--- a/tests/cpp/test_type_registry.cpp
+++ b/tests/cpp/test_type_registry.cpp
@@ -1586,6 +1586,27 @@ TEST_CASE("TypeRegistry::tsb lifts Bundle value fields without inferring "
       std::invalid_argument);
 }
 
+TEST_CASE("TypeRegistry: qualified TSB names isolate module declarations") {
+  using namespace hgraph;
+  auto &registry = TypeRegistry::instance();
+  const auto *integer = registry.ts(registry.value_type("int"));
+  const auto *string = registry.ts(registry.value_type("str"));
+  const auto *left = registry.tsb("tests.left.Pair", {{"value", integer}});
+  const auto *right = registry.tsb("tests.right.Pair", {{"value", string}});
+  const auto *same_shape =
+      registry.tsb("tests.same_shape.Pair", {{"value", integer}});
+
+  REQUIRE(left != right);
+  REQUIRE(left != same_shape);
+  REQUIRE(left->value_type != same_shape->value_type);
+  REQUIRE(left->wrapped_un_named_tsb() == same_shape->wrapped_un_named_tsb());
+  REQUIRE(registry.named_tsb("tests.left.Pair") == left);
+  REQUIRE(registry.named_tsb("tests.right.Pair") == right);
+  REQUIRE(registry.tsb("tests.left.Pair", {{"value", integer}}) == left);
+  REQUIRE_THROWS_AS(registry.tsb("tests.left.Pair", {{"value", string}}),
+                    std::invalid_argument);
+}
+
 TEST_CASE("TypeRegistry: un_named_tsb and tsb distinguish structural vs "
           "nominal identity") {
   using namespace hgraph;


### PR DESCRIPTION
## Summary

- qualify default Python TimeSeriesSchema registration with a family marker and an unambiguous module/qualname boundary while retaining short display names and explicit native namespaces
- apply the same boundary-preserving default namespace to CompoundScalar declarations and prevent same-named TSB/CompoundScalar Bundle collisions
- allocate process-lifetime Python operator IDs in the native bridge so collection, reload, and registry reset cannot recycle an overload-family identity
- cover cross-module, enclosing-scope, ambiguous-boundary, and cross-family schemas, same-name redeclaration, forced former ID collisions, and reset/reload behavior

## Validation

- cmake --preset cpp --fresh
- cmake --build --preset cpp --target clean
- cmake --build --preset cpp --parallel 12
- ctest --preset cpp --parallel 2: 1,735 passed
- Python 3.12 ABI3 wheel installed into a fresh Python 3.14 environment
- python -m pytest python/tests -q -m "not wip": 3,284 passed, 10 skipped
- sphinx -E -W --keep-going -b doctest docs/source /tmp/hgraph-766-doctest: 67 passed
- sphinx -E -W --keep-going -b html docs/source /tmp/hgraph-766-doctest-html
- HTTP/2 loopback test repeated until failure 25 times: all passed

Closes #653
Closes #661