### PR TITLE
HGL: enforce shape, injectable and runtime-placement rules in the checker (#767 item 2)

### DIFF
--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -6,6 +6,14 @@
   list can contain, so a `<` comparison followed anywhere later in the file by
   `> (` no longer breaks parsing (#767). The rule and its one residual
   ambiguity are recorded in the developer guide's "Struct construction".
+- Enforce in typed HIR completion the rules the language reference already
+  stated: rolling-window size kinds and ranges, positive fixed list sizes, the
+  approved injectable list (`out` and `logger`; `clock` and `scheduler` agreed
+  but not implemented), `out` requiring a function output, `state` and
+  `inject` before the executable blocks, at most one `start` and `stop`, no
+  nested `when`, and no `out` or `return` in a lifecycle block. `hgl check`
+  now reports them; the backends' copies became internal assertions (#767
+  item 2).
 - Add an installed `hgl::native_package` C++ authoring API for exact scalar and
   package-declared nominal native signatures. It produces deterministic sealed
   descriptors and applies the same safety validator used by `hgl check`.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1502,8 +1502,8 @@ expression is read from the syntax tree.
   a constant expression folds into a C++ expression with the same rules
   (`/` on integers is a `Float` division, `Int` and `Float` mix to `Float`,
   strings concatenate, durations and datetimes add and subtract); known
-  numeric values are retained far enough to reject zero divisors and invalid
-  compile-time rolling sizes before C++ is written; a
+  numeric values are retained far enough to reject zero divisors before C++
+  is written (rolling and list sizes are the checker's, see below); a
   time-series expression is `hgraph::wire<marker>(w, args...)` — the
   standard operator for each infix form (`add_`, `lt_`, `and_`, ...),
   `getitem_` / `getattr_` for indexing and fields, `valid` / `modified` /
@@ -1573,8 +1573,8 @@ deterministic (basenames, no timestamps).
 The first pass still fails closed, before writing either file, on: generated
 runtime sources, calls to other HGL runtime functions, non-scalar state, opaque
 native state, output kinds other than the
-implemented scalar, nominal-struct, map, and reference forms, injectables other than
-`out` and `logger`, lifecycle access to temporal inputs or output, optional
+implemented scalar, nominal-struct, map, and reference forms, lifecycle access
+to temporal inputs, a list or rolling size given by a `const` generic, optional
 field clearing in a sparse delta, generic constructor inference and typed
 `const` generic struct metadata, tuple and list literals and other compound
 constants, runtime-node `if` or a block used as a value, temporal conditionals
@@ -1582,6 +1582,17 @@ embedded inside another expression, zoned and civil temporal literals,
 an `impl fn` of an imported operator, wiring-time access through a reference,
 unresolved collection-reference mappings, and a missing module declaration.
 Each is a diagnostic naming the construct.
+
+The rules the language reference states as semantic restrictions are typed
+HIR completion's, not a backend's (`type_check.cpp`, `check_type_shape`,
+`check_runtime_layout`, the `inject` and `out` checks): rolling-window size
+kinds and ranges, positive fixed list sizes, the approved injectable list
+(`out` and `logger` lower; `clock` and `scheduler` are agreed names that fail
+closed), `out` requiring a function output, `state` and `inject` before the
+executable blocks, at most one `start` and one `stop`, no nested `when`, and
+no `out` or `return` inside a lifecycle block. `hgl check` reports them; the
+copies both backends used to carry are now internal consistency assertions
+("typed HIR admitted ...") that a correct checker never trips.
 
 `hgl_add_module()` (`cmake/HglLanguage.cmake`, installed with `hgl`) runs
 `emit-cpp` as an `add_custom_command` per `.hgl` source, compiles the pairs

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -618,6 +618,11 @@ inject
 Capabilities are function-level declarations at the same level as `state`.
 The compiler supplies each injectable only to lifecycle or evaluation hooks
 that use it. Duplicate, unknown, and phase-incompatible injectables are errors.
+Status: `out` and `logger` are implemented; `clock` and `scheduler` are agreed
+names that `hgl check` rejects as not yet implemented; any other name is
+rejected as unapproved, and `out` requires a function output. Reading or
+writing `out` inside `start` or `stop` is rejected while lifecycle output
+access remains an open question.
 
 ## Lifecycle
 

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -941,10 +941,11 @@ namespace hgl::codegen
                         result.kind = HType::Kind::List;
                         result.children.push_back(planned_type(type.children.front(), range, bindings));
                         if (type.size.valid()) {
+                            // The checker owns the size rules (type_check.cpp,
+                            // check_type_shape); a symbolic size is a backend limit.
                             const std::optional<std::int64_t> size = planned_integer(type.size, range);
-                            if (!size || *size <= 0) {
-                                fail(Category::Type, range, "a fixed list size must be a positive i64 literal");
-                            }
+                            if (!size) { unsupported(range, "a list size given by a const generic"); }
+                            if (*size <= 0) { backend(range, "typed HIR admitted a non-positive list size"); }
                             result.size = std::to_string(*size);
                         }
                         return result;
@@ -980,14 +981,12 @@ namespace hgl::codegen
                             return result;
                         }
                         if (const auto *size = std::get_if<std::int64_t>(&*maximum.literal)) {
-                            if (*size <= 0) {
-                                fail(Category::Type, range, "a rolling size is a positive i64 constant or a duration");
-                            }
+                            if (*size <= 0) { backend(range, "typed HIR admitted a non-positive rolling size"); }
                             result.size                               = std::to_string(*size);
                             const std::optional<std::int64_t> minimum = planned_integer(type.min_size, range);
-                            if (!minimum || *minimum < 0 || *minimum > *size) {
-                                fail(Category::Type, range,
-                                     "rolling sizes require a positive maximum and a non-negative minimum no larger than it");
+                            if (!minimum) { unsupported(range, "a rolling minimum given by a const generic"); }
+                            if (*minimum <= 0 || *minimum > *size) {
+                                backend(range, "typed HIR admitted an invalid rolling minimum size");
                             }
                             result.min_size = std::to_string(*minimum);
                             return result;
@@ -997,13 +996,14 @@ namespace hgl::codegen
                             const gir::ConstExpr &minimum = graph_constant(type.min_size, range);
                             const auto           *minimum_value =
                                 minimum.literal ? std::get_if<syntax::TemporalValue>(&*minimum.literal) : nullptr;
-                            if (minimum.kind != gir::ConstExprKind::Literal || minimum_value == nullptr ||
-                                minimum_value->kind != syntax::TemporalKind::Duration) {
-                                fail(Category::Type, range, "a duration rolling minimum must be a duration literal");
+                            if (minimum.kind != gir::ConstExprKind::Literal) {
+                                unsupported(range, "a rolling minimum given by a const generic");
+                            }
+                            if (minimum_value == nullptr || minimum_value->kind != syntax::TemporalKind::Duration) {
+                                backend(range, "typed HIR admitted a rolling duration with a non-duration minimum");
                             }
                             if (size->micros <= 0 || minimum_value->micros < 0 || minimum_value->micros > size->micros) {
-                                fail(Category::Type, range,
-                                     "rolling durations require a positive maximum and a non-negative minimum no larger than it");
+                                backend(range, "typed HIR admitted an invalid rolling duration");
                             }
                             result.duration_window = true;
                             result.size            = std::to_string(size->micros);
@@ -3157,7 +3157,7 @@ namespace hgl::codegen
                                 if (target.kind == gir::BindingKind::Capability && target.name == "out") {
                                     const gir::Callable &planned = callable(frame.fn);
                                     if (!frame.output_available || !has_planned_result(planned.result, planned.range)) {
-                                        fail(Category::Phase, place.range, "'out' is not available in this lifecycle block");
+                                        backend(place.range, "typed HIR admitted 'out' in a lifecycle block");
                                     }
                                     const HType result = planned_type(planned.result, planned.range);
                                     if (result.kind != HType::Kind::Map || result.children.size() != 2U) {
@@ -3191,7 +3191,7 @@ namespace hgl::codegen
                             backend(place.range, "'" + binding.name + "' is not writable in this hook");
                         }
                         if (binding.kind == gir::BindingKind::Capability && !frame.output_available) {
-                            fail(Category::Phase, place.range, "'out' is not available in this lifecycle block");
+                            backend(place.range, "typed HIR admitted 'out' in a lifecycle block");
                         }
                         const auto current_it = frame.planned_bindings.find(reference->binding.value);
                         if (current_it == frame.planned_bindings.end()) {
@@ -3220,7 +3220,7 @@ namespace hgl::codegen
                         }
                     } else if constexpr (std::is_same_v<T, gir::Return>) {
                         if (!frame.output_available) {
-                            fail(Category::Phase, statement.range, "'return' is not available in a lifecycle block");
+                            backend(statement.range, "typed HIR admitted 'return' in a lifecycle block");
                         }
                         if (node.value.valid()) {
                             const gir::Callable &planned = callable(frame.fn);
@@ -3763,7 +3763,10 @@ namespace hgl::codegen
                                     }
                                     info.logger_binding = id;
                                 } else {
-                                    backend(binding.range, "injectable '" + binding.name + "' is not supported by emit-cpp yet");
+                                    // The checker admits only the approved names
+                                    // and rejects the agreed-but-unimplemented ones.
+                                    backend(binding.range,
+                                            "hgraph IR inject binding '" + binding.name + "' has no generated selector");
                                 }
                             }
                         } else if constexpr (std::is_same_v<T, gir::Lifecycle>) {
@@ -3786,10 +3789,10 @@ namespace hgl::codegen
                 }
             }
             if (info.start_blocks.size() > 1U) {
-                backend(planned_block(info.start_blocks[1], body.range).range, "a runtime function has at most one 'start' block");
+                backend(planned_block(info.start_blocks[1], body.range).range, "typed HIR admitted a second 'start' block");
             }
             if (info.stop_blocks.size() > 1U) {
-                backend(planned_block(info.stop_blocks[1], body.range).range, "a runtime function has at most one 'stop' block");
+                backend(planned_block(info.stop_blocks[1], body.range).range, "typed HIR admitted a second 'stop' block");
             }
             if (info.has_when && info.active_parameters.empty()) {
                 backend(planned.range, "a generated runtime function with 'when' needs a temporal parameter in 'modified(...)'");

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -414,11 +414,12 @@ namespace hgl::ir
             }
 
             /// The placement rules of syntax-and-semantics.md "Runtime function
-            /// bodies": `state` and `inject` precede the executable blocks, a
-            /// function has at most one `start` and one `stop`, and `when` is
-            /// never nested, because a nested handler cannot contribute to the
-            /// node's activation policy. Semantic checks, so each diagnostic
-            /// names the misplaced construct.
+            /// bodies": `state`, `inject`, `start`, `stop`, and `when` are
+            /// function-level forms; `state` and `inject` precede the executable
+            /// blocks; a function has at most one `start` and one `stop`; and
+            /// `when` is never nested, because a nested handler cannot
+            /// contribute to the node's activation policy. Semantic checks, so
+            /// each diagnostic names the misplaced construct.
             void check_runtime_layout(BlockId body) {
                 bool        executable_seen = false;
                 std::size_t starts          = 0;
@@ -434,6 +435,7 @@ namespace hgl::ir
                                                         std::string{"'"} + (std::is_same_v<T, StateDecl> ? "state" : "inject") +
                                                             "' must be declared before runtime handlers");
                                 }
