### PR TITLE
HGL: bound the applied-constructor look-ahead so comparisons parse (#767 item 1)

### DIFF
--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Bound the applied-constructor look-ahead to the tokens a generic-argument
+  list can contain, so a `<` comparison followed anywhere later in the file by
+  `> (` no longer breaks parsing (#767). The rule and its one residual
+  ambiguity are recorded in the developer guide's "Struct construction".
 - Add an installed `hgl::native_package` C++ authoring API for exact scalar and
   package-declared nominal native signatures. It produces deterministic sealed
   descriptors and applies the same safety validator used by `hgl check`.

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1224,7 +1224,16 @@ An explicitly applied constructor such as `Box<f64>(value: 1.5)` must supply
 every generic argument. The `name<...>(...)` syntax is reserved for struct
 construction in the initial design; a callee that resolves to an ordinary
 function or operator is diagnosed because explicit generic function-call
-syntax remains open. Without the list, constructor inference binds parameters
+syntax remains open. The parser decides `name<` by look-ahead alone, before
+any name is resolved: it opens an applied constructor when every token up to
+the matching `>` is one a generic-argument list can contain (names, `::`,
+nested `<` and `>`, commas, newlines, literals, the scalar type keywords, and
+the arithmetic of a size expression) and that `>` is directly followed by
+`(`. Any other token, such as `&&`, a keyword, `)`, or the end of the
+declaration, makes the `<` a comparison. The one residual ambiguity is
+inherent to the syntax: `a < b, c > (d)` inside an argument or sequence list
+reads as the constructor `a<b, c>(d)`; parenthesize either comparison to write
+two comparisons there. Without the list, constructor inference binds parameters
 from the expected result and supplied fields, unifies repeated occurrences,
 then evaluates the struct's `requires` clause. Every parameter must resolve;
 `Maybe()` without either a type-bearing field or an expected `Maybe<T>` type is

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1227,13 +1227,15 @@ function or operator is diagnosed because explicit generic function-call
 syntax remains open. The parser decides `name<` by look-ahead alone, before
 any name is resolved: it opens an applied constructor when every token up to
 the matching `>` is one a generic-argument list can contain (names, `::`,
-nested `<` and `>`, commas, newlines, literals, the scalar type keywords, and
-the arithmetic of a size expression) and that `>` is directly followed by
-`(`. Any other token, such as `&&`, a keyword, `)`, or the end of the
-declaration, makes the `<` a comparison. The one residual ambiguity is
-inherent to the syntax: `a < b, c > (d)` inside an argument or sequence list
-reads as the constructor `a<b, c>(d)`; parenthesize either comparison to write
-two comparisons there. Without the list, constructor inference binds parameters
+nested `<` and `>`, commas, literals, the scalar type keywords, the
+arithmetic of a size expression, and a balanced parenthesized group, whose
+contents are not inspected) and that `>` is directly followed by `(`. A
+newline counts only where the argument list admits one: after `<` or `,`, or
+before `>` or `,`. Any other token, such as `&&`, a keyword, an unmatched
+`)`, a newline between two arguments, or the end of the declaration, makes
+the `<` a comparison. The one residual ambiguity is inherent to the syntax:
+`a < b, c > (d)` inside an argument or sequence list reads as the constructor
+`a<b, c>(d)`; parenthesize either comparison to write two comparisons there. Without the list, constructor inference binds parameters
 from the expected result and supplied fields, unifies repeated occurrences,
 then evaluates the struct's `requires` clause. Every parameter must resolve;
 `Maybe()` without either a type-bearing field or an expected `Maybe<T>` type is

--- a/language/src/syntax/token_grammar.cpp
+++ b/language/src/syntax/token_grammar.cpp
@@ -684,6 +684,39 @@ namespace hgl::syntax
 
     namespace
     {
+        /// The tokens a generic-argument list may contain: names, `::`, nested
+        /// `<`/`>`, separators, literals, the scalar type keywords, and the
+        /// arithmetic of a size expression. Anything else ends the look-ahead
+        /// that decides whether `name<` opens an applied constructor, so a `<`
+        /// comparison is never paired with a `>` from a later expression or
+        /// declaration (syntax-and-semantics.md, "Struct construction").
+        [[nodiscard]] constexpr bool can_occur_in_generic_arguments(TokenKind kind) noexcept {
+            switch (kind) {
+                case TokenKind::Identifier:
+                case TokenKind::ColonColon:
+                case TokenKind::Less:
+                case TokenKind::Greater:
+                case TokenKind::Comma:
+                case TokenKind::Newline:
+                case TokenKind::IntLiteral:
+                case TokenKind::FloatLiteral:
+                case TokenKind::StringLiteral:
+                case TokenKind::TemporalLiteral:
+                case TokenKind::Placeholder:
+                case TokenKind::KwTrue:
+                case TokenKind::KwFalse:
+                case TokenKind::KwNull:
+                case TokenKind::LParen:
+                case TokenKind::RParen:
+                case TokenKind::Plus:
+                case TokenKind::Minus:
+                case TokenKind::Star:
+                case TokenKind::Slash:
+                case TokenKind::Percent: return true;
+                default: return is_scalar_type_keyword(kind);
+            }
+        }
+
         [[nodiscard]] bool looks_like_applied_constructor(std::span<const Token> tokens, std::size_t position) noexcept {
             if (tokens[position].kind != TokenKind::Identifier) { return false; }
             std::size_t cursor = position + 1;
@@ -693,15 +726,26 @@ namespace hgl::syntax
             }
             if (cursor >= tokens.size() || tokens[cursor].kind != TokenKind::Less) { return false; }
 
-            int depth = 0;
+            // Parentheses only group a size expression, so an unmatched `)`
+            // ends the list and a `<` or `>` inside them is not a nesting
+            // level: `f(a < b) > (c)` is two comparisons.
+            int depth  = 0;
+            int parens = 0;
             for (; cursor < tokens.size(); ++cursor) {
-                if (tokens[cursor].kind == TokenKind::Less) {
+                const TokenKind kind = tokens[cursor].kind;
+                if (!can_occur_in_generic_arguments(kind)) { return false; }
+                if (kind == TokenKind::LParen) {
+                    ++parens;
+                } else if (kind == TokenKind::RParen) {
+                    if (parens == 0) { return false; }
+                    --parens;
+                } else if (kind == TokenKind::Less) {
+                    if (parens > 0) { return false; }
                     ++depth;
-                } else if (tokens[cursor].kind == TokenKind::Greater) {
+                } else if (kind == TokenKind::Greater) {
+                    if (parens > 0) { return false; }
                     --depth;
                     if (depth == 0) { return cursor + 1 < tokens.size() && tokens[cursor + 1].kind == TokenKind::LParen; }
-                } else if (tokens[cursor].kind == TokenKind::EndOfFile) {
-                    return false;
                 }
             }
             return false;

--- a/language/src/syntax/token_grammar.cpp
+++ b/language/src/syntax/token_grammar.cpp
@@ -726,27 +726,46 @@ namespace hgl::syntax
             }
             if (cursor >= tokens.size() || tokens[cursor].kind != TokenKind::Less) { return false; }
 
-            // Parentheses only group a size expression, so an unmatched `)`
-            // ends the list and a `<` or `>` inside them is not a nesting
-            // level: `f(a < b) > (c)` is two comparisons.
-            int depth  = 0;
-            int parens = 0;
+            // A parenthesized group is an arbitrary constant expression, so
+            // inside one nothing but its balance matters: `Flag<(1 < 2)>(...)`
+            // is a constructor, while an unmatched `)` ends the list and
+            // `f(a < b) > (c)` is two comparisons. Outside a group a newline is
+            // valid only where `generic_arguments` admits one: after `<` or
+            // `,`, or before `>` or `,`. A newline between two arguments-to-be
+            // is a statement boundary, so `a < b` and `c > (d)` on consecutive
+            // lines stay two comparisons.
+            int       depth    = 0;
+            int       parens   = 0;
+            TokenKind previous = TokenKind::Less;
             for (; cursor < tokens.size(); ++cursor) {
                 const TokenKind kind = tokens[cursor].kind;
+                if (parens > 0) {
+                    if (kind == TokenKind::EndOfFile || kind == TokenKind::LBrace || kind == TokenKind::RBrace) { return false; }
+                    if (kind == TokenKind::LParen) { ++parens; }
+                    if (kind == TokenKind::RParen) { --parens; }
+                    continue;
+                }
+                if (kind == TokenKind::Newline) {
+                    if (previous == TokenKind::Less || previous == TokenKind::Comma) { continue; }
+                    std::size_t next = cursor + 1;
+                    while (next < tokens.size() && tokens[next].kind == TokenKind::Newline) { ++next; }
+                    if (next < tokens.size() && (tokens[next].kind == TokenKind::Greater || tokens[next].kind == TokenKind::Comma)) {
+                        continue;
+                    }
+                    return false;
+                }
                 if (!can_occur_in_generic_arguments(kind)) { return false; }
                 if (kind == TokenKind::LParen) {
                     ++parens;
                 } else if (kind == TokenKind::RParen) {
-                    if (parens == 0) { return false; }
-                    --parens;
+                    return false;
                 } else if (kind == TokenKind::Less) {
-                    if (parens > 0) { return false; }
                     ++depth;
                 } else if (kind == TokenKind::Greater) {
-                    if (parens > 0) { return false; }
                     --depth;
                     if (depth == 0) { return cursor + 1 < tokens.size() && tokens[cursor + 1].kind == TokenKind::LParen; }
                 }
+                previous = kind;
             }
             return false;
         }

--- a/language/src/syntax/token_grammar.cpp
+++ b/language/src/syntax/token_grammar.cpp
@@ -749,7 +749,8 @@ namespace hgl::syntax
                     if (previous == TokenKind::Less || previous == TokenKind::Comma) { continue; }
                     std::size_t next = cursor + 1;
                     while (next < tokens.size() && tokens[next].kind == TokenKind::Newline) { ++next; }
-                    if (next < tokens.size() && (tokens[next].kind == TokenKind::Greater || tokens[next].kind == TokenKind::Comma)) {
+                    if (next < tokens.size() &&
+                        (tokens[next].kind == TokenKind::Greater || tokens[next].kind == TokenKind::Comma)) {
                         continue;
                     }
                     return false;

--- a/language/tests/syntax/parser_tests.cpp
+++ b/language/tests/syntax/parser_tests.cpp
@@ -438,6 +438,52 @@ TEST_CASE("struct and delta construction use named arguments", "[parser]") {
                                                               "    NullLiteral\n");
 }
 
+TEST_CASE("comparisons are not mistaken for applied constructors", "[parser]") {
+    // The look-ahead that decides `name<` stops at the first token a
+    // generic-argument list cannot contain, so a `<` comparison is never
+    // paired with a `>` from a later expression or declaration (#767).
+    REQUIRE(expr_dump("a < b && c > (d)") == "Binary &&\n"
+                                             "  Binary <\n"
+                                             "    NameRef a\n"
+                                             "    NameRef b\n"
+                                             "  Binary >\n"
+                                             "    NameRef c\n"
+                                             "    NameRef d\n");
+    REQUIRE(expr_dump("f(a < b) > (c)") == "Binary >\n"
+                                           "  Call\n"
+                                           "    callee: NameRef f\n"
+                                           "    Argument\n"
+                                           "      Binary <\n"
+                                           "        NameRef a\n"
+                                           "        NameRef b\n"
+                                           "  NameRef c\n");
+    const std::string module = dump_clean("module t\n"
+                                          "\n"
+                                          "export fn less(a: f64, b: f64) -> bool => a < b\n"
+                                          "\n"
+                                          "export fn greater(c: f64, d: f64) -> bool => c > (d + 1.0)\n");
+    REQUIRE(module.find("Binary <\n") != std::string::npos);
+    REQUIRE(module.find("Binary >\n") != std::string::npos);
+    REQUIRE(module.find("StructConstruct") == std::string::npos);
+
+    // Every token a generic-argument list can contain still reaches the
+    // constructor: nested applications, constant sizes, and newlines.
+    REQUIRE(expr_dump("Box<list<f64, 3>>(value: v)") == "StructConstruct\n"
+                                                        "  type: Type named Box\n"
+                                                        "    GenericArgument\n"
+                                                        "      Type list (value)\n"
+                                                        "        Type scalar f64 (value)\n"
+                                                        "        size: IntLiteral 3\n"
+                                                        "  Argument value\n"
+                                                        "    NameRef v\n");
+    REQUIRE(expr_dump("Box<\n    f64\n>(value: 1.0)") == "StructConstruct\n"
+                                                         "  type: Type named Box\n"
+                                                         "    GenericArgument\n"
+                                                         "      Type scalar f64 (value)\n"
+                                                         "  Argument value\n"
+                                                         "    FloatLiteral 1.0\n");
+}
+
 TEST_CASE("names and qualified references", "[parser]") {
     REQUIRE(expr_dump("x") == "NameRef x\n");
     REQUIRE(expr_dump("mc::my_op") == "QualifiedRef mc::my_op\n");

--- a/language/tests/syntax/parser_tests.cpp
+++ b/language/tests/syntax/parser_tests.cpp
@@ -466,6 +466,22 @@ TEST_CASE("comparisons are not mistaken for applied constructors", "[parser]") {
     REQUIRE(module.find("Binary >\n") != std::string::npos);
     REQUIRE(module.find("StructConstruct") == std::string::npos);
 
+    // Consecutive statements: the newline between `b` and `c` is not a
+    // position where a generic-argument list admits one.
+    const std::string block = dump_clean("module t\n"
+                                         "fn f(a: f64, b: f64, c: f64, d: f64) -> bool {\n"
+                                         "    let x = a < b\n"
+                                         "    let y = c > (d)\n"
+                                         "    x && y\n"
+                                         "}\n");
+    REQUIRE(block.find("Binary <\n") != std::string::npos);
+    REQUIRE(block.find("Binary >\n") != std::string::npos);
+    REQUIRE(block.find("StructConstruct") == std::string::npos);
+
+    // A parenthesized constant argument may itself compare: the group's
+    // balance, not its operators, is what the look-ahead tracks.
+    REQUIRE(expr_dump("Flag<(1 < 2)>(value: v)").find("StructConstruct\n  type: Type named Flag\n") == 0);
+
     // Every token a generic-argument list can contain still reaches the
     // constructor: nested applications, constant sizes, and newlines.
     REQUIRE(expr_dump("Box<list<f64, 3>>(value: v)") == "StructConstruct\n"


### PR DESCRIPTION
Corrective roadmap item 1 of #767.

## Problem

`looks_like_applied_constructor` (`language/src/syntax/token_grammar.cpp`) decided that `name <` opens an applied constructor whenever a depth-matched `>` followed by `(` occurred *anywhere later in the token stream*, ignoring operators, newlines and declaration boundaries. Two shapes that no checked-in example happened to contain failed to parse:

```hgl
export fn less(a: f64, b: f64) -> bool => a < b

export fn greater(c: f64, d: f64) -> bool => c > (d + 1.0)
```

```
parse: expected '>', found 'export'
```

and `a < b && c > (d)`, `f(a < b) > (c)` in one expression. Swapping the two functions made the file parse.

## Fix

The look-ahead now stops at the first token a generic-argument list cannot contain (names, `::`, nested `<`/`>`, commas, newlines, literals, the scalar type keywords and size-expression arithmetic remain allowed), an unmatched `)` ends it, and `<`/`>` inside parentheses are not nesting levels. Multi-line and nested applications (`Box<\n f64\n>(...)`, `Box<list<f64, 3>>(...)`) still reach the constructor.

The rule is now recorded in `syntax-and-semantics.md`, "Struct construction", together with its one residual ambiguity, inherent to the `name<...>(...)` syntax the spec reserves for construction: `a < b, c > (d)` inside an argument or sequence list reads as the constructor `a<b, c>(d)`; parenthesize either comparison to write two comparisons there.

## Tests

- New parser case "comparisons are not mistaken for applied constructors": the two-function module, `a < b && c > (d)`, `f(a < b) > (c)`, plus the nested and multi-line constructor forms.
- Local: `hgl_syntax_tests` 132/132 (3068 assertions); `ctest -R hgraph_language` 50/50; every `language/examples/*.hgl` still passes `hgl check`; the four failing probe files from the review now parse.
- Only `language/` changes; the default build does not compile it, so the core gate is unaffected. Linux GCC 14 and macOS are covered by the `Language toolchain` workflow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
