### PR TITLE
HGL: run every example test in CTest, pin embedded conditionals, direct-wiring coverage (#767 item 4)

### DIFF
--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -108,6 +108,15 @@
   examples with provisional forms labelled; a corrective-programme record;
   and the observed-but-undecided scalar, string, and validity behaviors
   listed as open decisions.
+- Run `hgl test` in CTest over every guide example that declares a `test`
+  block (configure-time discovery; runtime examples take the Unix-only
+  scripted path), pin the expression-embedded temporal conditional in the
+  parity fixture, add direct-wiring tick coverage for reference routing,
+  generic window resolution and dynamic traversal, split the REPL smoke test
+  into a composition-only session for every platform and the runtime session
+  for Unix, and give the standard-library design fixtures `module` lines and
+  an `// expect:` diagnostic convention with a CTest runner for the
+  implemented definite-assignment fixture.
 
 ## 0.1.0
 

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -13,8 +13,10 @@ can also forward an existing binding through a reference-qualified generated
 input. A consumed temporal conditional without `else` receives a typed
 never-ticking false branch in both backends. Early-return continuations work
 for top-level and nested direct temporal conditional statements and block
-tails. Scalar branch captures, temporal `else if`, and temporal conditionals
-embedded in other expression forms remain staged.
+tails. A temporal conditional embedded in another expression form is
+implemented in both backends and pinned by the parity fixture
+(`tests/codegen/parity.hgl`, `choose_embedded`). Scalar branch captures and
+temporal `else if` remain staged.
 A temporal `else if` is rejected rather than silently treated as an omitted
 `else`. This record uses the existing `if`/`else` syntax. It does not settle the
 other control-flow constructs or introduce new keywords.
@@ -389,8 +391,9 @@ The path retains a separate segment for every enclosing lexical block so
 intermediate tail expressions keep their source order. Both compiler backends
 consume that plan for top-level and nested direct temporal conditional
 statements, including paths nested inside an already-attached continuation.
-Temporal conditionals embedded in other expression forms remain outside this
-slice.
+A temporal conditional embedded in another expression form is implemented in
+both backends and pinned by the parity fixture; it carries no early return,
+so it needs no continuation plan.
 
 ## Outputless conditionals
 
@@ -593,8 +596,9 @@ continuation planning is implemented, including path-sensitive fallthrough,
 capture analysis, a distinct enclosing-function return result, and ordered
 lexical suffix segments for nested paths. Both execution backends consume the
 multi-segment plan for nested direct temporal conditional statements and block
-tails. Temporal `else if` and a temporal conditional embedded in another
-expression remain staged.
+tails. A temporal conditional embedded in another expression is implemented
+in both backends and pinned by the parity fixture. Temporal `else if` remains
+staged.
 
 The parser, typed uninitialized `var`, and path-sensitive definite assignment
 support are broader than this first backend slice. The early-return and

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -372,9 +372,11 @@ On Unix, file-based `hgl test` and `hgl run` also compile a unit containing
 runtime functions or implementations to a content-addressed image and load its
 candidates into the command process before wiring.
 Generated runtime sources and calls, compound constant literals, runtime-node
-`if` used as a value, temporal conditionals embedded inside another expression,
-and runtime constructs outside the supported selector/output forms fail closed
-with a diagnostic that names the construct. The REPL edits lines with history
+`if` used as a value, and runtime constructs outside the supported
+selector/output forms fail closed with a diagnostic that names the construct.
+A temporal conditional embedded inside another expression is implemented in
+both backends and pinned by the parity fixture (`tests/codegen/parity.hgl`,
+`choose_embedded`). The REPL edits lines with history
 and completion on a terminal.
 
 Development proceeds through executable vertical slices. Parser-only progress

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -471,18 +471,31 @@ and literal conversion, the failure detail of a wrong value and of a wrong
 length, selected tests and the REPL's described tail, the first-pass
 limits as diagnostics (timed sequences, an unloaded runtime function, element types),
 `run_program` into a stream with `--set`, `--start`, and a duration end,
-and `format_time`. `hgraph_language_test_midpoint` runs `hgl test` over
-the guide's `midpoint.hgl`.
+and `format_time`. `tests/wiring/backend_coverage_tests.cpp` (same binary)
+holds the direct-wiring counterparts of behaviour that otherwise has only
+generated-C++ evidence: `ref<T>` pass-through into operator consumers and
+fixed-list index routing, generic operator resolution over tick and duration
+windows built with `to_window`, and dynamic map/list traversal whose child
+graphs record their ticks through a test sink. It also pins the direct
+backend's remaining boundaries: a reference result adapted to a plain
+declared result, and a source-defined operator whose `impl fn` needs the
+scripted image the file driver loads. CTest runs `hgl test` over every guide
+example that declares a `test` block, discovered by a configure-time glob
+(`hgraph_language_test_<example>`); `midpoint.hgl` keeps its
+`hgraph::analytics` gate.
 
 The direct-wiring backend is tested against hgraph, not against a model of
 it:
 
-- for each standard operator used in the guides, `eval` over the operator
-  records the same ticks as the C++ `eval_node` harness in
-  `hgraph/lib/testing/eval_node.h` for the same arguments, dense and timed,
-  including padding, never-ticking outputs, and outputless callees;
-- exact-function inlining wires the same graph as calling the operators
-  directly (compare the wired node and edge sets, not only the ticks);
+- the parity fixture's compositions record the same dense ticks under `eval`
+  as the C++ `eval_node` harness in `hgraph/lib/testing/eval_node.h` records
+  for the generated module, including padding, never-ticking outputs, and
+  outputless callees; the expectations are written once in the fixture's
+  `test` blocks and once in `generated_tests.cpp`. Timed sequences are not
+  compared: the direct backend rejects them as a first-pass limit;
+- exact-function inlining is checked by ticks only; the wired node and edge
+  sets are not compared today, and that structural comparison remains an
+  acceptance target rather than an implemented test;
 - `const` folding produces the scalar arguments hgraph's resolver lifts,
   including temporal constants and `[run.params]` values of every mapped
   TOML type;
@@ -495,7 +508,11 @@ it:
   ticks as hgraph's `run_graph` for the equivalent graph, and the
   command-line overrides win over the file.
 
-Every `test` in the guide examples runs under `hgl test` in CI.
+Every `test` in the guide examples runs under `hgl test` in CI: CTest
+discovers them with a configure-time glob and content check
+(`tests/CMakeLists.txt`), registering composition-only examples on every
+platform and examples with runtime functions or `impl fn` declarations
+inside the Unix-only scripted block.
 
 `hgraph_language_test_runtime` and `hgraph_language_run_runtime` compile and
 load the runtime fixture through the actual CLI, covering an exported node, a
@@ -509,6 +526,17 @@ the test artifact.
 cold miss, warm hit, digest-corrupted entry quarantine and repair, compiler
 identity isolation, source invalidation, and two simultaneous cold publishers
 converging on one complete entry without leaked staging directories.
+
+`hgraph_language_repl_composition_smoke` drives a piped REPL session that
+stays on the direct backend and runs on every platform;
+`hgraph_language_repl_smoke` adds the runtime-bearing session (an `impl fn`
+that forces a scripted image and a later declaration that replaces it
+transactionally) where the scripted loader exists.
+
+`hgraph_language_stdlib_invalid_<fixture>` runs `hgl check` over a
+design-corpus fixture in `stdlib/examples/invalid/` and requires the
+diagnostic its leading `// expect:` comment names; only fixtures whose rule
+the compiler implements are registered.
 
 ## Generated C++
 

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -386,9 +386,10 @@ that does not assign it. A consumed temporal conditional without `else` uses a
 typed never-ticking false branch. Early returns work for top-level and nested
 temporal conditionals when the conditional is a direct statement or block tail;
 the compiler represents the remaining body as ordered lexical continuation
-segments. The current slice still rejects scalar branch captures, temporal
-`else if`, and temporal conditionals embedded inside arbitrary expressions. The
-existing syntax needs no new keyword.
+segments. A temporal conditional embedded inside another expression, such as
+`(if c { x } else { y }) + 1`, is implemented in both backends and pinned by
+the parity fixture. The current slice still rejects scalar branch captures and
+temporal `else if`. The existing syntax needs no new keyword.
 
 `if` has three context-dependent meanings:
 

--- a/language/examples/README.md
+++ b/language/examples/README.md
@@ -1,49 +1,94 @@
 # Language examples
 
-These files illustrate the proposed first language slice. Each one is a
-CTest case that must pass `hgl check`, and `midpoint.hgl` also runs its
-`test` under `hgl test`. The other examples declare no tests yet: some use
-runtime functions, generic functions, or `impl fn` declarations that the
-direct-wiring backend checks but does not run. Structural values and
-type-generic struct specializations also have executable unit coverage.
+These files illustrate the first language slice and are executable
+documentation (developer guide, "Documentation examples"). Every example is a
+CTest case that must pass `hgl check`, and every example that declares a
+`test` block also runs under `hgl test`: `../tests/CMakeLists.txt` discovers
+them with a configure-time glob and content check rather than a hand-written
+list. Composition-only examples run on every platform; an example containing
+a runtime function or an `impl fn` takes the Unix-only scripted native path.
+The generated fixtures compile every example through `hgl_add_module()` under
+the repository warning policy, and the `../tests/codegen/generated_*_tests.cpp`
+cases drive the generated graphs with hgraph's own harness. Where an example
+has no `test` block, the note below says which unit tests carry its behaviour.
 
 - [`midpoint.hgl`](midpoint.hgl) uses an internal helper, `export fn`, an
-  atomic tuple, a `const` window, and a `test` of the unexported helper.
+  atomic tuple, a `const` window, and a `test` of the unexported helper. It
+  imports `hgraph.analytics`. Tests: 1 `test` under `hgl test`
+  (`hgraph_language_test_midpoint`, gated on `hgraph::analytics`) and
+  `generated_example_tests.cpp`.
 - [`runtime-choice.hgl`](runtime-choice.hgl) contrasts a wiring-time topology
-  choice, explicit time-series selection, and a `when` runtime function.
+  choice, explicit time-series selection, and a `when` runtime function. It
+  imports `hgraph.analytics`. Tests: none in the file;
+  `generated_example_tests.cpp` builds it.
 - [`stateful-node.hgl`](stateful-node.hgl) demonstrates aggregate state,
   grouped injectables, lifecycle blocks, ordered handlers, previous output,
-  and incremental collection output.
+  and incremental collection output. Tests: none in the file; native behaviour
+  in `generated_example_tests.cpp`, and the `--dump-hir` /
+  `--dump-hgraph-ir` CTest cases read this example.
 - [`collection-views.hgl`](collection-views.hgl) demonstrates dual-phase
   `key_set`, runtime `keys`/`values`/`items`, built-in and inline predicates,
-  `last_modified`, and mutable lexical `var`.
+  `last_modified`, and mutable lexical `var`. Tests: none in the file; native
+  behaviour in `generated_example_tests.cpp`.
 - [`operators-and-generics.hgl`](operators-and-generics.hgl) demonstrates a
   nominal bodyless `operator`, a generic `impl fn` implementation, const-generic
   rolling-window sizes, an exported exact function, the default minimum window
-  size, and a duration window. Operators, functions, and structs may now carry
-  the agreed `requires` constraint syntax.
+  size, and a duration window. Operators, functions, and structs may carry
+  the agreed `requires` constraint syntax. Tests: none in the file; generic
+  resolution and window ticks in `generated_generic_tests.cpp` and, on the
+  direct backend, `../tests/wiring/backend_coverage_tests.cpp`.
 - [`structural-types.hgl`](structural-types.hgl) demonstrates a recursively
   temporal struct, `atomic<S>`, a type-generic struct, closed-set requirements,
   abstract-only inheritance with a default override, and a sparse delta in a
-  runtime function, alongside temporal maps and an anonymous `fn`.
+  runtime function, alongside temporal maps and an anonymous `fn`. Tests: none
+  in the file; `generated_structural_tests.cpp`, and direct-wiring struct
+  cases in `../tests/wiring/backend_tests.cpp`.
+- [`reference-routing.hgl`](reference-routing.hgl) demonstrates `ref<T>`
+  parameters and results in runtime functions: forwarding a reference, and
+  routing one element of a `list<ref<T>, 3>` by a temporal index. Tests: none
+  in the file; routing ticks in `generated_reference_tests.cpp` and, for the
+  composition shapes, `../tests/wiring/backend_coverage_tests.cpp`.
+- [`fixed-list-iteration.hgl`](fixed-list-iteration.hgl) demonstrates a
+  graph-phase `for` over a fixed temporal list with `values` and `items`,
+  wiring one body per child connection. Tests: none in the file; per-child
+  wiring in `generated_iteration_tests.cpp` and
+  `../tests/wiring/backend_tests.cpp`.
+- [`dynamic-collection-iteration.hgl`](dynamic-collection-iteration.hgl)
+  demonstrates a graph-phase `for` over a temporal map and an unbounded list,
+  one sink child graph per key or index, with shared captures passed whole.
+  Tests: none in the file; child-map ownership in
+  `generated_iteration_tests.cpp` and recorded child ticks in
+  `../tests/wiring/backend_coverage_tests.cpp`.
 - [`conditional-result.hgl`](conditional-result.hgl),
   [`conditional-results.hgl`](conditional-results.hgl), and
   [`conditional-mixed-results.hgl`](conditional-mixed-results.hgl) exercise
   temporal branch results, escaping assignments, structural result packing,
-  and remapping in both compiler backends.
+  and remapping in both compiler backends. Tests: none in the files; ticks in
+  `generated_tests.cpp` and `../tests/wiring/backend_tests.cpp`.
 - [`conditional-forwarding.hgl`](conditional-forwarding.hgl) preserves an
   initialized result through an implicit or explicit unassigned branch and
   exercises independent reference forwarding for structural result fields.
+  Tests: none in the file; ticks in `generated_tests.cpp` and
+  `../tests/wiring/backend_tests.cpp`.
 - [`conditional-omitted-else.hgl`](conditional-omitted-else.hgl) shows that a
   consumed temporal conditional without `else` produces no tick while false,
-  using a type-resolved `nothing` branch in both compiler backends.
+  using a type-resolved `nothing` branch in both compiler backends. Tests:
+  1 `test` under `hgl test` (`hgraph_language_test_conditional-omitted-else`)
+  and `generated_tests.cpp`.
+- [`conditional-early-return.hgl`](conditional-early-return.hgl) returns from
+  one temporal branch and composes the rest of the body as the other branch's
+  continuation, for top-level, nested, tail, assigned, and outputless forms.
+  Tests: 8 `test` blocks under `hgl test`
+  (`hgraph_language_test_conditional-early-return`) and `generated_tests.cpp`.
+- [`conditional-sinks.hgl`](conditional-sinks.hgl) controls child-graph
+  lifetime with an outputless temporal conditional through the native sink
+  switch, keeps a second sink outside it, and discards a sink conditional
+  inside a value-producing graph. Tests: none in the file; `generated_tests.cpp`
+  and `../tests/wiring/backend_tests.cpp`.
 
 As compiler slices land, each example should advance from parsing and typed IR
 coverage through `hgl test` to generated C++ behavior and backend parity.
-The CTest suite checks every example, and its generated fixtures compile the
-implemented AOT surface under the repository warning policy. The
-backend-parity module that is built both ways lives in
-`../tests/codegen/parity.hgl`.
-The acceptance
-sequence is defined in the
+The backend-parity module that is built both ways lives in
+`../tests/codegen/parity.hgl`; the expression-embedded temporal conditional
+is pinned there. The acceptance sequence is defined in the
 [Developer Guide](../docs/developer-guide/testing-and-compatibility.md#documentation-examples).

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -46,9 +46,12 @@ precedes the time-series argument.
 [conditional-unassigned-result.hgl](examples/invalid/conditional-unassigned-result.hgl)
 is intentionally invalid: the escaping variable has no incoming binding and
 is assigned only on the true path before it is used. It records the agreed
-compile-time definite-assignment error. The compiler now implements this
-path-sensitive check. The single explicit-two-branch result form now has
-backend lowering; the invalid example continues to guard the broader rule.
+compile-time definite-assignment error. The compiler implements this
+path-sensitive check, and CTest
+(`hgraph_language_stdlib_invalid_conditional-unassigned-result`) runs
+`hgl check` over the fixture and requires the diagnostic its `// expect:`
+comment names. The single explicit-two-branch result form has backend
+lowering; the invalid example continues to guard the broader rule.
 
 ## Explicit switch
 
@@ -179,6 +182,29 @@ both backends. Existing bindings can be forwarded by reference, independently
 for each structural result field. A value-producing temporal conditional may
 omit `else`; both backends supply a typed never-ticking false result.
 Continuations remain design inputs. Typed declarations without initializers and
-their definite-assignment checks are implemented. Files left here are not
-runnable tests and remain deliberately outside `language/examples/`, whose
-`.hgl` files are checked by CTest.
+their definite-assignment checks are implemented. Files left here remain
+deliberately outside `language/examples/`, whose `.hgl` files are checked by
+CTest; their own test status is below.
+
+## Fixture status
+
+Every fixture under `examples/` carries a `module stdlib.examples.<name>`
+line (`stdlib.examples.invalid.<name>` under `invalid/`), so `hgl check`
+reaches the rule a fixture documents instead of stopping at the missing
+module declaration. Each `invalid/` fixture also opens with a
+`// expect: <substring>` comment naming the diagnostic it must produce;
+`tests/stdlib/check_invalid_fixture.cmake` runs `hgl check` and passes only
+when the check fails and its output contains every expectation.
+
+| Fixture | Construct | Status |
+| --- | --- | --- |
+| `invalid/conditional-unassigned-result.hgl` | definite assignment | registered as `hgraph_language_stdlib_invalid_conditional-unassigned-result`; the expectation is the checker's wording |
+| `invalid/switch-temporal-case.hgl`, `invalid/enum-switch-*.hgl` | `switch` | not registered: `switch` is not parsed yet |
+| `invalid/enum-*.hgl` | `enum` | not registered: `enum` is not parsed yet |
+| `switch-scenarios.hgl`, `enum-*.hgl`, `string-conversion.hgl`, `elements-iteration.hgl` | `switch`, `enum`, `str(value)`, `elements` | valid design fixtures; not checked until their construct parses |
+
+An unregistered fixture's `// expect:` substring records the agreed rule in
+the fixture's own words; it is aligned with the checker's diagnostic and the
+fixture is added to `_hgl_stdlib_invalid_fixtures` in `tests/CMakeLists.txt`
+the moment its construct lands. Adding the comment and module line does not
+change what a fixture documents.

--- a/language/stdlib/examples/elements-iteration.hgl
+++ b/language/stdlib/examples/elements-iteration.hgl
@@ -1,6 +1,8 @@
 // Agreed list/set elements spelling; not yet supported by the compiler.
 // See language/docs/design/iteration.md for paired HGL/C++ mappings.
 
+module stdlib.examples.elements_iteration
+
 fn observe_elements(samples: list<f64, 3>) {
     for sample in elements(samples) {
         null_sink(sample)

--- a/language/stdlib/examples/enum-enumeration-order.hgl
+++ b/language/stdlib/examples/enum-enumeration-order.hgl
@@ -5,6 +5,8 @@
 // elements: EnumerationOrder::high, EnumerationOrder::low, EnumerationOrder::next.
 // Calls on the enum type return immutable fixed-size scalar lists.
 
+module stdlib.examples.enum_enumeration_order
+
 enum EnumerationOrder {
     high = 20,
     low = 5,

--- a/language/stdlib/examples/enum-number-range.hgl
+++ b/language/stdlib/examples/enum-number-range.hgl
@@ -1,6 +1,8 @@
 // Agreed signed-i64 enum numbering examples; compiler support is separate.
 // See language/docs/developer-guide/enum-cpp-mappings.md.
 
+module stdlib.examples.enum_number_range
+
 enum Direction {
     reverse = -1,
     stopped,

--- a/language/stdlib/examples/enum-switch.hgl
+++ b/language/stdlib/examples/enum-switch.hgl
@@ -1,6 +1,8 @@
 // Agreed enum-switch design; not yet supported by the compiler.
 // See language/docs/developer-guide/enum-switch-cpp-mappings.md.
 
+module stdlib.examples.enum_switch
+
 enum Mode {
     first = 10,
     second,

--- a/language/stdlib/examples/enum-values.hgl
+++ b/language/stdlib/examples/enum-values.hgl
@@ -5,6 +5,8 @@
 // String conversion uses the agreed str(value) spelling.
 // Checked enum construction uses the enum type name with a number or name.
 
+module stdlib.examples.enum_values
+
 enum Mode {
     first = 10,
     second,

--- a/language/stdlib/examples/invalid/conditional-unassigned-result.hgl
+++ b/language/stdlib/examples/invalid/conditional-unassigned-result.hgl
@@ -1,7 +1,10 @@
-// Intentionally invalid under the agreed design; not an executable test yet.
+// expect: 'r' may be used before it is assigned
+// Intentionally invalid under the agreed design; CTest runs it through hgl check.
 // Expected: a compile-time definite-assignment error at the later use of r.
 // The false path has no assignment and no incoming binding to forward.
 // See language/docs/design/control-flow.md.
+
+module stdlib.examples.invalid.conditional_unassigned_result
 
 fn unassigned_conditional_result(condition: bool, x: i64) -> i64 {
     var r: i64

--- a/language/stdlib/examples/invalid/enum-conversion-unknown-name.hgl
+++ b/language/stdlib/examples/invalid/enum-conversion-unknown-name.hgl
@@ -1,5 +1,8 @@
+// expect: "First" is not a member of Mode
 // Intentional design error: member names are exact and case-sensitive.
 // See language/docs/developer-guide/enum-cpp-mappings.md.
+
+module stdlib.examples.invalid.enum_conversion_unknown_name
 
 enum Mode {
     first = 10,

--- a/language/stdlib/examples/invalid/enum-conversion-unknown-number.hgl
+++ b/language/stdlib/examples/invalid/enum-conversion-unknown-number.hgl
@@ -1,5 +1,8 @@
+// expect: 12 is not a member of Mode
 // Intentional design error: 12 is not an assigned Mode number.
 // See language/docs/developer-guide/enum-cpp-mappings.md.
+
+module stdlib.examples.invalid.enum_conversion_unknown_number
 
 enum Mode {
     first = 10,

--- a/language/stdlib/examples/invalid/enum-duplicate-number.hgl
+++ b/language/stdlib/examples/invalid/enum-duplicate-number.hgl
@@ -1,6 +1,9 @@
+// expect: duplicate member number 10
 // Intentionally invalid enum design fixture; not implemented compiler checking.
 // Expected: duplicate member number 10 in DuplicateExplicit.
 // Numeric aliases are rejected in the initial HGL enum design.
+
+module stdlib.examples.invalid.enum_duplicate_number
 
 enum DuplicateExplicit {
     first = 10,

--- a/language/stdlib/examples/invalid/enum-implicit-duplicate-number.hgl
+++ b/language/stdlib/examples/invalid/enum-implicit-duplicate-number.hgl
@@ -1,6 +1,9 @@
+// expect: duplicate member number 11
 // Intentionally invalid enum design fixture; not implemented compiler checking.
 // Expected: collision receives 11, duplicating existing.
 // Automatic numbering follows the previous member, not the largest number.
+
+module stdlib.examples.invalid.enum_implicit_duplicate_number
 
 enum DuplicateAutomatic {
     existing = 11,

--- a/language/stdlib/examples/invalid/enum-number-above-range.hgl
+++ b/language/stdlib/examples/invalid/enum-number-above-range.hgl
@@ -1,5 +1,8 @@
+// expect: exceeds the signed i64 maximum
 // Intentional design error: explicit enum number exceeds signed-i64 maximum.
 // This must fail at compile time, without wrapping to the minimum.
+
+module stdlib.examples.invalid.enum_number_above_range
 
 enum AboveRange {
     value = 9223372036854775808

--- a/language/stdlib/examples/invalid/enum-number-below-range.hgl
+++ b/language/stdlib/examples/invalid/enum-number-below-range.hgl
@@ -1,5 +1,8 @@
+// expect: below the signed i64 minimum
 // Intentional design error: explicit enum number is below signed-i64 minimum.
 // This must fail at compile time, without wrapping to the maximum.
+
+module stdlib.examples.invalid.enum_number_below_range
 
 enum BelowRange {
     value = -9223372036854775809

--- a/language/stdlib/examples/invalid/enum-number-overflow.hgl
+++ b/language/stdlib/examples/invalid/enum-number-overflow.hgl
@@ -1,5 +1,8 @@
+// expect: exceeds the signed i64 maximum
 // Intentional design error: automatic successor exceeds signed-i64 maximum.
 // An explicit in-range reset would be valid; this implicit member must fail.
+
+module stdlib.examples.invalid.enum_number_overflow
 
 enum AutomaticOverflow {
     maximum = 9223372036854775807,

--- a/language/stdlib/examples/invalid/enum-switch-duplicate-case.hgl
+++ b/language/stdlib/examples/invalid/enum-switch-duplicate-case.hgl
@@ -1,5 +1,8 @@
+// expect: duplicate case Mode::first
 // Intentional source errors: resolve and type-check constants before
 // rejecting duplicate cases. Each function independently repeats Mode::first.
+
+module stdlib.examples.invalid.enum_switch_duplicate_case
 
 enum Mode {
     first = 10,

--- a/language/stdlib/examples/invalid/enum-switch-integer-case.hgl
+++ b/language/stdlib/examples/invalid/enum-switch-integer-case.hgl
@@ -1,4 +1,7 @@
+// expect: 10 is not a member of Mode
 // Intentional source error: Mode's assigned integer is not a Mode member.
+
+module stdlib.examples.invalid.enum_switch_integer_case
 
 enum Mode {
     first = 10

--- a/language/stdlib/examples/invalid/enum-switch-other-enum-case.hgl
+++ b/language/stdlib/examples/invalid/enum-switch-other-enum-case.hgl
@@ -1,4 +1,7 @@
+// expect: OtherMode::first is not a member of Mode
 // Intentional source error: coincident numbers do not erase enum identity.
+
+module stdlib.examples.invalid.enum_switch_other_enum_case
 
 enum Mode {
     first = 10

--- a/language/stdlib/examples/invalid/enum-switch-unassigned-result.hgl
+++ b/language/stdlib/examples/invalid/enum-switch-unassigned-result.hgl
@@ -1,5 +1,8 @@
+// expect: 'r' may be used before it is assigned
 // Intentional source error: full case coverage is not definite assignment.
 // The third case reaches the return without assigning r.
+
+module stdlib.examples.invalid.enum_switch_unassigned_result
 
 enum Mode {
     first = 10,

--- a/language/stdlib/examples/invalid/switch-temporal-case.hgl
+++ b/language/stdlib/examples/invalid/switch-temporal-case.hgl
@@ -1,6 +1,9 @@
+// expect: a case value must be a source constant
 // Intentionally invalid design fixture; switch checking is not implemented yet.
 // Expected: a case value must be expressible as a constant in source.
 // 'other' is a temporal input, not a constant, even if a particular run never changes it.
+
+module stdlib.examples.invalid.switch_temporal_case
 
 fn temporal_case_value(mode: i64, other: i64, value: i64) -> i64 {
     var r: i64

--- a/language/stdlib/examples/string-conversion.hgl
+++ b/language/stdlib/examples/string-conversion.hgl
@@ -2,6 +2,8 @@
 // See language/docs/developer-guide/enum-cpp-mappings.md.
 // Constants (including enums) are covered by enum-values.hgl.
 
+module stdlib.examples.string_conversion
+
 fn integer_text_node(value: i64) -> str {
     when modified(value) && valid(value) {
         return str(value)

--- a/language/stdlib/examples/switch-scenarios.hgl
+++ b/language/stdlib/examples/switch-scenarios.hgl
@@ -2,6 +2,8 @@
 // Paired source and C++ mappings: language/docs/developer-guide/control-flow-cpp-mappings.md.
 // Case values are source constants. This file is outside the executable example corpus.
 
+module stdlib.examples.switch_scenarios
+
 fn local_switch_example(mode: i64, x: i64, y: i64, fallback: i64) -> i64 {
     when modified(mode, x, y, fallback) && valid(mode, x, y, fallback) {
         var r: i64

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -208,7 +208,13 @@ set_tests_properties(hgraph_language_native_package_install_consumer PROPERTIES 
 
 # The direct-wiring backend against the live registry: folding, eval, the
 # failure detail, run_program (developer guide, "First pass").
-add_executable(hgl_wiring_tests wiring/backend_tests.cpp)
+# `backend_coverage_tests.cpp` adds the direct-wiring counterparts of cases
+# that otherwise exist only for generated C++: reference routing, generic
+# operator resolution over windows, and dynamic traversal ticks.
+add_executable(hgl_wiring_tests
+    wiring/backend_tests.cpp
+    wiring/backend_coverage_tests.cpp
+)
 target_compile_features(hgl_wiring_tests PRIVATE cxx_std_23)
 target_link_libraries(hgl_wiring_tests PRIVATE hgl::wiring Catch2::Catch2WithMain)
 hgl_link_runtime_executable(hgl_wiring_tests)
@@ -363,8 +369,48 @@ add_test(
     COMMAND $<TARGET_FILE:hgl> test ${CMAKE_CURRENT_SOURCE_DIR}/codegen/parity.hgl
 )
 set_tests_properties(hgraph_language_test_parity PROPERTIES
-    PASS_REGULAR_EXPRESSION "7 tests, 0 failed"
+    PASS_REGULAR_EXPRESSION "8 tests, 0 failed"
 )
+
+# Every guide example that declares a `test` block runs under `hgl test`
+# (developer guide, "Documentation examples"; examples/README.md). Discovery
+# is a configure-time glob plus a content check rather than a hand-written
+# list, so a new `test` in an example is registered the moment it is written.
+# Classification rule: an example with a runtime-function form (`state`,
+# `inject`, `when`, `start` or `stop` opening a line) or an `impl fn` is
+# compiled through the scripted native loader before wiring, which is
+# Unix-only today (see `hgraph_language_test_runtime`), so it is registered
+# inside the `if(UNIX)` block below; composition-only examples run on every
+# platform. An example importing `hgraph.analytics` keeps the
+# `TARGET hgraph::analytics` gate `hgraph_language_test_midpoint` always had.
+file(GLOB _hgl_examples CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../examples/*.hgl)
+set(_hgl_runtime_example_tests)
+foreach(_example IN LISTS _hgl_examples)
+    file(STRINGS ${_example} _test_lines REGEX "^test ")
+    if(NOT _test_lines)
+        continue()
+    endif()
+    file(STRINGS ${_example} _analytics_lines REGEX "^use hgraph\\.analytics")
+    if(_analytics_lines AND NOT TARGET hgraph::analytics)
+        continue()
+    endif()
+    file(STRINGS ${_example} _runtime_lines
+        REGEX "^[ \t]*(state|inject|when|start|stop)([^A-Za-z0-9_]|$)|^impl fn")
+    if(_runtime_lines)
+        list(APPEND _hgl_runtime_example_tests ${_example})
+        continue()
+    endif()
+    get_filename_component(_name ${_example} NAME_WE)
+    list(LENGTH _test_lines _test_count)
+    add_test(
+        NAME hgraph_language_test_${_name}
+        COMMAND $<TARGET_FILE:hgl> test ${_example}
+    )
+    set_tests_properties(hgraph_language_test_${_name} PROPERTIES
+        PASS_REGULAR_EXPRESSION "${_test_count} tests?, 0 failed"
+    )
+endforeach()
+unset(_hgl_examples)
 
 if(UNIX)
     # Runtime-node modules take the scripted compile/load path, then use the
@@ -392,6 +438,22 @@ if(UNIX)
         PROPERTIES ENVIRONMENT "HGL_CACHE_DIR=${CMAKE_CURRENT_BINARY_DIR}/scripted-cache"
     )
 
+    # Guide examples with runtime functions or `impl fn` declarations (the
+    # classification rule above) take the same scripted path.
+    foreach(_example IN LISTS _hgl_runtime_example_tests)
+        get_filename_component(_name ${_example} NAME_WE)
+        file(STRINGS ${_example} _test_lines REGEX "^test ")
+        list(LENGTH _test_lines _test_count)
+        add_test(
+            NAME hgraph_language_test_${_name}
+            COMMAND $<TARGET_FILE:hgl> test ${_example}
+        )
+        set_tests_properties(hgraph_language_test_${_name} PROPERTIES
+            PASS_REGULAR_EXPRESSION "${_test_count} tests?, 0 failed"
+            ENVIRONMENT "HGL_CACHE_DIR=${CMAKE_CURRENT_BINARY_DIR}/scripted-cache"
+        )
+    endforeach()
+
     add_test(
         NAME hgraph_language_native_compile_failure
         COMMAND ${CMAKE_COMMAND}
@@ -410,7 +472,19 @@ if(UNIX)
             -DOUT=${CMAKE_CURRENT_BINARY_DIR}/native-cache
             -P ${CMAKE_CURRENT_SOURCE_DIR}/driver/native_cache.cmake
     )
+
+    # The REPL over a pipe with runtime declarations: an `impl fn` forces a
+    # scripted image and a later declaration replaces it transactionally, so
+    # this session needs the Unix-only loader like the tests above.
+    add_test(
+        NAME hgraph_language_repl_smoke
+        COMMAND ${CMAKE_COMMAND}
+            -DHGL=$<TARGET_FILE:hgl>
+            -DOUT=${CMAKE_CURRENT_BINARY_DIR}/repl
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/repl/repl_smoke.cmake
+    )
 endif()
+unset(_hgl_runtime_example_tests)
 
 # The command itself: representative composition and runtime modules emit.
 add_test(
@@ -428,13 +502,14 @@ set_tests_properties(hgraph_language_emit_runtime PROPERTIES
     PASS_REGULAR_EXPRESSION "struct combined_total"
 )
 
-# The REPL over a pipe: the plain-line path of the line reader.
+# The REPL over a pipe (the plain-line path of the line reader) on every
+# platform: a composition-only session that never builds a native image.
 add_test(
-    NAME hgraph_language_repl_smoke
+    NAME hgraph_language_repl_composition_smoke
     COMMAND ${CMAKE_COMMAND}
         -DHGL=$<TARGET_FILE:hgl>
-        -DOUT=${CMAKE_CURRENT_BINARY_DIR}/repl
-        -P ${CMAKE_CURRENT_SOURCE_DIR}/repl/repl_smoke.cmake
+        -DOUT=${CMAKE_CURRENT_BINARY_DIR}/repl-composition
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/repl/repl_composition_smoke.cmake
 )
 
 # Configure the public package helper as an installed consumer would: there is
@@ -456,14 +531,20 @@ add_test(
 )
 set_tests_properties(hgraph_language_cmake_package PROPERTIES FIXTURES_REQUIRED hgl_native_scalar_descriptor)
 
-# The guide's test example passes end to end through the driver
-# (user guide, "Testing and running").
-if(TARGET hgraph::analytics)
+# Design-corpus fixtures under stdlib/examples/invalid/ declare their expected
+# diagnostic as a leading `// expect: <substring>` comment. Only fixtures whose
+# rule the compiler already implements are registered; the others are wired
+# here the moment their construct lands (stdlib/README.md, "Fixture status").
+set(_hgl_stdlib_invalid_fixtures
+    conditional-unassigned-result
+)
+foreach(_fixture IN LISTS _hgl_stdlib_invalid_fixtures)
     add_test(
-        NAME hgraph_language_test_midpoint
-        COMMAND $<TARGET_FILE:hgl> test ${CMAKE_CURRENT_SOURCE_DIR}/../examples/midpoint.hgl
+        NAME hgraph_language_stdlib_invalid_${_fixture}
+        COMMAND ${CMAKE_COMMAND}
+            -DHGL=$<TARGET_FILE:hgl>
+            -DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/../stdlib/examples/invalid/${_fixture}.hgl
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/stdlib/check_invalid_fixture.cmake
     )
-    set_tests_properties(hgraph_language_test_midpoint PROPERTIES
-        PASS_REGULAR_EXPRESSION "midpoint_ticks \\.\\.\\. ok"
-    )
-endif()
+endforeach()
+unset(_hgl_stdlib_invalid_fixtures)

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -161,7 +161,8 @@ TEST_CASE("emit-cpp names the pair after the module and exports its functions", 
 
     CHECK(emitted->namespace_name == "hgl::codegen::parity");
     CHECK(emitted->module_name == "hgl.codegen.parity");
-    CHECK(emitted->exports == std::vector<std::string>{"plus", "scaled_sum", "above", "maybe_double", "offset_by", "choose"});
+    CHECK(emitted->exports ==
+          std::vector<std::string>{"plus", "scaled_sum", "above", "maybe_double", "offset_by", "choose", "choose_embedded"});
     CHECK(contains(emitted->descriptor, "\"format\": \"hgl.module\""));
     CHECK(contains(emitted->descriptor, "\"identity\": \"hgl.codegen.parity\""));
     CHECK(contains(emitted->descriptor, "\"signature\": {"));
@@ -1155,8 +1156,9 @@ TEST_CASE("emit-cpp writes a Python wrapper over the registered names", "[codege
     REQUIRE(emitted);
     CHECK(contains(emitted->python, "from . import _parity as _hgl_native"));
     CHECK(contains(emitted->python, "\"plus\": _hgl_operator_function(\"hgl.codegen.parity.plus\")"));
-    CHECK(
-        contains(emitted->python, "__all__ = [\"plus\", \"scaled_sum\", \"above\", \"maybe_double\", \"offset_by\", \"choose\"]"));
+    CHECK(contains(
+        emitted->python,
+        "__all__ = [\"plus\", \"scaled_sum\", \"above\", \"maybe_double\", \"offset_by\", \"choose\", \"choose_embedded\"]"));
 }
 
 TEST_CASE("emit-cpp gives Python keyword exports a usable spelling", "[codegen]") {

--- a/language/tests/codegen/generated_tests.cpp
+++ b/language/tests/codegen/generated_tests.cpp
@@ -62,6 +62,13 @@ TEST_CASE("generated temporal conditionals match scripted switch behavior", "[co
           values<Int>(2, 3, 29));
 }
 
+TEST_CASE("generated temporal conditionals embedded in an expression feed the enclosing operator",
+          "[codegen][generated][conditional]") {
+    session();
+    CHECK(eval_node<parity::choose_embedded>(values<Bool>(true, false), values<Int>(1, 2), values<Int>(10, 20)) ==
+          values<Int>(2, 21));
+}
+
 TEST_CASE("generated temporal early returns place the continuation in the falling branch",
           "[codegen][generated][conditional][continuation]") {
     session();

--- a/language/tests/codegen/parity.hgl
+++ b/language/tests/codegen/parity.hgl
@@ -76,3 +76,12 @@ test offset_by_ticks {
 test choose_ticks {
     assert eval(choose, condition: [true, true, false], x: [1, 2, 3], y: [10, 20, 30]) == [2, 3, 29]
 }
+
+// A temporal conditional embedded in a larger expression: the `switch_`
+// result is an ordinary operand of the enclosing `add_` in both backends.
+export fn choose_embedded(condition: bool, x: i64, y: i64) -> i64 =>
+    (if condition { x } else { y }) + 1
+
+test choose_embedded_ticks {
+    assert eval(choose_embedded, condition: [true, false], x: [1, 2], y: [10, 20]) == [2, 21]
+}

--- a/language/tests/repl/repl_composition_smoke.cmake
+++ b/language/tests/repl/repl_composition_smoke.cmake
@@ -1,0 +1,37 @@
+# A scripted `hgl repl` session over a pipe that stays on the direct-wiring
+# backend: no runtime function or `impl fn`, so no scripted native image is
+# built and the session runs on every platform. Bindings persist, composition
+# declarations join the session and call each other, `eval` prints its
+# sequence (with `_` padding), a temporal conditional embedded in an
+# expression wires through `switch_`, and `:quit` leaves cleanly.
+# `repl_smoke.cmake` adds the runtime-bearing session where the scripted
+# loader exists.
+#   cmake -DHGL=<hgl> -DOUT=<dir> -P repl_composition_smoke.cmake
+file(MAKE_DIRECTORY "${OUT}")
+file(WRITE "${OUT}/input.txt"
+"let x = 1 + 2
+x
+fn twice(v: f64) -> f64 => v * 2.0
+eval(twice, v: [1.5, 2.0])
+fn quad(v: f64) -> f64 => twice(twice(v))
+eval(quad, v: [1.0, _, 2.5])
+fn choose(condition: bool, x: i64, y: i64) -> i64 => (if condition { x } else { y }) + 1
+eval(choose, condition: [true, false], x: [1, 2], y: [10, 20])
+:quit
+")
+execute_process(
+    COMMAND "${HGL}" repl
+    INPUT_FILE "${OUT}/input.txt"
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE errors
+    RESULT_VARIABLE status
+)
+if(NOT status EQUAL 0)
+    message(FATAL_ERROR "hgl repl exited ${status}\n${output}\n${errors}")
+endif()
+foreach(expected "hgl> 3\n" "[3.0, 4.0]" "[4.0, _, 10.0]" "[2, 21]")
+    string(FIND "${output}" "${expected}" at)
+    if(at EQUAL -1)
+        message(FATAL_ERROR "hgl repl output lacks '${expected}':\n${output}\n${errors}")
+    endif()
+endforeach()

--- a/language/tests/stdlib/check_invalid_fixture.cmake
+++ b/language/tests/stdlib/check_invalid_fixture.cmake
@@ -1,0 +1,30 @@
+# Run `hgl check` over an intentionally invalid design-corpus fixture
+# (stdlib/README.md, "Fixture status") and pass only when the check fails and
+# its output contains every expectation the fixture declares as a leading
+# `// expect: <substring>` comment.
+#   cmake -DHGL=<hgl> -DSOURCE=<fixture.hgl> -P check_invalid_fixture.cmake
+if(NOT HGL OR NOT SOURCE)
+    message(FATAL_ERROR "HGL and SOURCE are required")
+endif()
+
+file(STRINGS "${SOURCE}" _expect_lines REGEX "^// expect: ")
+if(NOT _expect_lines)
+    message(FATAL_ERROR "${SOURCE} declares no '// expect: <substring>' comment")
+endif()
+
+execute_process(
+    COMMAND "${HGL}" check "${SOURCE}"
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE _stdout
+    ERROR_VARIABLE _stderr)
+set(_output "${_stdout}\n${_stderr}")
+if(_result EQUAL 0)
+    message(FATAL_ERROR "hgl check unexpectedly accepted ${SOURCE}:\n${_output}")
+endif()
+foreach(_line IN LISTS _expect_lines)
+    string(REGEX REPLACE "^// expect: " "" _expected "${_line}")
+    string(FIND "${_output}" "${_expected}" _at)
+    if(_at EQUAL -1)
+        message(FATAL_ERROR "hgl check output for ${SOURCE} lacks '${_expected}':\n${_output}")
+    endif()
+endforeach()

--- a/language/tests/wiring/backend_coverage_tests.cpp
+++ b/language/tests/wiring/backend_coverage_tests.cpp
@@ -1,0 +1,437 @@
+// Direct-wiring counterparts of behaviour that otherwise has only
+// generated-C++ evidence (developer guide, "Direct-wiring backend and the
+// harness"): reference routing, generic operator resolution over tick and
+// duration windows, and dynamic collection traversal with recorded ticks.
+// The harness mirrors `backend_tests.cpp`: a unit goes through the frontend
+// against the live registry and its `test` blocks run on the backend.
+//
+// What the direct backend cannot express is said in place. `eval` drives only
+// `TS`/`SIGNAL` parameters, so references, windows and collections are built
+// inside the composition from registry operators. Runtime functions (the
+// reference-routing example's `forward`/`route3`) and source-defined `impl fn`
+// candidates need the scripted native image the file driver loads before
+// wiring; this harness has no loader, so those remain generated-only.
+#include "hgraph_ir/lower.h"
+#include "ir/lower.h"
+#include "ir/type_check.h"
+#include "semantics/resolve.h"
+#include "syntax/parser.h"
+#include "wiring/backend.h"
+#include "wiring/operator_types.h"
+
+#include <hgraph/lib/std/operators/collection.h>
+#include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/lib/std/value_util.h>
+#include <hgraph/types/operator_dispatch.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+using namespace hgl::syntax;
+using namespace hgl::semantics;
+using namespace hgl::wiring;
+
+namespace
+{
+    // Three sources packed into a fixed list: the `values: list<ref<T>, 3>`
+    // input of the reference-routing example, which composition code cannot
+    // spell as a literal (a time-series list literal is a first-pass limit).
+    struct coverage_triple_operator
+        : hgraph::Operator<"hgl_coverage_triple", hgraph::In<"a", hgraph::TS<hgraph::Float>>,
+                           hgraph::In<"b", hgraph::TS<hgraph::Float>>, hgraph::In<"c", hgraph::TS<hgraph::Float>>,
+                           hgraph::Out<hgraph::TSL<hgraph::TS<hgraph::Float>, 3>>>
+    {};
+
+    struct coverage_triple_graph
+    {
+        static constexpr auto name = "hgl_coverage_triple_graph";
+
+        static auto compose(hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Float>> a, hgraph::Port<hgraph::TS<hgraph::Float>> b,
+                            hgraph::Port<hgraph::TS<hgraph::Float>> c) {
+            return hgraph::stdlib::to_tsl(w, a, b, c);
+        }
+    };
+
+    struct coverage_book_operator : hgraph::Operator<"hgl_coverage_book", hgraph::In<"trigger", hgraph::TS<hgraph::Float>>,
+                                                     hgraph::Out<hgraph::TSD<hgraph::Str, hgraph::TS<hgraph::Float>>>>
+    {};
+
+    struct coverage_book_graph
+    {
+        static constexpr auto name = "hgl_coverage_book_graph";
+
+        static auto compose(hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Float>> trigger) {
+            static_cast<void>(trigger);
+            return hgraph::wire<hgraph::stdlib::const_, hgraph::TSD<hgraph::Str, hgraph::TS<hgraph::Float>>>(
+                w, hgraph::stdlib::make_map<hgraph::Str, hgraph::Float>(
+                       {{hgraph::Str{"A"}, hgraph::Float{1.0}}, {hgraph::Str{"B"}, hgraph::Float{2.0}}}));
+        }
+    };
+
+    struct coverage_samples_operator : hgraph::Operator<"hgl_coverage_samples", hgraph::In<"trigger", hgraph::TS<hgraph::Float>>,
+                                                        hgraph::Out<hgraph::TSL<hgraph::TS<hgraph::Float>>>>
+    {};
+
+    struct coverage_samples_graph
+    {
+        static constexpr auto name = "hgl_coverage_samples_graph";
+
+        static auto compose(hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Float>> trigger) {
+            static_cast<void>(trigger);
+            return hgraph::wire<hgraph::stdlib::const_, hgraph::TSL<hgraph::TS<hgraph::Float>>>(
+                w, hgraph::stdlib::make_list<hgraph::Float>({hgraph::Float{1.0}, hgraph::Float{2.0}}));
+        }
+    };
+
+    // A sink that records every value it is evaluated with, so a child graph
+    // wired per key or index by a dynamic `for` body leaves observable ticks.
+    struct coverage_observe_operator : hgraph::Operator<"hgl_coverage_observe", hgraph::In<"ts", hgraph::TS<hgraph::Float>>>
+    {};
+
+    struct coverage_observe_node
+    {
+        static inline std::vector<double> observed{};
+
+        static void eval(hgraph::In<"ts", hgraph::TS<hgraph::Float>> ts) { observed.push_back(ts.value()); }
+    };
+
+    void register_coverage_operators() {
+        static const bool registered = [] {
+            ensure_session();
+            hgraph::register_graph_overload<coverage_triple_operator, coverage_triple_graph>();
+            hgraph::register_graph_overload<coverage_book_operator, coverage_book_graph>();
+            hgraph::register_graph_overload<coverage_samples_operator, coverage_samples_graph>();
+            hgraph::register_overload<coverage_observe_operator, coverage_observe_node>();
+            return true;
+        }();
+        static_cast<void>(registered);
+    }
+
+    // A unit through the frontend against the live registry, ready for the
+    // backend; the same shape as `backend_tests.cpp`.
+    struct Unit
+    {
+        SourceFile             file;
+        DiagnosticSink         diagnostics;
+        ast::Module            module;
+        ResolvedModule         resolved;
+        hgl::ir::hir::Module   hir;
+        hgl::hgraph_ir::Module graph_ir;
+
+        explicit Unit(std::string text)
+            : file{"coverage.hgl", std::move(text)}, module{parse(file, diagnostics)},
+              resolved{resolve(file, module, has_operator, diagnostics)} {
+            if (!diagnostics.has_errors()) { hir = hgl::ir::lower_to_hir(module, resolved, diagnostics); }
+            if (!diagnostics.has_errors() && hgl::ir::complete_hir(hir, resolve_operator_types, diagnostics)) {
+                graph_ir = hgl::hgraph_ir::lower(hir, diagnostics);
+            }
+        }
+
+        [[nodiscard]] std::vector<TestResult> tests(std::vector<std::string> names = {}) {
+            INFO(diagnostics.render(file));
+            REQUIRE_FALSE(diagnostics.has_errors());
+            TestOptions options;
+            options.names = std::move(names);
+            return run_tests(file, graph_ir, options, diagnostics);
+        }
+
+        [[nodiscard]] bool has(Category category, std::string_view fragment) const {
+            return std::any_of(diagnostics.diagnostics().begin(), diagnostics.diagnostics().end(), [&](const Diagnostic &d) {
+                return d.category == category && d.message.find(fragment) != std::string::npos;
+            });
+        }
+    };
+
+    TestResult only(std::vector<TestResult> results) {
+        REQUIRE(results.size() == 1);
+        return std::move(results.front());
+    }
+
+    void check_all_pass(Unit &unit) {
+        for (const TestResult &result : unit.tests()) {
+            INFO(result.name << ": " << result.message);
+            CHECK(result.passed);
+        }
+    }
+}  // namespace
+
+TEST_CASE("reference-typed compositions forward a selected source to operator consumers", "[wiring][coverage][ref]") {
+    Unit unit{R"(
+module coverage.reference_routing
+
+use hgraph.std::{abs_, add_, if_then_else}
+
+// The composition form of the example's `forward`: a reference parameter
+// passes through untouched. References are opaque to composition code, so
+// the selected value is observed through operators that accept a reference
+// input, not through arithmetic on the reference.
+fn forward(value: ref<f64>) -> ref<f64> => value
+
+fn select(condition: bool, a: f64, b: f64) -> f64 =>
+    add_(forward(if_then_else(condition, a, b)), 0.0)
+
+fn magnitude(condition: bool, a: f64, b: f64) -> f64 =>
+    abs_(forward(if_then_else(condition, a, b)))
+
+test select_ticks {
+    assert eval(select, condition: [true, false, false], a: [1.0, 2.0, 3.0], b: [10.0, 20.0, 30.0]) == [1.0, 20.0, 30.0]
+}
+
+test magnitude_ticks {
+    assert eval(magnitude, condition: [true, false, false], a: [-1.0, 2.0, 3.0], b: [10.0, -20.0, 30.0]) == [1.0, 20.0, 30.0]
+}
+)"};
+    check_all_pass(unit);
+}
+
+TEST_CASE("fixed-list index routing follows the selected source", "[wiring][coverage][ref]") {
+    register_coverage_operators();
+    Unit unit{R"(
+module coverage.reference_routing
+
+use hgraph.std::{add_, hgl_coverage_triple}
+
+// The shape of the example's `route3`: one element of a fixed list selected
+// by a temporal index. Indexing a temporal list yields a reference to the
+// selected element, consumed here by `add_`.
+fn route(index: i64, a: f64, b: f64, c: f64) -> f64 {
+    let values: list<f64, 3> = hgl_coverage_triple(a, b, c)
+    add_(values[index], 0.0)
+}
+
+// The generated fixture's case: a constant index follows the first source.
+test route_first_ticks {
+    assert eval(route, index: [0], a: [1.0, 2.0], b: [10.0, 20.0], c: [100.0, 200.0]) == [1.0, 2.0]
+}
+
+test route_switching_ticks {
+    assert eval(route, index: [0, 1, 2], a: [1.0, 2.0, 3.0], b: [10.0, 20.0, 30.0], c: [100.0, 200.0, 300.0]) == [1.0, 20.0, 300.0]
+}
+)"};
+    check_all_pass(unit);
+}
+
+TEST_CASE("a reference result runs under eval and its adaptation to a plain result is a backend boundary",
+          "[wiring][coverage][ref]") {
+    SECTION("a ref<f64> composition wires and runs") {
+        Unit             unit{R"(
+module coverage.reference_result
+
+use hgraph.std::{if_then_else}
+
+fn pick(condition: bool, a: f64, b: f64) -> ref<f64> => if_then_else(condition, a, b)
+
+// The harness records the reference itself, so there is no float sequence to
+// assert against; the test passes when the graph wires and runs.
+test pick_runs {
+    eval(pick, condition: [true, false], a: [1.0, 2.0], b: [10.0, 20.0])
+}
+)"};
+        const TestResult result = only(unit.tests());
+        INFO(unit.diagnostics.render(unit.file));
+        INFO(result.message);
+        CHECK(result.passed);
+    }
+
+    SECTION("a reference is not adapted to a declared plain result") {
+        // The frontend accepts a reference where its target type is declared;
+        // the direct backend's result adaptation then resolves hgraph's
+        // `convert` operator, which is ambiguous for a reference source, so
+        // the test fails with a diagnostic instead of wiring-time
+        // dereference. The generated fixture routes through a declared
+        // `ref<T>` result instead. When the direct backend adapts a reference
+        // at the result boundary this section becomes a tick assertion.
+        Unit             unit{R"(
+module coverage.reference_result
+
+use hgraph.std::{if_then_else}
+
+fn pick(condition: bool, a: f64, b: f64) -> f64 => if_then_else(condition, a, b)
+
+test pick_ticks {
+    assert eval(pick, condition: [true, false], a: [1.0, 2.0], b: [10.0, 20.0]) == [1.0, 20.0]
+}
+)"};
+        const TestResult result = only(unit.tests());
+        CHECK_FALSE(result.passed);
+        CHECK(unit.diagnostics.has_errors());
+    }
+}
+
+TEST_CASE("generic operator resolution over tick and duration windows", "[wiring][coverage][generic]") {
+    Unit unit{R"(
+module coverage.operators_and_generics
+
+use hgraph.std::{mean, to_window}
+
+// The example's exported windows: tick windows whose minimum defaults to the
+// maximum, and a duration window. `mean` resolves to the window candidate
+// for each concrete `rolling` shape.
+fn summarize_full_window(window: rolling<f64, 20>) -> f64 => mean(window)
+
+fn summarize_short_window(window: rolling<f64, 3>) -> f64 => mean(window)
+
+fn summarize_recent(window: rolling<f64, 5m>) -> f64 => mean(window)
+
+// `eval` drives only ts parameters, so each window is built inside the
+// composition from `to_window`; the declared `rolling` type of the receiving
+// parameter or local gives the operator its expected result shape.
+fn full_window_mean(x: f64) -> f64 => summarize_full_window(to_window(x, 20, 20))
+
+fn short_window_mean(x: f64) -> f64 => summarize_short_window(to_window(x, 3, 3))
+
+fn partial_window_mean(x: f64) -> f64 {
+    let window: rolling<f64, 3, 1> = to_window(x, 3, 1)
+    mean(window)
+}
+
+fn recent_mean(x: f64) -> f64 => summarize_recent(to_window(x, 5m, 5m))
+
+fn open_recent_mean(x: f64) -> f64 {
+    let window: rolling<f64, 5m, 0s> = to_window(x, 5m, 0s)
+    mean(window)
+}
+
+// The generated fixture's fixed-window case: the mean of 1..20 arrives once
+// the window is full.
+test full_window_ticks {
+    assert eval(
+        full_window_mean,
+        x: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0],
+    ) == [_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, 10.5]
+}
+
+test short_window_ticks {
+    assert eval(short_window_mean, x: [1.0, 2.0, 3.0, 4.0]) == [_, _, 2.0, 3.0]
+}
+
+test partial_window_ticks {
+    assert eval(partial_window_mean, x: [1.0, 2.0, 3.0, 4.0]) == [1.0, 1.5, 2.0, 3.0]
+}
+
+// The generated fixture's duration case: one-microsecond harness cycles never
+// span the five-minute minimum, so the window never becomes valid.
+test recent_ticks {
+    assert eval(recent_mean, x: [1.0, 2.0]) == [_, _]
+}
+
+test open_recent_ticks {
+    assert eval(open_recent_mean, x: [1.0, 2.0]) == [1.0, 1.5]
+}
+)"};
+    check_all_pass(unit);
+}
+
+TEST_CASE("a source-defined generic operator needs the scripted image in direct wiring", "[wiring][coverage][generic]") {
+    // The example's `operator summarize` + generic `impl fn`. The file driver
+    // compiles such a unit to a native image and loads its candidates before
+    // wiring (`hgl test` on Unix); this harness has no loader, so the call is
+    // an operator diagnostic rather than a silently wrong graph.
+    Unit unit{R"(
+module coverage.source_operator
+
+use hgraph.std::{mean, to_window}
+
+operator summarize<T, const max_size: i64, const min_size: i64>(window: rolling<T, max_size, min_size>) -> T
+
+impl fn summarize<const max_size: i64, const min_size: i64>(window: rolling<f64, max_size, min_size>) -> f64 =>
+    mean(window)
+
+fn summarize_full_window(window: rolling<f64, 3>) -> f64 => summarize(window)
+
+fn full_window_mean(x: f64) -> f64 => summarize_full_window(to_window(x, 3, 3))
+
+test full_window_ticks {
+    assert eval(full_window_mean, x: [1.0, 2.0, 3.0, 4.0]) == [_, _, 2.0, 3.0]
+}
+)"};
+    if (!unit.diagnostics.has_errors()) {
+        const TestResult result = only(unit.tests());
+        CHECK_FALSE(result.passed);
+    }
+    INFO(unit.diagnostics.render(unit.file));
+    CHECK(unit.diagnostics.has_errors());
+    CHECK(unit.has(Category::Operator, "summarize"));
+}
+
+TEST_CASE("dynamic collection graph iteration ticks one child per key or index", "[wiring][coverage][iteration]") {
+    register_coverage_operators();
+    Unit unit{R"(
+module coverage.dynamic_iteration
+
+use hgraph.std::{hgl_coverage_book, hgl_coverage_observe, hgl_coverage_samples}
+
+// `eval` drives only ts parameters, so the map and the unbounded list come
+// from registered graphs. `offset` is a shared capture passed whole to every
+// child; each child records what it computes on every cycle it evaluates.
+fn observe_values(trigger: f64, offset: f64) {
+    let book: map<str, f64> = hgl_coverage_book(trigger)
+    for value in values(book) {
+        hgl_coverage_observe(value + offset)
+    }
+}
+
+fn observe_items(trigger: f64, offset: f64) {
+    let book: map<str, f64> = hgl_coverage_book(trigger)
+    for key, value in items(book) {
+        hgl_coverage_observe(value + offset)
+    }
+}
+
+fn observe_list_values(trigger: f64, offset: f64) {
+    let samples: list<f64> = hgl_coverage_samples(trigger)
+    for value in values(samples) {
+        hgl_coverage_observe(value + offset)
+    }
+}
+
+fn observe_list_items(trigger: f64, offset: f64) {
+    let samples: list<f64> = hgl_coverage_samples(trigger)
+    for index, value in items(samples) {
+        hgl_coverage_observe(value + index + offset)
+    }
+}
+
+test values_ticks {
+    eval(observe_values, trigger: [1.0], offset: [10.0, 20.0])
+}
+
+test items_ticks {
+    eval(observe_items, trigger: [1.0], offset: [10.0, 20.0])
+}
+
+test list_values_ticks {
+    eval(observe_list_values, trigger: [1.0], offset: [10.0, 20.0])
+}
+
+test list_items_ticks {
+    eval(observe_list_items, trigger: [1.0], offset: [10.0, 20.0])
+}
+)"};
+    struct Expectation
+    {
+        const char         *name;
+        std::vector<double> ticks;  // sorted: child order is not observable
+    };
+    const std::vector<Expectation> expectations{
+        {"values_ticks", {11.0, 12.0, 21.0, 22.0}},
+        {"items_ticks", {11.0, 12.0, 21.0, 22.0}},
+        {"list_values_ticks", {11.0, 12.0, 21.0, 22.0}},
+        {"list_items_ticks", {11.0, 13.0, 21.0, 23.0}},
+    };
+    for (const Expectation &expectation : expectations) {
+        coverage_observe_node::observed.clear();
+        const TestResult result = only(unit.tests({expectation.name}));
+        INFO(unit.diagnostics.render(unit.file));
+        INFO(result.name << ": " << result.message);
+        CHECK(result.passed);
+        std::vector<double> observed = coverage_observe_node::observed;
+        std::ranges::sort(observed);
+        CHECK(observed == expectation.ticks);
+    }
+}


### PR DESCRIPTION
Implements corrective-roadmap item 4 ("Tests") of #767. Paths are relative to `language/`.

## Deliverables

1. **CTest runs `hgl test` for every example that declares a `test` block.** `tests/CMakeLists.txt` discovers them with a configure-time glob plus `file(STRINGS ... REGEX "^test ")`, not a hand-written list. Composition-only examples register on every platform; an example containing a runtime form (`^[ \t]*(state|inject|when|start|stop)\b`) or `impl fn` is collected and registered inside the existing `if(UNIX)` block with the scripted-cache environment (rule documented in a comment). `midpoint.hgl` keeps its `hgraph::analytics` gate through a `use hgraph.analytics` content check. Each case asserts `"<N> tests?, 0 failed"` with N counted from the file. New cases: `hgraph_language_test_conditional-early-return` (8 tests) and `hgraph_language_test_conditional-omitted-else` (1 test); `hgraph_language_test_midpoint` is now produced by the same loop.
2. **Expression-embedded temporal conditional pinned.** `choose_embedded` and `choose_embedded_ticks` in `tests/codegen/parity.hgl` (`(if condition { x } else { y }) + 1`, ticks `[2, 21]`); the matching `eval_node` expectation in `tests/codegen/generated_tests.cpp`; the parity regex is now `"8 tests, 0 failed"`; the two emitter export snapshots in `emitter_tests.cpp` include the new export. The generated side passes, so the four documented sentences (`docs/design/roadmap.md`, `docs/design/control-flow.md` x3, `docs/user-guide/functions.md`) now say the form is implemented in both backends and pinned by the parity fixture. No other doc sentences were touched.
3. **Direct-wiring coverage.** New `tests/wiring/backend_coverage_tests.cpp` added to `hgl_wiring_tests` (6 cases, 40 assertions): `ref<f64>` parameter/result pass-through consumed by `add_`/`abs_`; fixed-list index routing (the `route3` shape) with a constant index and a switching index; generic `mean` resolution over `rolling<f64, 20>` (the generated fixture's 20-tick case), `rolling<f64, 3>`, `rolling<f64, 3, 1>`, and duration windows `rolling<f64, 5m>` / `rolling<f64, 5m, 0s>` built with `to_window`; dynamic map and unbounded-list traversal (`values`/`items`) with per-child ticks recorded by a test sink across two cycles. What the direct backend cannot express is stated in comments and pinned as a boundary: a `ref<f64>` operator result adapted to a declared `f64` result, and a source-defined `operator` + `impl fn` (needs the scripted image the file driver loads). `eval` drives only `TS`/`SIGNAL` parameters, so references, windows and collections are built inside the compositions from registry operators; the example's runtime `forward`/`route3` stay generated-only.
4. **REPL smoke split.** `hgraph_language_repl_composition_smoke` (new `tests/repl/repl_composition_smoke.cmake`: `let` persistence, compositions calling each other, `eval` with `_` padding, an embedded temporal conditional, `:quit`) runs on every platform; the existing `hgraph_language_repl_smoke` (declares an `impl fn`) moves inside `if(UNIX)`, script unchanged.
5. **stdlib fixtures.** Every `stdlib/examples/**/*.hgl` now has a `module stdlib.examples.<name>` / `module stdlib.examples.invalid.<name>` line; every `invalid/` fixture opens with `// expect: <substring>`; `tests/stdlib/check_invalid_fixture.cmake` runs `hgl check` and passes only when the check fails and the output contains every expectation. Registered: `hgraph_language_stdlib_invalid_conditional-unassigned-result` (definite assignment; verified to produce `'r' may be used before it is assigned` once the module line is present). The enum/switch fixtures are not registered; `stdlib/README.md` "Fixture status" says they are wired the moment their construct lands and that their `// expect:` substrings record the agreed rule in the fixture's own words. Fixture bodies are unchanged.
6. **Docs owned by this PR.** `examples/README.md` lists all 16 examples with what each demonstrates and which have tests (the "declare no tests yet" claim is gone); `docs/developer-guide/testing-and-compatibility.md` describes the glob (making "every `test` in the guide examples runs under `hgl test` in CI" true), corrects the "dense and timed" and "compare the wired node and edge sets" claims to what is tested, and records the new coverage file, REPL split and stdlib runner; `stdlib/README.md` fixture status; `CHANGELOG.md` entry as the last bullet under Unreleased.

## Evidence

`ctest --test-dir build-hgl -R hgraph_language --output-on-failure -j4` (macOS, Ninja, Release, `HGRAPH_BUILD_LANGUAGE=ON`, analytics extension on):

```
Test #50: hgraph_language_test_conditional-early-return ..................   Passed
Test #51: hgraph_language_test_conditional-omitted-else ..................   Passed
Test #52: hgraph_language_test_midpoint ..................................   Passed
Test #49: hgraph_language_test_parity ....................................   Passed
Test #60: hgraph_language_repl_composition_smoke .........................   Passed
Test #57: hgraph_language_repl_smoke .....................................   Passed
Test #62: hgraph_language_stdlib_invalid_conditional-unassigned-result ...   Passed
Test #42: hgraph_language_wiring .........................................   Passed
Test #47: hgraph_language_codegen ........................................   Passed
Test #48: hgraph_language_generated ......................................   Passed
100% tests passed, 0 tests failed out of 54
```

(54 cases; the tree at `origin/main` registers 50 in the same configuration.)
`hgl_wiring_tests "[coverage]"`: All tests passed (40 assertions in 6 test cases).
`git clang-format --diff origin/main`: clean.

## Findings noted while probing the direct backend (not changed here)

- A `ref<T>` operator result flowing into a declared plain result fails on direct wiring with hgraph's ambiguous `convert` (`convert_identity` vs `convert_bundle_upcast`) rather than a construct-naming diagnostic or an adaptation; pinned as a boundary in `backend_coverage_tests.cpp`.
- `dereference` accepts only TSB/TSL references, so a scalar `ref<f64>` can be observed on direct wiring only through an operator input.
- `to_window(...)` reports `operator 'to_window' needs an expected result type` unless the receiving parameter or local declares a `rolling` type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