+                                if constexpr (std::is_same_v<T, StateDecl>) { reject_nested_function_level_in(node.init); }
                             } else if constexpr (std::is_same_v<T, LifecycleBlock>) {
                                 executable_seen    = true;
                                 std::size_t &count = node.is_stop ? stops : starts;
@@ -442,18 +444,13 @@ namespace hgl::ir
                                                         std::string{"a runtime function has at most one '"} +
                                                             (node.is_stop ? "stop" : "start") + "' block");
                                 }
-                                reject_nested_when(node.block);
+                                reject_nested_function_level(node.block);
                             } else if constexpr (std::is_same_v<T, WhenStmt>) {
                                 executable_seen = true;
-                                reject_nested_when(node.block);
-                            } else if constexpr (std::is_same_v<T, ForStmt>) {
-                                reject_nested_when(node.block);
-                            } else if constexpr (std::is_same_v<T, LocalDecl>) {
-                                reject_nested_when_in(node.init);
-                            } else if constexpr (std::is_same_v<T, AssignStmt>) {
-                                reject_nested_when_in(node.value);
-                            } else if constexpr (std::is_same_v<T, ReturnStmt> || std::is_same_v<T, ExprStmt>) {
-                                reject_nested_when_in(expression_of(node));
+                                reject_nested_function_level_in(node.condition);
+                                reject_nested_function_level(node.block);
+                            } else {
+                                reject_nested_function_level_in_statement(node);
                             }
                         },
                         statement.node);
@@ -468,7 +465,29 @@ namespace hgl::ir
                 }
             }
 
-            void reject_nested_when(BlockId id) {
+            /// The ordinary statements' expressions and nested blocks.
+            template <typename Node> void reject_nested_function_level_in_statement(const Node &node) {
+                if constexpr (std::is_same_v<Node, ForStmt>) {
+                    reject_nested_function_level_in(node.iterable);
+                    reject_nested_function_level(node.block);
+                } else if constexpr (std::is_same_v<Node, LocalDecl>) {
+                    reject_nested_function_level_in(node.init);
+                } else if constexpr (std::is_same_v<Node, AssignStmt>) {
+                    reject_nested_function_level_in(node.place);
+                    reject_nested_function_level_in(node.value);
+                } else if constexpr (std::is_same_v<Node, AssertStmt>) {
+                    reject_nested_function_level_in(node.condition);
+                } else if constexpr (std::is_same_v<Node, ReturnStmt> || std::is_same_v<Node, ExprStmt>) {
+                    reject_nested_function_level_in(expression_of(node));
+                }
+            }
+
+            /// Every statement of a block nested inside a runtime body: the
+            /// function-level forms are diagnosed, and everything is walked,
+            /// including the expressions, so a block hidden inside a call
+            /// argument, operand, element, or lambda cannot carry one past the
+            /// checker.
+            void reject_nested_function_level(BlockId id) {
                 if (!id.valid()) { return; }
                 const Block &block = module_.block(id);
                 for (StmtId stmt_id : block.statements) {
@@ -480,31 +499,66 @@ namespace hgl::ir
                                 diagnostics_.report(syntax::Category::FunctionKind, statement.range,
                                                     "'when' cannot be nested in another block; it declares "
                                                     "node-level activation");
-                                reject_nested_when(node.block);
-                            } else if constexpr (std::is_same_v<T, LifecycleBlock> || std::is_same_v<T, ForStmt>) {
-                                reject_nested_when(node.block);
-                            } else if constexpr (std::is_same_v<T, LocalDecl>) {
-                                reject_nested_when_in(node.init);
-                            } else if constexpr (std::is_same_v<T, AssignStmt>) {
-                                reject_nested_when_in(node.value);
-                            } else if constexpr (std::is_same_v<T, ReturnStmt> || std::is_same_v<T, ExprStmt>) {
-                                reject_nested_when_in(expression_of(node));
+                                reject_nested_function_level_in(node.condition);
+                                reject_nested_function_level(node.block);
+                            } else if constexpr (std::is_same_v<T, LifecycleBlock>) {
+                                diagnostics_.report(syntax::Category::FunctionKind, statement.range,
+                                                    std::string{"'"} + (node.is_stop ? "stop" : "start") +
+                                                        "' must be a function-level block, not nested in another block");
+                                reject_nested_function_level(node.block);
+                            } else if constexpr (std::is_same_v<T, StateDecl> || std::is_same_v<T, InjectDecl>) {
+                                diagnostics_.report(syntax::Category::FunctionKind, statement.range,
+                                                    std::string{"'"} + (std::is_same_v<T, StateDecl> ? "state" : "inject") +
+                                                        "' must be declared at function level, not inside a block");
+                                if constexpr (std::is_same_v<T, StateDecl>) { reject_nested_function_level_in(node.init); }
+                            } else {
+                                reject_nested_function_level_in_statement(node);
                             }
                         },
                         statement.node);
                 }
-                reject_nested_when_in(block.tail);
+                reject_nested_function_level_in(block.tail);
             }
 
-            void reject_nested_when_in(ExprId id) {
+            void reject_nested_function_level_in(ExprId id) {
                 if (!id.valid()) { return; }
                 const Expr &expression = module_.expr(id);
-                if (const auto *conditional = std::get_if<If>(&expression.node)) {
-                    reject_nested_when(conditional->then_block);
-                    reject_nested_when_in(conditional->otherwise);
-                } else if (const auto *block = std::get_if<BlockExpr>(&expression.node)) {
-                    reject_nested_when(block->block);
-                }
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, Unary>) {
+                            reject_nested_function_level_in(node.operand);
+                        } else if constexpr (std::is_same_v<T, Binary>) {
+                            reject_nested_function_level_in(node.lhs);
+                            reject_nested_function_level_in(node.rhs);
+                        } else if constexpr (std::is_same_v<T, Call> || std::is_same_v<T, Eval>) {
+                            reject_nested_function_level_in(node.callee);
+                            for (const Argument &argument : node.arguments) { reject_nested_function_level_in(argument.value); }
+                        } else if constexpr (std::is_same_v<T, Construct>) {
+                            for (const Argument &argument : node.arguments) { reject_nested_function_level_in(argument.value); }
+                        } else if constexpr (std::is_same_v<T, Index>) {
+                            reject_nested_function_level_in(node.target);
+                            reject_nested_function_level_in(node.index);
+                        } else if constexpr (std::is_same_v<T, Field>) {
+                            reject_nested_function_level_in(node.target);
+                        } else if constexpr (std::is_same_v<T, Sequence>) {
+                            for (const SequenceElement &element : node.elements) {
+                                reject_nested_function_level_in(element.key);
+                                reject_nested_function_level_in(element.value);
+                            }
+                        } else if constexpr (std::is_same_v<T, Tuple>) {
+                            for (ExprId element : node.elements) { reject_nested_function_level_in(element); }
+                        } else if constexpr (std::is_same_v<T, Lambda>) {
+                            reject_nested_function_level_in(node.body);
+                        } else if constexpr (std::is_same_v<T, If>) {
+                            reject_nested_function_level_in(node.condition);
+                            reject_nested_function_level(node.then_block);
+                            reject_nested_function_level_in(node.otherwise);
+                        } else if constexpr (std::is_same_v<T, BlockExpr>) {
+                            reject_nested_function_level(node.block);
+                        }
+                    },
+                    expression.node);
             }
 
             void require_assignable(TypeId expected, const Expr &actual, std::string_view what) {
@@ -578,6 +632,15 @@ namespace hgl::ir
                 if (value.kind == TypeKind::List) {
                     if (!value.size.valid()) { return; }
                     const Expr &size = module_.expr(value.size);
+                    // A symbolic size (`list<T, n>` with `const n`) has no folded
+                    // value but does have a declared type, which must be i64.
+                    if (size.type.valid()) {
+                        const Type &size_type = type(canonical(size.type));
+                        if (size_type.kind != TypeKind::Scalar || size_type.scalar != ScalarType::I64) {
+                            type_error(size.range, "a list size must be an i64 constant or 'unbounded'");
+                            return;
+                        }
+                    }
                     if (!size.constant) { return; }
                     const auto *count = std::get_if<std::int64_t>(&*size.constant);
                     if (count == nullptr || *count <= 0) {

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -373,6 +373,9 @@ namespace hgl::ir
                                 node.effects = body.effects;
                             }
                             collect_capabilities(node, id);
+                            if (node.kind == FunctionKind::Runtime && node.block_body.valid()) {
+                                check_runtime_layout(node.block_body);
+                            }
                         } else if constexpr (std::is_same_v<T, TestDecl>) {
                             active_native_phase_ = NativePhase::Wiring;
                             validate_owned_type_applications(id);
@@ -403,8 +406,104 @@ namespace hgl::ir
                 for (const Stmt &statement : module_.stmts) {
                     if (statement.owner != owner) { continue; }
                     if (const auto *inject = std::get_if<InjectDecl>(&statement.node)) {
+                        // A repeated name is a resolver error ("declared twice
+                        // in the block"), so the list is duplicate-free here.
                         fn.capabilities.insert(fn.capabilities.end(), inject->symbols.begin(), inject->symbols.end());
                     }
+                }
+            }
+
+            /// The placement rules of syntax-and-semantics.md "Runtime function
+            /// bodies": `state` and `inject` precede the executable blocks, a
+            /// function has at most one `start` and one `stop`, and `when` is
+            /// never nested, because a nested handler cannot contribute to the
+            /// node's activation policy. Semantic checks, so each diagnostic
+            /// names the misplaced construct.
+            void check_runtime_layout(BlockId body) {
+                bool        executable_seen = false;
+                std::size_t starts          = 0;
+                std::size_t stops           = 0;
+                for (StmtId id : module_.block(body).statements) {
+                    const Stmt &statement = module_.stmt(id);
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, StateDecl> || std::is_same_v<T, InjectDecl>) {
+                                if (executable_seen) {
+                                    diagnostics_.report(syntax::Category::FunctionKind, statement.range,
+                                                        std::string{"'"} + (std::is_same_v<T, StateDecl> ? "state" : "inject") +
+                                                            "' must be declared before runtime handlers");
+                                }
+                            } else if constexpr (std::is_same_v<T, LifecycleBlock>) {
+                                executable_seen    = true;
+                                std::size_t &count = node.is_stop ? stops : starts;
+                                if (++count > 1U) {
+                                    diagnostics_.report(syntax::Category::FunctionKind, statement.range,
+                                                        std::string{"a runtime function has at most one '"} +
+                                                            (node.is_stop ? "stop" : "start") + "' block");
+                                }
+                                reject_nested_when(node.block);
+                            } else if constexpr (std::is_same_v<T, WhenStmt>) {
+                                executable_seen = true;
+                                reject_nested_when(node.block);
+                            } else if constexpr (std::is_same_v<T, ForStmt>) {
+                                reject_nested_when(node.block);
+                            } else if constexpr (std::is_same_v<T, LocalDecl>) {
+                                reject_nested_when_in(node.init);
+                            } else if constexpr (std::is_same_v<T, AssignStmt>) {
+                                reject_nested_when_in(node.value);
+                            } else if constexpr (std::is_same_v<T, ReturnStmt> || std::is_same_v<T, ExprStmt>) {
+                                reject_nested_when_in(expression_of(node));
+                            }
+                        },
+                        statement.node);
+                }
+            }
+
+            template <typename Node> [[nodiscard]] static ExprId expression_of(const Node &node) {
+                if constexpr (std::is_same_v<Node, ReturnStmt>) {
+                    return node.value;
+                } else {
+                    return node.expr;
+                }
+            }
+
+            void reject_nested_when(BlockId id) {
+                if (!id.valid()) { return; }
+                const Block &block = module_.block(id);
+                for (StmtId stmt_id : block.statements) {
+                    const Stmt &statement = module_.stmt(stmt_id);
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, WhenStmt>) {
+                                diagnostics_.report(syntax::Category::FunctionKind, statement.range,
+                                                    "'when' cannot be nested in another block; it declares "
+                                                    "node-level activation");
+                                reject_nested_when(node.block);
+                            } else if constexpr (std::is_same_v<T, LifecycleBlock> || std::is_same_v<T, ForStmt>) {
+                                reject_nested_when(node.block);
+                            } else if constexpr (std::is_same_v<T, LocalDecl>) {
+                                reject_nested_when_in(node.init);
+                            } else if constexpr (std::is_same_v<T, AssignStmt>) {
+                                reject_nested_when_in(node.value);
+                            } else if constexpr (std::is_same_v<T, ReturnStmt> || std::is_same_v<T, ExprStmt>) {
+                                reject_nested_when_in(expression_of(node));
+                            }
+                        },
+                        statement.node);
+                }
+                reject_nested_when_in(block.tail);
+            }
+
+            void reject_nested_when_in(ExprId id) {
+                if (!id.valid()) { return; }
+                const Expr &expression = module_.expr(id);
+                if (const auto *conditional = std::get_if<If>(&expression.node)) {
+                    reject_nested_when(conditional->then_block);
+                    reject_nested_when_in(conditional->otherwise);
+                } else if (const auto *block = std::get_if<BlockExpr>(&expression.node)) {
+                    reject_nested_when(block->block);
                 }
             }
 
@@ -463,6 +562,81 @@ namespace hgl::ir
                     check_constant(value.min_size);
                     for (const TypeArgument &argument : value.arguments) {
                         if (argument.kind == TypeArgumentKind::Value) { check_constant(argument.value); }
+                    }
+                    check_type_shape(value);
+                }
+            }
+
+            /// The size rules of syntax-and-semantics.md "Time-series
+            /// collections": a fixed list size is a positive constant; a
+            /// rolling window's sizes are both `i64` or both `duration`; tick
+            /// sizes are positive, a duration minimum may be `0s`, and no
+            /// minimum exceeds its maximum. A symbolic size (an in-scope
+            /// `const` generic) carries its declared kind and has no value to
+            /// range-check here.
+            void check_type_shape(const Type &value) {
+                if (value.kind == TypeKind::List) {
+                    if (!value.size.valid()) { return; }
+                    const Expr &size = module_.expr(value.size);
+                    if (!size.constant) { return; }
+                    const auto *count = std::get_if<std::int64_t>(&*size.constant);
+                    if (count == nullptr || *count <= 0) {
+                        type_error(size.range, "list size must be a positive constant or 'unbounded'");
+                    }
+                    return;
+                }
+                if (value.kind != TypeKind::Rolling || !value.size.valid()) { return; }
+                const Expr &maximum = module_.expr(value.size);
+                const Expr *minimum = value.min_size.valid() ? &module_.expr(value.min_size) : nullptr;
+                enum class SizeKind : std::uint8_t { Unknown, Tick, Duration, Other };
+                // Source types are not yet canonicalized when this runs, so
+                // classify by the scalar itself rather than by interned identity.
+                const auto size_kind = [&](const Expr &expression) {
+                    if (!expression.type.valid()) { return SizeKind::Unknown; }
+                    const Type &size_type = type(canonical(expression.type));
+                    if (size_type.kind != TypeKind::Scalar) { return SizeKind::Other; }
+                    if (size_type.scalar == ScalarType::I64) { return SizeKind::Tick; }
+                    if (size_type.scalar == ScalarType::Duration) { return SizeKind::Duration; }
+                    return SizeKind::Other;
+                };
+                const SizeKind max_kind = size_kind(maximum);
+                const SizeKind min_kind = minimum != nullptr ? size_kind(*minimum) : max_kind;
+                if (max_kind == SizeKind::Other || min_kind == SizeKind::Other) {
+                    type_error(max_kind == SizeKind::Other ? maximum.range : minimum->range,
+                               "a rolling size must be an i64 or duration constant");
+                    return;
+                }
+                if (max_kind != SizeKind::Unknown && min_kind != SizeKind::Unknown && max_kind != min_kind) {
+                    type_error(minimum->range, "rolling sizes must both be i64 or both be duration");
+                    return;
+                }
+                const auto tick = [](const Expr &expression) -> std::optional<std::int64_t> {
+                    if (!expression.constant) { return std::nullopt; }
+                    if (const auto *count = std::get_if<std::int64_t>(&*expression.constant)) { return *count; }
+                    return std::nullopt;
+                };
+                const auto micros = [](const Expr &expression) -> std::optional<std::int64_t> {
+                    if (!expression.constant) { return std::nullopt; }
+                    const auto *temporal = std::get_if<syntax::TemporalValue>(&*expression.constant);
+                    if (temporal == nullptr || temporal->kind != syntax::TemporalKind::Duration) { return std::nullopt; }
+                    return temporal->micros;
+                };
+                const syntax::SourceRange minimum_range = minimum != nullptr ? minimum->range : maximum.range;
+                if (max_kind == SizeKind::Tick) {
+                    const std::optional<std::int64_t> max_value = tick(maximum);
+                    const std::optional<std::int64_t> min_value = minimum != nullptr ? tick(*minimum) : max_value;
+                    if (max_value && *max_value <= 0) {
+                        type_error(maximum.range, "a rolling tick size must be positive");
+                    } else if (min_value && (*min_value <= 0 || (max_value && *min_value > *max_value))) {
+                        type_error(minimum_range, "a rolling minimum size must be positive and no larger than the maximum");
+                    }
+                } else if (max_kind == SizeKind::Duration) {
+                    const std::optional<std::int64_t> max_value = micros(maximum);
+                    const std::optional<std::int64_t> min_value = minimum != nullptr ? micros(*minimum) : max_value;
+                    if (max_value && *max_value <= 0) {
+                        type_error(maximum.range, "a rolling duration must be positive");
+                    } else if (min_value && (*min_value < 0 || (max_value && *min_value > *max_value))) {
+                        type_error(minimum_range, "a rolling minimum duration must be non-negative and no longer than the maximum");
                     }
                 }
             }
@@ -580,6 +754,15 @@ namespace hgl::ir
                         expression.effects    = Effect::ReadState;
                         break;
                     case SymbolKind::InjectedCapability:
+                        // Output access during lifecycle hooks is an open
+                        // question (language-model.md); the checker rejects it
+                        // rather than leaving it to a backend.
+                        if (symbol.name == "out" &&
+                            (active_native_phase_ == NativePhase::Start || active_native_phase_ == NativePhase::Stop)) {
+                            diagnostics_.report(syntax::Category::Phase, expression.range,
+                                                std::string{"'out' is not available during "} +
+                                                    (active_native_phase_ == NativePhase::Stop ? "stop" : "start"));
+                        }
                         expression.type       = canonical(symbol.type);
                         expression.phase      = Phase::Runtime;
                         expression.value_kind = symbol.name == "out" ? ValueKind::RuntimeValue : ValueKind::Function;
@@ -1876,9 +2059,30 @@ namespace hgl::ir
                             FunctionDecl *fn = function(statement.owner);
                             for (SymbolId symbol_id : node.symbols) {
                                 Symbol &symbol = module_.symbols[symbol_id.value];
+                                // `inject` names compiler-approved capabilities only
+                                // (syntax-and-semantics.md, "Runtime state,
+                                // injectables, and lifecycle"). `out` and `logger`
+                                // lower today; `clock` and `scheduler` are agreed
+                                // and fail closed until their selectors exist.
                                 if (symbol.name == "out") {
+                                    const TypeId result = fn != nullptr ? fn->signature.result : TypeId{};
+                                    if (!result.valid() || same(result, void_type_)) {
+                                        diagnostics_.report(syntax::Category::Injectable, symbol.range,
+                                                            "'out' requires a function output");
+                                    }
                                     symbol.type = fn ? fn->signature.result : void_type_;
                                 } else {
+                                    if (symbol.name == "clock" || symbol.name == "scheduler") {
+                                        diagnostics_.report(syntax::Category::Injectable, symbol.range,
+                                                            "the '" + symbol.name +
+                                                                "' injectable is agreed but not implemented yet; "
+                                                                "'out' and 'logger' are available");
+                                    } else if (symbol.name != "logger") {
+                                        diagnostics_.report(syntax::Category::Injectable, symbol.range,
+                                                            "'" + symbol.name +
+                                                                "' is not an approved runtime capability; the "
+                                                                "injectables are out, logger, clock, and scheduler");
+                                    }
                                     symbol.type = make_type(TypeKind::Capability, {}, symbol_id);
                                 }
                                 symbol_phase_[symbol_id.value] = Phase::Runtime;
@@ -1928,6 +2132,11 @@ namespace hgl::ir
                                 }
                             }
                         } else if constexpr (std::is_same_v<T, ReturnStmt>) {
+                            if (active_native_phase_ == NativePhase::Start || active_native_phase_ == NativePhase::Stop) {
+                                diagnostics_.report(syntax::Category::Phase, statement.range,
+                                                    std::string{"'return' is not available during "} +
+                                                        (active_native_phase_ == NativePhase::Stop ? "stop" : "start"));
+                            }
                             Expr &value = check_expr(node.value, expected_return);
                             require_assignable(expected_return, value, "return value");
                             statement.effects = value.effects;

--- a/language/src/wiring/type_bridge.cpp
+++ b/language/src/wiring/type_bridge.cpp
@@ -387,28 +387,30 @@ namespace hgl::wiring
                     const std::optional<hgraph::Value> period_value  = literal(type.size);
                     const std::optional<hgraph::Value> minimum_value = literal(type.min_size);
                     if (!period_value || !minimum_value) { return nullptr; }
+                    // The checker owns the size rules (type_check.cpp, check_type_shape);
+                    // what remains here guards the materialization against a
+                    // typed HIR that did not enforce them.
                     if (period_value->schema() == types_.timedelta_type) {
                         if (minimum_value->schema() != types_.timedelta_type) {
-                            report(type.range, "a minimum rolling duration must be a duration constant");
+                            report(type.range, "typed HIR admitted a rolling duration with a non-duration minimum");
                             return nullptr;
                         }
                         const hgraph::TimeDelta period  = period_value->view().checked_as<hgraph::TimeDelta>();
                         const hgraph::TimeDelta minimum = minimum_value->view().checked_as<hgraph::TimeDelta>();
                         if (period <= hgraph::TimeDelta{0} || minimum < hgraph::TimeDelta{0} || minimum > period) {
-                            report(type.range,
-                                   "rolling durations require a positive maximum and a non-negative minimum no larger than it");
+                            report(type.range, "typed HIR admitted an invalid rolling duration");
                             return nullptr;
                         }
                         return registry_.tsw_duration(element, period, minimum);
                     }
                     if (period_value->schema() != types_.int_type || minimum_value->schema() != types_.int_type) {
-                        report(type.range, "a rolling size must be an i64 or duration constant");
+                        report(type.range, "typed HIR admitted a rolling size that is neither i64 nor duration");
                         return nullptr;
                     }
                     const std::int64_t period  = period_value->view().checked_as<hgraph::Int>();
                     const std::int64_t minimum = minimum_value->view().checked_as<hgraph::Int>();
-                    if (period <= 0 || minimum < 0 || minimum > period) {
-                        report(type.range, "rolling sizes require a positive maximum and a non-negative minimum no larger than it");
+                    if (period <= 0 || minimum <= 0 || minimum > period) {
+                        report(type.range, "typed HIR admitted an invalid rolling minimum size");
                         return nullptr;
                     }
                     return registry_.tsw(element, static_cast<std::size_t>(period), static_cast<std::size_t>(minimum));

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -1763,7 +1763,9 @@ export fn sampled(value: f64) {
 }
 )"};
         CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Backend, "a 'when' block must be at function top level"));
+        // Placement is the checker's rule (#767 item 2); the emitter never
+        // sees a nested handler.
+        CHECK(unit.has(Category::FunctionKind, "'when' cannot be nested in another block"));
     }
 }
 
@@ -1801,13 +1803,15 @@ export fn seeded(x: f64) -> f64 {
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Phase, "temporal parameters are not available in runtime lifecycle blocks"));
     }
+    // The size rules below are typed HIR completion's (#767 item 2); they
+    // reach the emitter as diagnostics of the unit, never as emitter guards.
     SECTION("a non-positive rolling size") {
         Unit unit{R"(
 module t
 export fn recent(window: rolling<f64, 0>) -> f64 => 1.0
 )"};
         CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Type, "a rolling size is a positive i64 constant or a duration"));
+        CHECK(unit.has(Category::Type, "a rolling tick size must be positive"));
     }
     SECTION("a negative rolling size") {
         Unit unit{R"(
@@ -1815,7 +1819,7 @@ module t
 export fn recent(window: rolling<f64, -1>) -> f64 => 1.0
 )"};
         CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Type, "a rolling size is a positive i64 constant or a duration"));
+        CHECK(unit.has(Category::Type, "a rolling tick size must be positive"));
     }
     SECTION("a rolling minimum larger than its maximum") {
         Unit unit{R"(
@@ -1823,7 +1827,7 @@ module t
 export fn recent(window: rolling<f64, 5, 6>) -> f64 => 1.0
 )"};
         CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Type, "minimum no larger than it"));
+        CHECK(unit.has(Category::Type, "a rolling minimum size must be positive and no larger than the maximum"));
     }
     SECTION("a zero fixed list size") {
         Unit unit{R"(
@@ -1831,7 +1835,7 @@ module t
 export fn recent(values: list<f64, 0>) -> f64 => 1.0
 )"};
         CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Type, "a fixed list size must be a positive i64 literal"));
+        CHECK(unit.has(Category::Type, "list size must be a positive constant or 'unbounded'"));
     }
     SECTION("a missing module declaration") {
         // The front end rejects the unit before the emitter sees it; the

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -1499,3 +1499,115 @@ TEST_CASE("HIR lowering reports an unresolved identity instead of fabricating on
     REQUIRE(reference != nullptr);
     CHECK_FALSE(reference->symbol.valid());
 }
+
+// ---------------------------------------------------------------- #767 item 2:
+// the language reference's shape, injectable and placement rules are typed-HIR
+// diagnostics, not backend afterthoughts.
+
+namespace
+{
+    std::string completion_diagnostics(std::string source) {
+        Lowered lowered{std::move(source)};
+        require_clean(lowered);
+        CHECK_FALSE(complete(lowered));
+        return lowered.diagnostics.render(lowered.file);
+    }
+
+    bool completes(std::string source) {
+        Lowered lowered{std::move(source)};
+        require_clean(lowered);
+        const bool ok = complete(lowered);
+        INFO(lowered.diagnostics.render(lowered.file));
+        return ok;
+    }
+}  // namespace
+
+TEST_CASE("typed HIR enforces rolling and list size rules", "[ir][typed][shape]") {
+    CHECK(completes("module checks.sizes_ok\n"
+                    "export fn a(w: rolling<f64, 20, 5>, v: rolling<f64, 5m, 0s>, xs: list<f64, 3>) -> f64 => 1.0\n"
+                    "export fn b<T, const n: i64>(xs: list<T, n>, w: rolling<T, n>) -> f64 => 1.0\n"));
+    CHECK(completion_diagnostics("module checks.rolling_mixed\n"
+                                 "export fn f(w: rolling<f64, 5m, 3>) -> f64 => 1.0\n")
+              .find("rolling sizes must both be i64 or both be duration") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.rolling_min\n"
+                                 "export fn f(w: rolling<f64, 20, 25>) -> f64 => 1.0\n")
+              .find("a rolling minimum size must be positive and no larger than the maximum") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.rolling_zero\n"
+                                 "export fn f(w: rolling<f64, 0>) -> f64 => 1.0\n")
+              .find("a rolling tick size must be positive") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.rolling_zero_min\n"
+                                 "export fn f(w: rolling<f64, 20, 0>) -> f64 => 1.0\n")
+              .find("a rolling minimum size must be positive") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.rolling_long_min\n"
+                                 "export fn f(w: rolling<f64, 5m, 6m>) -> f64 => 1.0\n")
+              .find("a rolling minimum duration must be non-negative and no longer than the maximum") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.list_zero\n"
+                                 "export fn f(xs: list<f64, 0>) -> f64 => 1.0\n")
+              .find("list size must be a positive constant or 'unbounded'") != std::string::npos);
+}
+
+TEST_CASE("typed HIR admits only approved injectables", "[ir][typed][injectable]") {
+    CHECK(completes("module checks.inject_ok\n"
+                    "fn f(value: f64) -> f64 {\n"
+                    "    inject out, logger\n"
+                    "    when modified(value) { out = value }\n"
+                    "}\n"));
+    CHECK(completion_diagnostics("module checks.inject_unknown\n"
+                                 "fn f(value: f64) -> f64 {\n"
+                                 "    inject out, banana\n"
+                                 "    when modified(value) { out = value }\n"
+                                 "}\n")
+              .find("injectable: 'banana' is not an approved runtime capability") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.inject_clock\n"
+                                 "fn f(value: f64) -> f64 {\n"
+                                 "    inject out, clock\n"
+                                 "    when modified(value) { out = value }\n"
+                                 "}\n")
+              .find("injectable: the 'clock' injectable is agreed but not implemented yet") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.inject_outputless\n"
+                                 "fn f(value: f64) {\n"
+                                 "    inject out\n"
+                                 "    when modified(value) { out = value }\n"
+                                 "}\n")
+              .find("injectable: 'out' requires a function output") != std::string::npos);
+}
+
+TEST_CASE("typed HIR enforces runtime body placement", "[ir][typed][function-kind]") {
+    CHECK(completion_diagnostics("module checks.late_state\n"
+                                 "fn f(value: f64) -> f64 {\n"
+                                 "    inject out\n"
+                                 "    when modified(value) { out = value }\n"
+                                 "    state total: f64 = 0.0\n"
+                                 "}\n")
+              .find("function-kind: 'state' must be declared before runtime handlers") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.nested_when\n"
+                                 "fn f(value: f64) -> f64 {\n"
+                                 "    inject out\n"
+                                 "    when modified(value) {\n"
+                                 "        when valid(value) { out = value }\n"
+                                 "    }\n"
+                                 "}\n")
+              .find("function-kind: 'when' cannot be nested in another block") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.two_starts\n"
+                                 "fn f(value: f64) -> f64 {\n"
+                                 "    inject out, logger\n"
+                                 "    start { logger.info(\"a\") }\n"
+                                 "    start { logger.info(\"b\") }\n"
+                                 "    when modified(value) { out = value }\n"
+                                 "}\n")
+              .find("function-kind: a runtime function has at most one 'start' block") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.out_in_stop\n"
+                                 "fn f(value: f64) -> f64 {\n"
+                                 "    inject out\n"
+                                 "    when modified(value) { out = value }\n"
+                                 "    stop { out = 0.0 }\n"
+                                 "}\n")
+              .find("phase: 'out' is not available during stop") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.return_in_start\n"
+                                 "fn f(value: f64) -> f64 {\n"
+                                 "    inject out\n"
+                                 "    start { return 1.0 }\n"
+                                 "    when modified(value) { out = value }\n"
+                                 "}\n")
+              .find("phase: 'return' is not available during start") != std::string::npos);
+}

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -1544,6 +1544,10 @@ TEST_CASE("typed HIR enforces rolling and list size rules", "[ir][typed][shape]"
     CHECK(completion_diagnostics("module checks.list_zero\n"
                                  "export fn f(xs: list<f64, 0>) -> f64 => 1.0\n")
               .find("list size must be a positive constant or 'unbounded'") != std::string::npos);
+    // A symbolic size has no folded value but does have a declared kind.
+    CHECK(completion_diagnostics("module checks.list_duration_size\n"
+                                 "export fn f<const n: duration>(xs: list<f64, n>) -> f64 => 1.0\n")
+              .find("a list size must be an i64 constant or 'unbounded'") != std::string::npos);
 }
 
 TEST_CASE("typed HIR admits only approved injectables", "[ir][typed][injectable]") {
@@ -1610,4 +1614,32 @@ TEST_CASE("typed HIR enforces runtime body placement", "[ir][typed][function-kin
                                  "    when modified(value) { out = value }\n"
                                  "}\n")
               .find("phase: 'return' is not available during start") != std::string::npos);
+    // Function-level forms hidden inside nested blocks and expressions.
+    CHECK(completion_diagnostics("module checks.nested_start\n"
+                                 "fn f(value: f64) -> f64 {\n"
+                                 "    inject out, logger\n"
+                                 "    when modified(value) {\n"
+                                 "        start { logger.info(\"late\") }\n"
+                                 "        out = value\n"
+                                 "    }\n"
+                                 "}\n")
+              .find("function-kind: 'start' must be a function-level block, not nested in another block") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.nested_state\n"
+                                 "fn f(value: f64) -> f64 {\n"
+                                 "    inject out\n"
+                                 "    when modified(value) {\n"
+                                 "        state total: f64 = 0.0\n"
+                                 "        out = value\n"
+                                 "    }\n"
+                                 "}\n")
+              .find("function-kind: 'state' must be declared at function level, not inside a block") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.when_in_operand\n"
+                                 "fn f(value: f64) -> f64 {\n"
+                                 "    inject out\n"
+                                 "    when modified(value) {\n"
+                                 "        out = 1.0 + { when valid(value) { out = value }\n"
+                                 "                      value }\n"
+                                 "    }\n"
+                                 "}\n")
+              .find("function-kind: 'when' cannot be nested in another block") != std::string::npos);
 }

--- a/language/tests/wiring/type_bridge_tests.cpp
+++ b/language/tests/wiring/type_bridge_tests.cpp
@@ -217,17 +217,18 @@ fn consume(values: list<f64, 3>) -> list<f64, 3> => values
     CHECK_FALSE(unit.diagnostics.has_errors());
 }
 
-TEST_CASE("hgraph IR type materialization rejects unusable fixed extents", "[wiring][hgraph-ir][types]") {
+// The size rules are typed HIR completion's (#767 item 2); the bridge's own
+// guards are internal assertions it never reaches from a checked module.
+TEST_CASE("typed HIR rejects unusable fixed extents before materialization", "[wiring][hgraph-ir][types]") {
     SECTION("zero-sized fixed list") {
         Unit unit{R"(
 module checks.zero_list
 fn consume(values: list<f64, 0>) -> list<f64, 0> => values
 )"};
         INFO(unit.diagnostics.render(unit.file));
-        REQUIRE_FALSE(unit.diagnostics.has_errors());
-        hgl::wiring::TypeBridge bridge{unit.graph, unit.diagnostics};
-        CHECK(bridge.schema(unit.parameter("consume", "values")) == nullptr);
-        CHECK(unit.diagnostics.render(unit.file).find("fixed list size must be positive") != std::string::npos);
+        CHECK(unit.diagnostics.has_errors());
+        CHECK(unit.diagnostics.render(unit.file).find("type: list size must be a positive constant or 'unbounded'") !=
+              std::string::npos);
     }
 
     SECTION("tick minimum exceeds capacity") {
@@ -236,10 +237,9 @@ module checks.tick_window
 fn consume(values: rolling<f64, 20, 25>) -> rolling<f64, 20, 25> => values
 )"};
         INFO(unit.diagnostics.render(unit.file));
-        REQUIRE_FALSE(unit.diagnostics.has_errors());
-        hgl::wiring::TypeBridge bridge{unit.graph, unit.diagnostics};
-        CHECK(bridge.schema(unit.parameter("consume", "values")) == nullptr);
-        CHECK(unit.diagnostics.render(unit.file).find("minimum no larger than it") != std::string::npos);
+        CHECK(unit.diagnostics.has_errors());
+        CHECK(unit.diagnostics.render(unit.file).find("a rolling minimum size must be positive and no larger than the maximum") !=
+              std::string::npos);
     }
 
     SECTION("duration minimum exceeds maximum") {
@@ -248,9 +248,8 @@ module checks.duration_window
 fn consume(values: rolling<f64, 1s, 2s>) -> rolling<f64, 1s, 2s> => values
 )"};
         INFO(unit.diagnostics.render(unit.file));
-        REQUIRE_FALSE(unit.diagnostics.has_errors());
-        hgl::wiring::TypeBridge bridge{unit.graph, unit.diagnostics};
-        CHECK(bridge.schema(unit.parameter("consume", "values")) == nullptr);
-        CHECK(unit.diagnostics.render(unit.file).find("minimum no larger than it") != std::string::npos);
+        CHECK(unit.diagnostics.has_errors());
+        CHECK(unit.diagnostics.render(unit.file).find(
+                  "a rolling minimum duration must be non-negative and no longer than the maximum") != std::string::npos);
     }
 }


### PR DESCRIPTION
Corrective roadmap item 2 of #767 ("Checker enforcement: the frontend owns the rules").

## Problem

The language reference (`syntax-and-semantics.md`, "Time-series collections" and "Runtime function bodies") states these as semantic restrictions, and `compiler-architecture.md` requires invalid phase transitions to be rejected before HIR is complete. In practice only `emit-cpp` (and the direct backend's type bridge) applied them, so `hgl check` silently accepted:

- `rolling<f64, 5m, 3>` (mixed size kinds), `rolling<f64, 20, 25>` (minimum above maximum), `rolling<f64, 0>`, `list<f64, 0>`;
- `inject out, banana` (any name), `inject out, clock` (agreed, not implemented), `inject out` in an outputless function;
- `state` after `when`, two `start` blocks, a `when` nested in a block, `out` written in `stop`, `return` in `start`.

## Change

`type_check.cpp` gains `check_type_shape`, `check_runtime_layout`, the `inject` name checks and the lifecycle `out`/`return` phase checks; each diagnostic uses the category the reference assigns (`type`, `injectable`, `function-kind`, `phase`) and names the construct, e.g.

```
type: rolling sizes must both be i64 or both be duration
type: list size must be a positive constant or 'unbounded'
injectable: the 'clock' injectable is agreed but not implemented yet; 'out' and 'logger' are available
injectable: 'out' requires a function output
function-kind: 'state' must be declared before runtime handlers
function-kind: 'when' cannot be nested in another block; it declares node-level activation
phase: 'out' is not available during stop
```

Symbolic sizes (`list<T, n>`, `rolling<T, n>` with a `const` generic) keep their declared kind and skip the value checks, as the reference says; the emitter now names that case as its own limitation ("a list size given by a const generic is not supported by emit-cpp yet") instead of calling it a bad literal.

The emitter's and type bridge's copies of these checks became internal assertions ("typed HIR admitted ...") that a correct checker never trips. Duplicate injectable names were already a resolver error and stay there.

Not in this PR: the spec's date/duration arithmetic table (item 2's last bullet). Every form in the table has a registered hgraph operator, so composition can lower it, but runtime-body emission would need Date/CivilDateTime/ZonedDateTime arithmetic helpers in generated C++ first; enabling the checker before that would move the failure from a clear `hgl check` diagnostic into a generated-code compile error. Tracked on #767 as item 2b.

## Tests

- `tests/ir/lower_tests.cpp`: three new cases covering every rule above plus the valid forms (`rolling<f64, 5m, 0s>`, generic sizes).
- `tests/wiring/type_bridge_tests.cpp` and `tests/codegen/emitter_tests.cpp`: the cases that asserted backend-time messages now assert the checker's.
- Local: `hgl_ir_tests` 54/54, `hgl_codegen_tests` 56/56, `hgl_wiring_type_tests` 5/5, `ctest -R hgraph_language` 50/50; every `language/examples/*.hgl` still passes `hgl check`.
- Only `language/` changes; the default build does not compile it. Linux GCC 14 and macOS run in the `Language toolchain` workflow on this PR.

Docs in the same change: `compiler-and-lowering.md` (the checker owns these rules; fail-closed list corrected), `docs/user-guide/functions.md` (injectable status), `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
