### PR TITLE
HGL: report control-flow guards once from shared IR, unify reserved names, direct-backend map lambda (#767 item 3)

### DIFF
--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -117,6 +117,16 @@
   for Unix, and give the standard-library design fixtures `module` lines and
   an `// expect:` diagnostic convention with a CTest runner for the
   implemented definite-assignment fixture.
+- Report each first-pass control-flow rule once from hgraph IR: the shared
+  analysis attaches the rule to its plan (`PlanIssue`), lowering reports the
+  context-free ones so `hgl check` rejects them, and the backends forward the
+  rest instead of carrying copies; a CTest case now fails when both backends
+  own the same diagnostic text. Optional-field clearing through a sparse delta
+  has one wording. The direct backend wires `map(a, b, fn(x, y) => ...)` as a
+  per-key child graph, matching the generated backend. `hgl emit-cpp
+  --print-namespace` prints a module's C++ namespace and `hgl_add_module()`
+  writes the Python bootstrap from the generated descriptors, removing the
+  CMake copies of the reserved-name tables (#767, item 3).
 
 ## 0.1.0
 

--- a/language/cmake/HglLanguage.cmake
+++ b/language/cmake/HglLanguage.cmake
@@ -30,54 +30,37 @@
 # The `hgl` compiler is the `hgl` target when the language is part of the
 # build, else the installed `hgl` program (set HGL_EXECUTABLE to override).
 
+# Script mode. `hgl_add_module` runs this file with `cmake -P` at build time
+# to write a package's Python bootstrap from the descriptors `emit-cpp`
+# produced. Each descriptor carries its module's registration symbol
+# (`pkg::new_::register_operators`), so the C++ spelling of a module
+# namespace has exactly one source, the compiler; CMake never re-derives it
+# from the `module` line.
+if(CMAKE_SCRIPT_MODE_FILE AND HGL_BOOTSTRAP_OUT)
+    set(HGL_PYTHON_MODULE "${HGL_BOOTSTRAP_MODULE}")
+    set(HGL_PYTHON_INCLUDES "")
+    set(HGL_PYTHON_REGISTRATIONS "")
+    foreach(_header IN LISTS HGL_BOOTSTRAP_HEADERS)
+        string(APPEND HGL_PYTHON_INCLUDES "#include <${_header}>\n")
+    endforeach()
+    foreach(_descriptor IN LISTS HGL_BOOTSTRAP_DESCRIPTORS)
+        file(READ "${_descriptor}" _json)
+        string(JSON _symbol ERROR_VARIABLE _json_error GET "${_json}" build registration symbol)
+        if(_json_error OR NOT _symbol)
+            message(FATAL_ERROR "hgl_add_module: '${_descriptor}' carries no registration symbol: ${_json_error}")
+        endif()
+        string(APPEND HGL_PYTHON_REGISTRATIONS "    ${_symbol}();\n")
+    endforeach()
+    configure_file("${HGL_BOOTSTRAP_TEMPLATE}" "${HGL_BOOTSTRAP_OUT}" @ONLY)
+    return()
+endif()
+
 include_guard(GLOBAL)
 
 set(_HGL_LANGUAGE_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 if(NOT TARGET hgl::native_interface AND EXISTS "${_HGL_LANGUAGE_CMAKE_DIR}/HglLanguageTargets.cmake")
     include("${_HGL_LANGUAGE_CMAKE_DIR}/HglLanguageTargets.cmake")
 endif()
-
-# Keep module namespace spelling in lockstep with emit-cpp's generated C++.
-# HGL identifiers are broader than C++ identifiers (`module prices.new` is
-# valid), while the generated code also reserves a few implementation names.
-function(_hgl_cpp_name out_var name)
-    set(_reserved
-        alignas alignof and and_eq asm auto bitand bitor bool break case catch char char8_t char16_t char32_t class
-        compl concept const consteval constexpr constinit const_cast continue co_await co_return co_yield decltype default
-        delete do double dynamic_cast else enum explicit export extern false float for friend goto if inline int long mutable
-        namespace new noexcept not not_eq nullptr operator or or_eq private protected public register reinterpret_cast requires
-        return short signed sizeof static static_assert static_cast struct switch template this thread_local throw true try
-        typedef typeid typename union unsigned using virtual void volatile wchar_t while xor xor_eq
-        w hgraph std operators operator_contracts register_operators compose name defaults)
-    list(FIND _reserved "${name}" _reserved_index)
-    if(_reserved_index EQUAL -1)
-        set(${out_var} "${name}" PARENT_SCOPE)
-    else()
-        set(${out_var} "${name}_" PARENT_SCOPE)
-    endif()
-endfunction()
-
-function(_hgl_module_namespace out_var source)
-    file(STRINGS "${source}" _module_lines
-        REGEX "^[ \t]*module[ \t]+[A-Za-z_][A-Za-z0-9_.]*")
-    list(LENGTH _module_lines _module_count)
-    if(NOT _module_count EQUAL 1)
-        message(FATAL_ERROR
-            "hgl_add_module: '${source}' must contain exactly one module declaration")
-    endif()
-    list(GET _module_lines 0 _module_line)
-    string(REGEX REPLACE
-        "^[ \t]*module[ \t]+([A-Za-z_][A-Za-z0-9_.]*).*$" "\\1"
-        _module_name "${_module_line}")
-    string(REPLACE "." ";" _module_parts "${_module_name}")
-    set(_cpp_parts)
-    foreach(_part IN LISTS _module_parts)
-        _hgl_cpp_name(_cpp_part "${_part}")
-        list(APPEND _cpp_parts "${_cpp_part}")
-    endforeach()
-    list(JOIN _cpp_parts "::" _module_namespace)
-    set(${out_var} "${_module_namespace}" PARENT_SCOPE)
-endfunction()
 
 function(_hgl_resolve_compiler out_var)
     if(TARGET hgl)
@@ -113,17 +96,11 @@ function(hgl_add_module target)
         message(FATAL_ERROR "hgl_add_module(${target}): use OUT_DIR or INCLUDE_DIR/SRC_DIR, not both")
     endif()
     if(_hgl_PYTHON_MODULE)
+        # The shape check is early feedback; `emit-cpp --python-native` owns the
+        # Python identifier and keyword rules and rejects the name at build time.
         if(NOT _hgl_PYTHON_MODULE MATCHES "^[A-Za-z_][A-Za-z0-9_]*$")
             message(FATAL_ERROR
                 "hgl_add_module(${target}): PYTHON_MODULE must be one Python identifier")
-        endif()
-        set(_python_keywords
-            False None True and as assert async await break class continue def del elif else except finally for from global if
-            import in is lambda nonlocal not or pass raise return try while with yield)
-        list(FIND _python_keywords "${_hgl_PYTHON_MODULE}" _python_keyword_index)
-        if(NOT _python_keyword_index EQUAL -1)
-            message(FATAL_ERROR
-                "hgl_add_module(${target}): PYTHON_MODULE cannot be the Python keyword '${_hgl_PYTHON_MODULE}'")
         endif()
     endif()
 
@@ -229,23 +206,29 @@ function(hgl_add_module target)
     set_property(TARGET ${target} PROPERTY HGL_MODULE_DESCRIPTORS "${_generated_descriptors}")
 
     if(_hgl_PYTHON_MODULE)
-        # One registration call per HGL module, in HGL source order.
-        set(_includes)
-        set(_registrations)
-        foreach(_hgl_file IN LISTS _hgl_HGL)
-            get_filename_component(_hgl_abs "${_hgl_file}" ABSOLUTE)
-            get_filename_component(_stem "${_hgl_abs}" NAME_WE)
-            string(APPEND _includes "#include <${_stem}.h>\n")
-            # Read the module declaration at configure time because this
-            # bootstrap has to reference every generated registration function.
-            _hgl_module_namespace(_module_ns "${_hgl_abs}")
-            string(APPEND _registrations "    ${_module_ns}::register_operators();\n")
+        # One registration call per HGL module, in HGL source order. The
+        # bootstrap is written at build time (this file in script mode) from
+        # the descriptors emit-cpp produces: the compiler alone spells each
+        # module's C++ namespace, so no table here can drift from it.
+        set(_bootstrap_headers)
+        foreach(_stem IN LISTS _generated_stems)
+            list(APPEND _bootstrap_headers "${_stem}.h")
         endforeach()
-        set(HGL_PYTHON_MODULE "${_hgl_PYTHON_MODULE}")
-        set(HGL_PYTHON_INCLUDES "${_includes}")
-        set(HGL_PYTHON_REGISTRATIONS "${_registrations}")
         set(_python_module_source "${CMAKE_CURRENT_BINARY_DIR}/hgl/${target}/${_hgl_PYTHON_MODULE}_module.cpp")
-        configure_file("${_HGL_LANGUAGE_CMAKE_DIR}/hgl_python_module.cpp.in" "${_python_module_source}" @ONLY)
+        set(_bootstrap_template "${_HGL_LANGUAGE_CMAKE_DIR}/hgl_python_module.cpp.in")
+        add_custom_command(
+            OUTPUT "${_python_module_source}"
+            COMMAND "${CMAKE_COMMAND}"
+                "-DHGL_BOOTSTRAP_OUT=${_python_module_source}"
+                "-DHGL_BOOTSTRAP_TEMPLATE=${_bootstrap_template}"
+                "-DHGL_BOOTSTRAP_MODULE=${_hgl_PYTHON_MODULE}"
+                "-DHGL_BOOTSTRAP_HEADERS=${_bootstrap_headers}"
+                "-DHGL_BOOTSTRAP_DESCRIPTORS=${_generated_descriptors}"
+                -P "${_HGL_LANGUAGE_CMAKE_DIR}/HglLanguage.cmake"
+            DEPENDS ${_generated_descriptors} "${_bootstrap_template}" "${_HGL_LANGUAGE_CMAKE_DIR}/HglLanguage.cmake"
+            COMMENT "hgl python bootstrap ${_hgl_PYTHON_MODULE}"
+            VERBATIM
+        )
 
         if(COMMAND hgraph_add_python_module AND TARGET hgraph::nanobind)
             hgraph_add_python_module(${_hgl_PYTHON_MODULE} STABLE_ABI NOMINSIZE "${_python_module_source}")
@@ -257,6 +240,7 @@ function(hgl_add_module target)
                 "(hgraph_add_python_module) or nanobind (nanobind_add_module)")
         endif()
         target_link_libraries(${_hgl_PYTHON_MODULE} PRIVATE ${target})
+        set_property(TARGET ${_hgl_PYTHON_MODULE} PROPERTY HGL_PYTHON_BOOTSTRAP "${_python_module_source}")
         # A generator expression suppresses the automatic Debug/Release child
         # directory that multi-config generators otherwise append. Wrappers,
         # __init__.py and the native extension therefore remain one package.

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -427,7 +427,8 @@ Result analysis is local to the conditional. A discarded outputless
 conditional uses this sink-switch path even when a later expression supplies
 the enclosing graph's return value. The current implementation accepts an
 omitted `else` or a block `else`; temporal `else if` lowering remains staged and
-is diagnosed explicitly.
+is diagnosed explicitly, once, by the shared analysis (`PlanIssue` in
+`hgraph_ir/control_flow.h`) rather than by each backend.
 
 The true branch takes `value` as a temporal input, with `"enabled"` as its
 fixed label. The selector is `enabled`. The false path has no conditional

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -269,7 +269,32 @@ nominal operator bindings, exports, and registration plans. A declaration
 range maps each typed struct, local operator, callable, or test handle to the
 record it names;
 invalid, duplicate, missing, and imported-operator entries in the source-order
-sequence are backend diagnostics. Callable and operator parameter/result names,
+sequence are backend diagnostics.
+
+A language rule is reported once, from hgraph IR, never from both backends.
+The control-flow analysis (`hgraph_ir/control_flow.h`) attaches every
+first-pass rule a temporal conditional or graph-phase loop breaks to its plan
+as a `PlanIssue` carrying the message text: temporal `else if`, a return
+inside a branch that cannot terminate the callable, scalar configuration
+captured by a temporal branch or a dynamic loop body, assignment escaping a
+loop, return from a loop, graph-phase iterator predicates, `keys(...)`, and
+unsupported collection kinds. `report_first_pass_rules`, run by hgraph IR
+lowering, reports the context-free issues together with the other shared
+rules (assignment places that are not plain bindings, the shape of a
+`map(...)` call with an anonymous function, runtime-only intrinsics in a
+composition body, clearing an optional field through a sparse delta), so
+`hgl check` rejects them before either backend runs. A backend forwards a
+plan's remaining issues and otherwise keeps only invariant checks about the IR
+it consumes, whose messages begin with `hgraph IR`. The CTest case
+`hgraph_language_backend_diagnostics_shared_once`
+(`tests/cmake/backend_diagnostics.cmake`) fails when the same diagnostic text
+is passed to a reporting helper in both `wiring/backend.cpp` and
+`codegen/cpp_emitter.cpp`; the `hgraph IR` prefix and short literal fragments
+are its only exemptions. One rule stays a backend decision with shared
+wording, `first_pass::unsupported_temporal_literal`, because a zoned or civil
+literal folded into a constant comparison never reaches a backend.
+
+Callable and operator parameter/result names,
 roles, canonical types, rolling-window shapes, generated selector signatures,
 and supported callable parameter defaults now come from hgraph IR. Nominal struct
 identity, abstractness, type-generic parameters, applied parents, and effective
@@ -1457,7 +1482,12 @@ overrides the executable selected when `hgl` was built.
 
 What is emitted, in this order:
 
-Before emission, hgraph IR determines the module namespace, typed source-order
+Before emission, hgraph IR determines the module namespace (`module_namespace`
+in `codegen/cpp_emitter.h`, the one place that escapes a segment that is a C++
+keyword or a name the generated code reserves; `hgl emit-cpp --print-namespace`
+prints it, and the descriptor's registration symbol carries it, so
+`hgl_add_module()` writes the Python bootstrap at build time from the
+descriptors instead of re-deriving the spelling), typed source-order
 declaration sequence, callable set, visibility, composition/runtime
 classification, canonical callable and operator identities, export surface,
 registry bindings, and all callable/operator parameter and result types.

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -200,6 +200,7 @@ hgl run path/to/program.hgl [--entry name] [--mode sim|realtime]
         [--module-descriptor <file>]...
 hgl emit-cpp path/to/program.hgl [--out-dir <dir> | --include-dir <dir> --src-dir <dir>]
         [--python <file.py> --python-native <module>] [--print]
+        [--print-namespace]
         [--module-descriptor <file>]...
 hgl repl [--module-descriptor <file>]...
 ```
@@ -383,7 +384,10 @@ links the target that supplies the native header and exact symbol. This initial
 bootstrap follows direct target edges; it does not yet calculate a transitive
 locked package closure. `PYTHON_MODULE` adds a
 stable-ABI extension module whose import registers every operator the HGL
-modules export, and a Python package directory with one generated wrapper
+modules export (its bootstrap is generated at build time from each module's
+descriptor, which carries the registration symbol the compiler spelled; the
+same spelling is what `hgl emit-cpp <file> --print-namespace` prints), and a
+Python package directory with one generated wrapper
 module per source so that
 
 ```python

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -810,7 +810,7 @@ namespace hgl::codegen
                         return make_const("hgraph::Str{" + quote(item) + "}", scalar_type(hir::ScalarType::Str), range);
                     } else if constexpr (std::is_same_v<T, syntax::TemporalValue>) {
                         if (std::optional<Value> value = temporal_constant(item, range)) { return std::move(*value); }
-                        backend(range, "zoned and civil literals are not supported by the first pass");
+                        backend(range, std::string{gir::first_pass::unsupported_temporal_literal});
                     }
                 },
                 literal);
@@ -1414,7 +1414,7 @@ namespace hgl::codegen
                     backend(value.range, "passing a function to an operator is not supported by the first pass");
                 case Value::Kind::Void: break;
             }
-            backend(value.range, "this expression produces no value");
+            backend(value.range, "hgraph IR value produces no wiring value");
         }
 
         std::string Emitter::as_runtime(const Value &value, const HType &target, SourceRange range, const std::string &what) {
@@ -1864,8 +1864,7 @@ namespace hgl::codegen
                 }
                 const auto found = nested.planned_bindings.find(slot.binding.value);
                 if (found == nested.planned_bindings.end()) {
-                    backend(body_range,
-                            "a time-series conditional branch did not assign escaping result '" + slot.field_name + "'");
+                    backend(body_range, "hgraph IR conditional branch did not assign escaping result '" + slot.field_name + "'");
                 }
                 outputs.push_back(as_port(found->second, type, body_range));
             }
@@ -1957,12 +1956,9 @@ namespace hgl::codegen
             const gir::ConditionalPlan plan    = gir::analyze_temporal_conditional(graph_, id, std::move(continuation));
             const auto                 results = gir::plan_temporal_conditional_results(graph_, plan, result_used);
             if (returns_from_callable != nullptr) { *returns_from_callable = plan.returns_from_callable; }
-            if (plan.has_otherwise && !plan.when_false) {
-                backend(range, "temporal 'else if' is not supported in this compiler stage; use a block 'else'");
-            }
-            if (!plan.returns_from_callable && (plan.when_true.returns || (plan.when_false && plan.when_false->returns))) {
-                backend(range, "return from a time-series 'if' branch is not supported in this compiler stage");
-            }
+            // The plan carries every first-pass rule it breaks; the wording is
+            // owned by the shared analysis (control_flow.h, PlanIssue).
+            for (const gir::PlanIssue &issue : plan.issues) { backend(issue.range, issue.message); }
 
             const gir::ConditionalBranchPlan           otherwise = plan.when_false.value_or(gir::ConditionalBranchPlan{});
             std::vector<std::pair<std::string, HType>> parameters;
@@ -1973,13 +1969,9 @@ namespace hgl::codegen
             arguments.reserve(plan.captures.size() + 2U);
             for (const gir::ConditionalCapture &capture : plan.captures) {
                 const gir::Binding &binding = planned_binding(capture.binding, range);
-                if (capture.phase != hir::Phase::Wiring) {
-                    backend(binding.range,
-                            "capturing scalar configuration in a time-series 'if' branch is not supported in this compiler stage");
-                }
-                const auto outer = frame.planned_bindings.find(capture.binding.value);
+                const auto          outer   = frame.planned_bindings.find(capture.binding.value);
                 if (outer == frame.planned_bindings.end() || !outer->second.is_port()) {
-                    backend(binding.range, "a temporal conditional capture is not bound to a time-series port");
+                    backend(binding.range, "hgraph IR conditional capture is not bound to a time-series port");
                 }
                 const std::string base   = cpp_name(binding.name);
                 std::string       name   = base;
@@ -2179,7 +2171,7 @@ namespace hgl::codegen
                     } else if constexpr (std::is_same_v<T, gir::Tuple>) {
                         unsupported(expression.range, "a tuple literal");
                     } else if constexpr (std::is_same_v<T, gir::Lambda>) {
-                        backend(expression.range, "anonymous functions are not supported by the first pass");
+                        backend(expression.range, "hgraph IR lambda outside a planned map call");
                     } else if constexpr (std::is_same_v<T, gir::Conditional>) {
                         if (expression.phase == hir::Phase::Wiring) {
                             return lower_planned_conditional(id, node, expression.range, frame);
@@ -2330,19 +2322,19 @@ namespace hgl::codegen
             for (const gir::Argument &argument : call.arguments) {
                 const gir::Value &expression = planned_value(argument.value, argument.range);
                 if (std::holds_alternative<gir::Lambda>(expression.node)) {
-                    if (lambda_id.valid()) { backend(expression.range, "map takes one anonymous function"); }
+                    if (lambda_id.valid()) { backend(expression.range, "hgraph IR map call has more than one anonymous function"); }
                     lambda_id = argument.value;
                 } else {
                     inputs.push_back(eval_planned_expr(argument.value, frame));
                 }
             }
-            if (!lambda_id.valid()) { backend(range, "map needs an anonymous function"); }
-            if (inputs.empty()) { backend(range, "map needs at least one temporal map input"); }
+            if (!lambda_id.valid()) { backend(range, "hgraph IR map call has no anonymous function"); }
+            if (inputs.empty()) { backend(range, "hgraph IR map call has no mapped input"); }
 
             const gir::Value  &lambda_expression = planned_value(lambda_id, range);
             const gir::Lambda &anonymous         = std::get<gir::Lambda>(lambda_expression.node);
             if (anonymous.parameters.size() != inputs.size()) {
-                fail(Category::Type, lambda_expression.range, "the map function parameter count must match its mapped inputs");
+                backend(lambda_expression.range, "hgraph IR anonymous map parameter count differs from its inputs");
             }
 
             Frame lambda;
@@ -2351,7 +2343,7 @@ namespace hgl::codegen
             for (std::size_t index = 0; index < inputs.size(); ++index) {
                 const Value &input = inputs[index];
                 if (!input.is_port() || input.type.kind != HType::Kind::Map) {
-                    backend(input.range, "the first anonymous map slice takes temporal map inputs");
+                    backend(input.range, "hgraph IR map call input is not a temporal map");
                 }
                 const gir::Binding &binding = planned_binding(anonymous.parameters[index], lambda_expression.range);
                 if (binding.kind != gir::BindingKind::LambdaParameter) {
@@ -2370,8 +2362,7 @@ namespace hgl::codegen
             const HType result_type =
                 anonymous.result.valid() ? planned_type(anonymous.result, lambda_expression.range) : lambda_result.type;
             if (result_type.kind == HType::Kind::Unknown) {
-                backend(planned_value(anonymous.body, lambda_expression.range).range,
-                        "the anonymous map result type cannot be inferred");
+                backend(planned_value(anonymous.body, lambda_expression.range).range, "hgraph IR anonymous map result has no type");
             }
 
             const std::string helper = "hgl_anonymous_" + std::to_string(++anonymous_function_index_);
@@ -2449,9 +2440,7 @@ namespace hgl::codegen
                 }
 
                 if (planned_null(argument->value, argument->range)) {
-                    if (delta) {
-                        backend(argument->range, "clearing an optional struct field needs a native clear-delta operation");
-                    }
+                    if (delta) { backend(argument->range, "hgraph IR delta construction retained an optional-field clear"); }
                     temporal_fields.push_back("hgraph::wire<hgraph::stdlib::nothing, " + schema(field_type, field_range) + ">(w)");
                     continue;
                 }
@@ -2558,13 +2547,12 @@ namespace hgl::codegen
             }
             if (name == "keys" || name == "values" || name == "items") {
                 if (!frame.runtime) {
-                    if (call.arguments.size() != 1U) { backend(range, "graph-phase iterator predicates are not defined yet"); }
+                    // The first-pass iterator rules are reported once by the
+                    // shared traversal analysis; the iterator only has to exist.
+                    if (call.arguments.size() != 1U) { backend(range, "hgraph IR graph iterator call has more than one argument"); }
                     const Value source = eval_planned_expr(call.arguments.front().value, frame);
                     if (!source.is_port() || (source.type.kind != HType::Kind::List && source.type.kind != HType::Kind::Map)) {
-                        backend(range, "graph-phase iteration currently supports temporal maps and lists");
-                    }
-                    if (name == "keys") {
-                        backend(range, "graph-phase keys(...) traversal is not defined yet; use values(...) or items(...)");
+                        backend(range, "hgraph IR graph iterator schema does not match its collection type");
                     }
 
                     Value result;
@@ -2644,7 +2632,7 @@ namespace hgl::codegen
                 }
                 return result;
             }
-            backend(range, "'" + name + "' is a runtime traversal; it is not available in a composition body of the first pass");
+            backend(range, "hgraph IR intrinsic without a composition lowering: " + name);
         }
 
         Value Emitter::eval_planned_call(const gir::Value &expression, const gir::Call &call, Frame &frame) {
@@ -2772,7 +2760,7 @@ namespace hgl::codegen
                         const gir::Value &place     = planned_value(node.place, statement.range);
                         const auto       *reference = std::get_if<gir::Reference>(&place.node);
                         if (reference == nullptr || reference->kind != gir::ReferenceKind::Binding) {
-                            backend(place.range, "assignment targets a local in the first pass");
+                            backend(place.range, "hgraph IR assignment place is not a binding");
                         }
                         const gir::Binding &binding = planned_binding(reference->binding, place.range);
                         if (binding.kind != gir::BindingKind::LocalVar) {
@@ -2835,16 +2823,15 @@ namespace hgl::codegen
                     } else if constexpr (std::is_same_v<T, gir::Traversal>) {
                         emit_planned_traversal(node, statement.range, frame, out);
                     } else {
-                        backend(statement.range, "runtime statements are not evaluated by the first pass");
+                        backend(statement.range, "hgraph IR runtime statement in a composition body");
                     }
                 },
                 statement.node);
         }
 
         void Emitter::emit_planned_traversal(const gir::Traversal &traversal, SourceRange range, Frame &frame, Writer &out) {
-            const gir::TraversalPlan plan = gir::analyze_traversal(graph_, traversal);
-            if (!plan.assigned_outer.empty()) { backend(range, "assignment escaping a graph 'for' body is not defined yet"); }
-            if (plan.returns) { backend(range, "return from a graph 'for' body is not defined yet"); }
+            const gir::TraversalPlan plan = gir::analyze_traversal(graph_, traversal, range);
+            for (const gir::PlanIssue &issue : plan.issues) { backend(issue.range, issue.message); }
 
             const gir::Value &iterable_expression = planned_value(traversal.iterable, range);
             const Value       iterator            = eval_planned_expr(traversal.iterable, frame);
@@ -2888,19 +2875,16 @@ namespace hgl::codegen
             const bool map          = iterator.type.kind == HType::Kind::Map;
             const bool dynamic_list = iterator.type.kind == HType::Kind::List && iterator.type.size.empty();
             if (!map && !dynamic_list) {
-                backend(iterable_expression.range, "dynamic graph traversal currently supports temporal maps and unbounded lists");
+                backend(iterable_expression.range, "hgraph IR dynamic traversal schema is not a temporal map or list");
             }
 
             std::vector<std::pair<gir::ConditionalCapture, Value>> captures;
             captures.reserve(plan.captures.size());
             for (const gir::ConditionalCapture &capture : plan.captures) {
                 const gir::Binding &binding = planned_binding(capture.binding, range);
-                if (capture.phase != hir::Phase::Wiring) {
-                    backend(binding.range, "capturing scalar configuration in a dynamic graph 'for' body is not supported yet");
-                }
-                const auto outer = frame.planned_bindings.find(capture.binding.value);
+                const auto          outer   = frame.planned_bindings.find(capture.binding.value);
                 if (outer == frame.planned_bindings.end() || !outer->second.is_port()) {
-                    backend(binding.range, "a dynamic graph traversal capture is not bound to a time-series port");
+                    backend(binding.range, "hgraph IR dynamic traversal capture is not bound to a time-series port");
                 }
                 captures.emplace_back(capture, outer->second);
             }
@@ -2969,10 +2953,9 @@ namespace hgl::codegen
         void Emitter::emit_planned_if(const gir::Conditional &branch, SourceRange range, Frame &frame, Writer &out) {
             const gir::Value &condition_expression = planned_value(branch.condition, range);
             const Value       condition            = eval_planned_expr(branch.condition, frame);
-            if (condition.is_port()) {
-                backend(condition_expression.range,
-                        "'if' over a time-series condition is not supported by the first pass; use if_then_else");
-            }
+            // A temporal condition is planned through switch_ before this
+            // scalar form is reached, so a port here is an IR inconsistency.
+            if (condition.is_port()) { backend(condition_expression.range, "hgraph IR scalar 'if' has a time-series condition"); }
             if (!condition.is_const() || !condition.type.is(hir::ScalarType::Bool)) {
                 fail(Category::Type, condition_expression.range, "an 'if' condition is a bool");
             }
@@ -4352,20 +4335,7 @@ namespace hgl::codegen
             EmittedModule result;
             result.module_name = graph_.path;
             if (result.module_name.empty()) { fail(Category::Module, SourceRange{0, 0}, "emit-cpp needs a module declaration"); }
-            {
-                std::string ns;
-                std::string part;
-                for (const char c : result.module_name) {
-                    if (c == '.') {
-                        ns += cpp_name(part) + "::";
-                        part.clear();
-                    } else {
-                        part += c;
-                    }
-                }
-                ns += cpp_name(part);
-                namespace_ = ns;
-            }
+            namespace_            = module_namespace(graph_);
             result.namespace_name = namespace_;
             module_name_          = result.module_name;
             basename_             = file_.path();
@@ -4609,6 +4579,21 @@ namespace hgl::codegen
             return result;
         }
     }  // namespace
+
+    std::string module_namespace(const hgraph_ir::Module &graph) {
+        std::string ns;
+        std::string part;
+        for (const char c : graph.path) {
+            if (c == '.') {
+                ns += cpp_name(part) + "::";
+                part.clear();
+            } else {
+                part += c;
+            }
+        }
+        ns += cpp_name(part);
+        return ns;
+    }
 
     std::optional<EmittedModule> emit_cpp(const syntax::SourceFile &file, const hgraph_ir::Module &graph,
                                           const EmitOptions &options, syntax::DiagnosticSink &diagnostics) {

--- a/language/src/codegen/cpp_emitter.h
+++ b/language/src/codegen/cpp_emitter.h
@@ -54,6 +54,14 @@ namespace hgl::codegen
         std::vector<std::string> exports{};
     };
 
+    /// The C++ namespace generated code for this module lives in
+    /// (`examples::prices` for `module examples.prices`; a segment that is a
+    /// C++ keyword or a name the generated code reserves gets a trailing
+    /// underscore). This is the only place that spelling is decided:
+    /// `hgl emit-cpp --print-namespace` prints it and the descriptor's
+    /// registration symbol carries it, so build tooling never re-derives it.
+    [[nodiscard]] std::string module_namespace(const hgraph_ir::Module &graph);
+
     /// Emit the module. Returns nullopt after reporting a diagnostic; every
     /// construct outside the first pass is reported as a `backend`
     /// diagnostic that names the construct.

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -54,7 +54,7 @@ namespace hgl::driver
                          "          [--set <name>=<constant expression>]... [--module-descriptor <file>]...\n"
                          "  hgl emit-cpp <file> [--out-dir <dir> | --include-dir <dir> --src-dir <dir>]\n"
                          "               [--python <file.py> --python-native <module>] [--print]\n"
-                         "               [--module-descriptor <file>]...\n"
+                         "               [--print-namespace] [--module-descriptor <file>]...\n"
                          "  hgl repl [--module-descriptor <file>]...\n"
                          "  hgl --help\n"
                          "  hgl --version\n\n"
@@ -64,7 +64,8 @@ namespace hgl::driver
                          "  run       bind an entry to a mode, clock and parameters, then execute it\n"
                          "  emit-cpp  write the module as a C++ header/source pair and versioned JSON\n"
                          "            descriptor, named after the file, in the module's namespace;\n"
-                         "            --python also writes the Python wrapper module\n"
+                         "            --python also writes the Python wrapper module and\n"
+                         "            --print-namespace only prints that C++ namespace\n"
                          "  repl      accumulate declarations and evaluate expressions interactively\n"
                          "            (line editing, history and completion on a terminal)\n\n"
                          "Native runtime environment (Unix):\n"
@@ -454,7 +455,8 @@ namespace hgl::driver
             std::optional<std::string> src_dir;
             std::optional<std::string> python_path;
             std::string                python_native;
-            bool                       print = false;
+            bool                       print           = false;
+            bool                       print_namespace = false;
             for (std::size_t i = 0; i < arguments.size(); ++i) {
                 const std::string_view argument = arguments[i];
                 const auto             value    = [&]() -> std::optional<std::string_view> {
@@ -483,6 +485,8 @@ namespace hgl::driver
                     python_native = std::string{*name};
                 } else if (argument == "--print") {
                     print = true;
+                } else if (argument == "--print-namespace") {
+                    print_namespace = true;
                 } else if (argument.starts_with("--")) {
                     return usage_error("unknown option '" + std::string{argument} + "'");
                 } else if (path) {
@@ -507,6 +511,12 @@ namespace hgl::driver
                                          "C++ generation requires completed hgraph IR");
                 std::cerr << unit->diagnostics.render(unit->file);
                 return exit_diagnostics;
+            }
+            if (print_namespace) {
+                // Build tooling asks the compiler rather than re-deriving the
+                // spelling from the module line (cmake/HglLanguage.cmake).
+                std::cout << codegen::module_namespace(*unit->hgraph) << '\n';
+                return exit_ok;
             }
 
             // Generated artifacts are named after the source: prices.hgl ->

--- a/language/src/hgraph_ir/control_flow.cpp
+++ b/language/src/hgraph_ir/control_flow.cpp
@@ -2,7 +2,10 @@
 
 #include <algorithm>
 #include <span>
+#include <string>
+#include <string_view>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 
@@ -314,6 +317,58 @@ namespace hgl::hgraph_ir
                 captures, [&](const ConditionalCapture &candidate) { return candidate.binding == capture.binding; });
             if (!exists) { captures.push_back(capture); }
         }
+
+        [[nodiscard]] syntax::SourceRange binding_range(const Module &module, BindingId binding, syntax::SourceRange fallback) {
+            return binding.valid() && binding.value < module.bindings.size() ? module.bindings[binding.value].range : fallback;
+        }
+
+        [[nodiscard]] const Value *value_at(const Module &module, ValueId id) {
+            return id.valid() && id.value < module.values.size() ? &module.values[id.value] : nullptr;
+        }
+
+        [[nodiscard]] const Type *type_at(const Module &module, TypeId id) {
+            return id.valid() && id.value < module.types.size() ? &module.types[id.value] : nullptr;
+        }
+
+        /// The name an intrinsic call resolves to, or empty when the callee is
+        /// not an intrinsic reference.
+        [[nodiscard]] std::string_view intrinsic_name(const Module &module, ValueId callee) {
+            const Value *target = value_at(module, callee);
+            if (target == nullptr) { return {}; }
+            const auto *reference = std::get_if<Reference>(&target->node);
+            if (reference == nullptr || reference->kind != ReferenceKind::Intrinsic) { return {}; }
+            return reference->registry_name.empty() ? reference->identity : reference->registry_name;
+        }
+
+        /// The first-pass rules a temporal conditional breaks. The message
+        /// text is owned here; both backends only forward it.
+        void record_conditional_issues(const Module &module, const Value &value, ConditionalPlan &plan) {
+            if (plan.has_otherwise && !plan.when_false) {
+                plan.issues.push_back(PlanIssue{
+                    .range        = value.range,
+                    .message      = "temporal 'else if' is not supported in this compiler stage; use a block 'else'",
+                    .context_free = true,
+                });
+            }
+            // Whether a branch return terminates the callable depends on the
+            // continuation the backend supplies, so this rule stays with the plan.
+            if (!plan.returns_from_callable && (plan.when_true.returns || (plan.when_false && plan.when_false->returns))) {
+                plan.issues.push_back(PlanIssue{
+                    .range        = value.range,
+                    .message      = "return from a time-series 'if' branch is not supported in this compiler stage",
+                    .context_free = false,
+                });
+            }
+            for (const ConditionalCapture &capture : plan.captures) {
+                if (capture.phase == ir::hir::Phase::Wiring) { continue; }
+                plan.issues.push_back(PlanIssue{
+                    .range = binding_range(module, capture.binding, value.range),
+                    .message =
+                        "capturing scalar configuration in a time-series 'if' branch is not supported in this compiler stage",
+                    .context_free = true,
+                });
+            }
+        }
     }  // namespace
 
     ConditionalContinuationPlan plan_temporal_continuation(const Module &module, BlockId enclosing, std::size_t first_statement,
@@ -407,6 +462,7 @@ namespace hgl::hgraph_ir
             // branch's assignments so generated child compositions can
             // materialize their local bindings.
             plan.assigned_outer.clear();
+            record_conditional_issues(module, value, plan);
             return plan;
         }
 
@@ -429,6 +485,7 @@ namespace hgl::hgraph_ir
                 });
             }
         }
+        record_conditional_issues(module, value, plan);
         return plan;
     }
 
@@ -481,13 +538,295 @@ namespace hgl::hgraph_ir
         return results;
     }
 
-    TraversalPlan analyze_traversal(const Module &module, const Traversal &traversal) {
+    TraversalPlan analyze_traversal(const Module &module, const Traversal &traversal, syntax::SourceRange range) {
         ConditionalBranchPlan nested = BranchAnalyzer{module, traversal.block, traversal.bindings}.take();
-        return TraversalPlan{
+        TraversalPlan         plan{
             .block          = nested.block,
             .captures       = std::move(nested.captures),
             .assigned_outer = std::move(nested.assigned_outer),
             .returns        = nested.returns,
         };
+        if (range.begin == range.end && traversal.block.valid() && traversal.block.value < module.blocks.size()) {
+            range = module.blocks[traversal.block.value].range;
+        }
+        const auto issue = [&](syntax::SourceRange at, std::string message) {
+            plan.issues.push_back(PlanIssue{.range = at, .message = std::move(message), .context_free = true});
+        };
+        if (!plan.assigned_outer.empty()) { issue(range, "assignment escaping a graph 'for' body is not defined yet"); }
+        if (plan.returns) { issue(range, "return from a graph 'for' body is not defined yet"); }
+
+        // The iterator forms the first pass defines for a graph-phase loop:
+        // one-argument values(...) or items(...) over a temporal map or list.
+        // Runtime loops (a traversal inside node evaluation) are unrestricted.
+        const Value *iterable = value_at(module, traversal.iterable);
+        if (iterable == nullptr || iterable->phase != ir::hir::Phase::Wiring) { return plan; }
+        bool dynamic = true;
+        if (const auto *call = std::get_if<Call>(&iterable->node)) {
+            const std::string_view name = intrinsic_name(module, call->callee);
+            if (name == "keys" || name == "values" || name == "items") {
+                if (call->arguments.size() != 1U) {
+                    issue(iterable->range, "graph-phase iterator predicates are not defined yet");
+                } else {
+                    const Value *source     = value_at(module, call->arguments.front().value);
+                    const Type  *collection = source != nullptr ? type_at(module, source->type) : nullptr;
+                    if (collection == nullptr ||
+                        (collection->kind != ir::hir::TypeKind::List && collection->kind != ir::hir::TypeKind::Map)) {
+                        issue(iterable->range, "graph-phase iteration currently supports temporal maps and lists");
+                    } else {
+                        dynamic = !(collection->kind == ir::hir::TypeKind::List && collection->size.valid());
+                    }
+                }
+                if (name == "keys") {
+                    issue(iterable->range, "graph-phase keys(...) traversal is not defined yet; use values(...) or items(...)");
+                }
+            }
+        }
+        if (!dynamic) { return plan; }
+        // A fixed list is unrolled at wiring time, so its body may read
+        // scalar configuration; a per-key child graph cannot yet.
+        for (const ConditionalCapture &capture : plan.captures) {
+            if (capture.phase == ir::hir::Phase::Wiring) { continue; }
+            issue(binding_range(module, capture.binding, range),
+                  "capturing scalar configuration in a dynamic graph 'for' body is not supported yet");
+        }
+        return plan;
+    }
+
+    namespace
+    {
+        /// Walks every callable and test body once and reports the
+        /// context-free first-pass rules. The graph-phase rules (loops,
+        /// temporal conditionals, assignment places, anonymous functions,
+        /// intrinsics) apply to composition bodies only: a runtime traversal,
+        /// predicate lambda, or indexed output assignment is ordinary node
+        /// evaluation. Clearing an optional field through a sparse delta is
+        /// rejected in either phase.
+        class FirstPassRules
+        {
+          public:
+            FirstPassRules(const Module &module, syntax::DiagnosticSink &diagnostics)
+                : module_{module}, diagnostics_{diagnostics} {}
+
+            void run() {
+                for (const Callable &callable : module_.callables) {
+                    runtime_ = callable.kind != CallableKind::Composition;
+                    visit_value(callable.concise_body);
+                    visit_block(callable.block_body);
+                }
+                runtime_ = false;
+                for (const TestPlan &test : module_.tests) { visit_block(test.body); }
+            }
+
+          private:
+            void report(syntax::SourceRange range, std::string message) {
+                diagnostics_.report(syntax::Category::Backend, range, std::move(message));
+            }
+
+            void report(const PlanIssue &issue) {
+                if (issue.context_free) { report(issue.range, issue.message); }
+            }
+
+            /// The operator a call resolves to, by registry spelling.
+            [[nodiscard]] std::string_view operator_name(const Value &value, const Call &call) const {
+                if (!value.operation.registry_name.empty()) { return value.operation.registry_name; }
+                const Value *target = value_at(module_, call.callee);
+                if (target == nullptr) { return {}; }
+                const auto *reference = std::get_if<Reference>(&target->node);
+                if (reference == nullptr || reference->kind != ReferenceKind::Operator) { return {}; }
+                return reference->registry_name.empty() ? reference->identity : reference->registry_name;
+            }
+
+            /// `map(inputs..., fn(params...) => body)`: the shape both backends
+            /// lower as one per-key child graph.
+            void check_map_lambda_call(const Value &value, const Call &call) {
+                std::vector<const Value *> inputs;
+                const Value               *anonymous = nullptr;
+                for (const Argument &argument : call.arguments) {
+                    const Value *item = value_at(module_, argument.value);
+                    if (item == nullptr) { continue; }
+                    if (std::holds_alternative<Lambda>(item->node)) {
+                        if (anonymous != nullptr) { report(item->range, "map takes one anonymous function"); }
+                        anonymous = item;
+                    } else {
+                        inputs.push_back(item);
+                    }
+                }
+                if (anonymous == nullptr) { return; }
+                if (inputs.empty()) { report(value.range, "map needs at least one temporal map input"); }
+                for (const Value *input : inputs) {
+                    const Type *type = type_at(module_, input->type);
+                    if (type == nullptr || type->kind != ir::hir::TypeKind::Map) {
+                        report(input->range, "the first anonymous map slice takes temporal map inputs");
+                    }
+                }
+                const auto &lambda = std::get<Lambda>(anonymous->node);
+                if (lambda.parameters.size() != inputs.size()) {
+                    diagnostics_.report(syntax::Category::Type, anonymous->range,
+                                        "the map function parameter count must match its mapped inputs");
+                }
+                const Value *body   = value_at(module_, lambda.body);
+                const TypeId result = lambda.result.valid() ? lambda.result : (body != nullptr ? body->type : TypeId{});
+                if (type_at(module_, result) == nullptr) {
+                    report(anonymous->range, "the anonymous map result type cannot be inferred");
+                }
+            }
+
+            [[nodiscard]] const StructContract *structure(TypeId id) const {
+                const Type *type = type_at(module_, id);
+                while (type != nullptr && type->kind == ir::hir::TypeKind::Atomic && type->children.size() == 1U) {
+                    type = type_at(module_, type->children.front());
+                }
+                if (type == nullptr) { return nullptr; }
+                const auto found = std::ranges::find_if(
+                    module_.structures, [&](const StructContract &item) { return item.identity == type->nominal_identity; });
+                return found == module_.structures.end() ? nullptr : &*found;
+            }
+
+            [[nodiscard]] bool is_null(ValueId id) const {
+                const Value *value = value_at(module_, id);
+                if (value == nullptr) { return false; }
+                if (value->constant && std::holds_alternative<ir::hir::NullValue>(*value->constant)) { return true; }
+                const auto *literal = std::get_if<Literal>(&value->node);
+                return literal != nullptr && std::holds_alternative<ir::hir::NullValue>(literal->value);
+            }
+
+            void check_delta_clear(const Construct &construct) {
+                if (!construct.delta) { return; }
+                const StructContract *contract = structure(construct.type);
+                if (contract == nullptr) { return; }
+                for (const Argument &argument : construct.arguments) {
+                    if (!is_null(argument.value)) { continue; }
+                    const auto field =
+                        std::ranges::find_if(contract->fields, [&](const StructField &item) { return item.name == argument.name; });
+                    if (field == contract->fields.end() || !field->optional) { continue; }
+                    // An omitted delta field means no change; there is no public
+                    // hgraph operation yet that distinguishes an explicit clear.
+                    report(value_at(module_, argument.value)->range,
+                           "clearing an optional struct field needs the distinct public hgraph clear-delta operation");
+                }
+            }
+
+            void visit_block(BlockId id) {
+                if (!id.valid() || id.value >= module_.blocks.size()) { return; }
+                const Block &block = module_.blocks[id.value];
+                for (StatementId statement : block.statements) { visit_statement(statement); }
+                visit_value(block.tail);
+            }
+
+            void visit_statement(StatementId id) {
+                if (!id.valid() || id.value >= module_.statements.size()) { return; }
+                const Statement &statement = module_.statements[id.value];
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, LocalBinding> || std::is_same_v<T, StateBinding>) {
+                            visit_value(node.init);
+                        } else if constexpr (std::is_same_v<T, Lifecycle>) {
+                            visit_block(node.block);
+                        } else if constexpr (std::is_same_v<T, Activation>) {
+                            visit_value(node.condition);
+                            visit_block(node.block);
+                        } else if constexpr (std::is_same_v<T, Traversal>) {
+                            if (!runtime_) {
+                                const TraversalPlan plan = analyze_traversal(module_, node, statement.range);
+                                for (const PlanIssue &issue : plan.issues) { report(issue); }
+                            }
+                            visit_value(node.iterable);
+                            visit_block(node.block);
+                        } else if constexpr (std::is_same_v<T, Assignment>) {
+                            const Value *place     = value_at(module_, node.place);
+                            const auto  *reference = place != nullptr ? std::get_if<Reference>(&place->node) : nullptr;
+                            if (!runtime_ && place != nullptr &&
+                                (reference == nullptr || reference->kind != ReferenceKind::Binding)) {
+                                report(place->range, "assignment targets a local in the first pass");
+                            }
+                            visit_value(node.place);
+                            visit_value(node.value);
+                        } else if constexpr (std::is_same_v<T, Return>) {
+                            visit_value(node.value);
+                        } else if constexpr (std::is_same_v<T, Assert>) {
+                            visit_value(node.condition);
+                        } else if constexpr (std::is_same_v<T, Evaluate>) {
+                            visit_value(node.value);
+                        }
+                    },
+                    statement.node);
+            }
+
+            void visit_value(ValueId id) {
+                const Value *value = value_at(module_, id);
+                if (value == nullptr || !visited_.insert(id.value).second) { return; }
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, Unary>) {
+                            visit_value(node.operand);
+                        } else if constexpr (std::is_same_v<T, Binary>) {
+                            visit_value(node.lhs);
+                            visit_value(node.rhs);
+                        } else if constexpr (std::is_same_v<T, Call>) {
+                            const std::string_view intrinsic = intrinsic_name(module_, node.callee);
+                            if (!runtime_ && !intrinsic.empty() && value->phase == ir::hir::Phase::Wiring &&
+                                !composition_intrinsic(intrinsic)) {
+                                report(value->range, "'" + std::string{intrinsic} +
+                                                         "' is a runtime traversal; it is not available in a composition "
+                                                         "body of the first pass");
+                            }
+                            const std::string_view operator_spelling = operator_name(*value, node);
+                            const bool             map_call          = operator_spelling == "map_" || operator_spelling == "map";
+                            if (map_call && !runtime_) { check_map_lambda_call(*value, node); }
+                            visit_value(node.callee);
+                            for (const Argument &argument : node.arguments) { visit_value(argument.value); }
+                        } else if constexpr (std::is_same_v<T, Index>) {
+                            visit_value(node.target);
+                            visit_value(node.index);
+                        } else if constexpr (std::is_same_v<T, Field>) {
+                            visit_value(node.target);
+                        } else if constexpr (std::is_same_v<T, Sequence>) {
+                            for (const SequenceElement &element : node.elements) {
+                                visit_value(element.key);
+                                visit_value(element.value);
+                            }
+                        } else if constexpr (std::is_same_v<T, Tuple>) {
+                            for (ValueId element : node.elements) { visit_value(element); }
+                        } else if constexpr (std::is_same_v<T, Lambda>) {
+                            // The frontend admits an anonymous function only where
+                            // a callable parameter gives it a contextual type.
+                            visit_value(node.body);
+                        } else if constexpr (std::is_same_v<T, Conditional>) {
+                            if (!runtime_ && value->phase == ir::hir::Phase::Wiring) {
+                                const ConditionalPlan plan = analyze_temporal_conditional(module_, id);
+                                for (const PlanIssue &issue : plan.issues) { report(issue); }
+                            }
+                            visit_value(node.condition);
+                            visit_block(node.then_block);
+                            visit_value(node.otherwise);
+                        } else if constexpr (std::is_same_v<T, BlockValue>) {
+                            visit_block(node.block);
+                        } else if constexpr (std::is_same_v<T, HarnessEval>) {
+                            visit_value(node.callee);
+                            for (const Argument &argument : node.arguments) { visit_value(argument.value); }
+                        } else if constexpr (std::is_same_v<T, Construct>) {
+                            check_delta_clear(node);
+                            for (const Argument &argument : node.arguments) { visit_value(argument.value); }
+                        }
+                    },
+                    value->node);
+            }
+
+            [[nodiscard]] static bool composition_intrinsic(std::string_view name) noexcept {
+                return name == "valid" || name == "modified" || name == "all_valid" || name == "last_modified" ||
+                       name == "last_modified_time" || name == "key_set" || name == "keys" || name == "values" || name == "items";
+            }
+
+            const Module                     &module_;
+            syntax::DiagnosticSink           &diagnostics_;
+            std::unordered_set<std::uint32_t> visited_{};
+            bool                              runtime_{false};
+        };
+    }  // namespace
+
+    void report_first_pass_rules(const Module &module, syntax::DiagnosticSink &diagnostics) {
+        FirstPassRules{module, diagnostics}.run();
     }
 }  // namespace hgl::hgraph_ir

--- a/language/src/hgraph_ir/control_flow.cpp
+++ b/language/src/hgraph_ir/control_flow.cpp
@@ -618,7 +618,14 @@ namespace hgl::hgraph_ir
             }
 
           private:
+            /// Report-once: a nested temporal conditional is analyzed both by
+            /// its enclosing plan and by this visitor's own descent, and the
+            /// sink does not deduplicate, so the same rule at the same range
+            /// is reported exactly once here.
             void report(syntax::SourceRange range, std::string message) {
+                if (!reported_.insert(std::to_string(range.begin) + ':' + std::to_string(range.end) + ':' + message).second) {
+                    return;
+                }
                 diagnostics_.report(syntax::Category::Backend, range, std::move(message));
             }
 
@@ -822,6 +829,7 @@ namespace hgl::hgraph_ir
             const Module                     &module_;
             syntax::DiagnosticSink           &diagnostics_;
             std::unordered_set<std::uint32_t> visited_{};
+            std::unordered_set<std::string>   reported_{};
             bool                              runtime_{false};
         };
     }  // namespace

--- a/language/src/hgraph_ir/control_flow.h
+++ b/language/src/hgraph_ir/control_flow.h
@@ -2,15 +2,42 @@
 #define HGL_HGRAPH_IR_CONTROL_FLOW_H
 
 #include "hgraph_ir/ir.h"
+#include "syntax/diagnostic.h"
 
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace hgl::hgraph_ir
 {
+    /// A fail-closed rule the shared analysis found while planning. Both
+    /// execution backends report every issue through their own diagnostic
+    /// channel and never re-derive the rule: the message text lives here only,
+    /// so the direct and generated backends cannot drift apart.
+    struct PlanIssue
+    {
+        syntax::SourceRange range{};
+        std::string         message{};
+        /// True when the rule does not depend on how a backend reached the
+        /// construct. `report_first_pass_rules` reports these once during
+        /// hgraph IR lowering, so `hgl check` already rejects them; the
+        /// context-dependent rules remain in the plan for the backend that
+        /// supplied the context (a callable continuation, for instance).
+        bool context_free{true};
+    };
+
+    /// Rules only an execution backend can decide because they depend on the
+    /// values it has to materialize (a zoned literal folded into a constant
+    /// comparison never reaches one). The wording still has a single owner.
+    namespace first_pass
+    {
+        inline constexpr std::string_view unsupported_temporal_literal =
+            "zoned and civil literals are not supported by the first pass";
+    }  // namespace first_pass
+
     /// An outer lexical binding read by a nested conditional branch. The
     /// phase is retained at the use site so execution backends can distinguish
     /// temporal boundary inputs from scalar configuration captures.
@@ -70,6 +97,8 @@ namespace hgl::hgraph_ir
         std::vector<BindingId>               assigned_outer{};
         /// Every selected child supplies the enclosing callable's result.
         bool returns_from_callable{false};
+        /// Rules the conditional breaks; a backend reports them before lowering.
+        std::vector<PlanIssue> issues{};
     };
 
     /// Copy the suffix beginning at first_statement from an enclosing block.
@@ -147,9 +176,26 @@ namespace hgl::hgraph_ir
         std::vector<ConditionalCapture> captures{};
         std::vector<BindingId>          assigned_outer{};
         bool                            returns{false};
+        /// Rules the graph-phase loop breaks: escaping assignment or return,
+        /// scalar captures in a dynamic body, and the iterator forms the first
+        /// pass does not define. A backend reports them before lowering.
+        std::vector<PlanIssue> issues{};
     };
 
-    [[nodiscard]] TraversalPlan analyze_traversal(const Module &module, const Traversal &traversal);
+    /// `range` is the traversal statement's range, used for the loop-level
+    /// issues; the loop block's range is used when it is omitted.
+    [[nodiscard]] TraversalPlan analyze_traversal(const Module &module, const Traversal &traversal, syntax::SourceRange range = {});
+
+    /// Report, once, every context-free rule of the first pass that both
+    /// execution backends would otherwise re-derive: the control-flow plans'
+    /// context-free issues for every graph-phase conditional and loop in a
+    /// composition callable or test, assignment places that are not plain
+    /// bindings, the shape of a `map(...)` call with an anonymous function,
+    /// runtime-only intrinsics in a composition body, and clearing an optional
+    /// struct field through a sparse delta (in either phase). Hgraph IR
+    /// lowering calls this after the module is complete, so `hgl check`
+    /// rejects the constructs and neither backend needs an opinion of its own.
+    void report_first_pass_rules(const Module &module, syntax::DiagnosticSink &diagnostics);
 }  // namespace hgl::hgraph_ir
 
 #endif  // HGL_HGRAPH_IR_CONTROL_FLOW_H

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -1,5 +1,7 @@
 #include "hgraph_ir/lower.h"
 
+#include "hgraph_ir/control_flow.h"
+
 #include <cstddef>
 #include <set>
 #include <string>
@@ -38,6 +40,10 @@ namespace hgl::hgraph_ir
                 lower_tests();
                 collect_provider_requirements();
                 lower_source_order();
+                // The first-pass rules both execution backends share are
+                // reported once here, so `hgl check` rejects the constructs
+                // and neither backend re-derives them (control_flow.h).
+                if (!diagnostics_.has_errors()) { report_first_pass_rules(result_, diagnostics_); }
                 if (!diagnostics_.has_errors()) { result_.completion = Completion::Bodies; }
                 return std::move(result_);
             }

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -371,6 +371,8 @@ namespace hgl::wiring
             [[nodiscard]] Slot eval_intrinsic(std::string_view name, const std::vector<gir::Argument> &arguments, SourceRange range,
                                               Frame &frame);
             [[nodiscard]] Slot eval_harness(const gir::HarnessEval &eval, SourceRange range, Frame &frame);
+            [[nodiscard]] Slot eval_map_lambda_call(const gir::Value &expression, const gir::Call &call, std::string_view name,
+                                                    Frame &frame);
             [[nodiscard]] Slot eval_sequence(gir::ValueId id, const gir::Sequence &sequence, SourceRange range, Frame &frame);
             [[nodiscard]] Slot eval_tuple(const gir::Tuple &tuple, SourceRange range, Frame &frame);
             [[nodiscard]] Slot assemble_construct(gir::TypeId type, std::vector<std::pair<std::string, Slot>> supplied, bool delta,
@@ -423,6 +425,32 @@ namespace hgl::wiring
                 std::string                                      label{};
             };
 
+            /// The concise anonymous function of `map(a, b, fn(x, y) => ...)`:
+            /// one value-producing child graph that map_ multiplexes per key,
+            /// the erased counterpart of the `compose(...)` helper struct the
+            /// generated backend emits for the same call.
+            struct MapLambdaContext
+            {
+                Compiler                                        *compiler{nullptr};
+                gir::CallableId                                  callable{};
+                gir::ValueId                                     body{};
+                std::vector<gir::BindingId>                      parameters{};
+                std::vector<const hgraph::TSValueTypeMetaData *> schemas{};
+                std::vector<std::string_view>                    parameter_names{};
+                const hgraph::TSValueTypeMetaData               *result_schema{nullptr};
+                bool                                             in_test{false};
+                SourceRange                                      range{};
+                std::string                                      label{};
+            };
+
+            [[nodiscard]] static const hgraph::WiredFnOps &map_lambda_ops();
+            [[nodiscard]] hgraph::WiredFn   map_lambda_function(const gir::Value &lambda_value, const gir::Lambda &lambda,
+                                                                std::span<const Slot> inputs, Frame &frame, SourceRange range);
+            static hgraph::WiringPortRef    wire_map_lambda(const void *context, hgraph::Wiring &child,
+                                                            std::span<const hgraph::WiringPortRef> arguments);
+            static hgraph::CompiledSubGraph compile_map_lambda(const void *context, hgraph::Wiring *parent,
+                                                               std::span<const hgraph::TSValueTypeMetaData *const> input_schemas);
+
             [[nodiscard]] hgraph::WiredFn conditional_branch(Frame &frame, const gir::ConditionalPlan &plan,
                                                              const gir::ConditionalBranchPlan       &branch,
                                                              std::vector<gir::ConditionalResultSlot> results,
@@ -451,6 +479,7 @@ namespace hgl::wiring
             // WiredFn is a non-owning view; retain its callback contexts for this compilation.
             std::vector<std::unique_ptr<ConditionalBranchContext>> conditional_branches_{};
             std::vector<std::unique_ptr<TraversalContext>>         traversals_{};
+            std::vector<std::unique_ptr<MapLambdaContext>>         map_lambdas_{};
         };
 
         Slot Compiler::constant(const hir::Constant &source, SourceRange range) {
@@ -478,7 +507,7 @@ namespace hgl::wiring
                             case syntax::TemporalKind::ZonedDateTime:
                             case syntax::TemporalKind::ZonedTime:
                             case syntax::TemporalKind::TimeZone:
-                                backend(range, "zoned and civil literals are not supported by the first pass");
+                                backend(range, std::string{gir::first_pass::unsupported_temporal_literal});
                         }
                     }
                     backend(range, "unsupported hgraph IR constant");
@@ -894,7 +923,7 @@ namespace hgl::wiring
                 slot.kind == Slot::Kind::Intrinsic || slot.kind == Slot::Kind::Struct || slot.kind == Slot::Kind::Iterator) {
                 backend(slot.range, "passing a callable to an operator is not supported by the first pass");
             }
-            backend(slot.range, "this expression produces no value");
+            backend(slot.range, "hgraph IR value produces no wiring value");
         }
 
         Slot Compiler::wire_constant(const Slot &slot, const hgraph::TSValueTypeMetaData *target) {
@@ -1063,10 +1092,7 @@ namespace hgl::wiring
                 Slot &item = *effective[index];
                 if (item.kind == Slot::Kind::Null) {
                     if (!field.optional) { fail(Category::Type, item.range, "required field '" + field.name + "' cannot be null"); }
-                    if (delta) {
-                        backend(item.range,
-                                "clearing an optional struct field needs the distinct public hgraph clear-delta operation");
-                    }
+                    if (delta) { backend(item.range, "hgraph IR delta construction retained an optional-field clear"); }
                     continue;
                 }
                 if (!item.is_const() && !item.is_port() && item.kind != Slot::Kind::Delta) {
@@ -1268,7 +1294,10 @@ namespace hgl::wiring
                 return wire(name == "key_set" ? "keys_" : "last_modified_time", {time_series_arg(item.port)}, range);
             }
             if (name == "keys" || name == "values" || name == "items") {
-                if (arguments.size() != 1U) { backend(range, "graph-phase iterator predicates are not defined yet"); }
+                // The first-pass iterator rules (one argument, values or
+                // items, a temporal map or list) are reported once by the
+                // shared traversal analysis; the iterator only has to exist.
+                if (arguments.size() != 1U) { backend(range, "hgraph IR graph iterator call has more than one argument"); }
                 Slot source = eval_value(arguments.front().value, frame);
                 if (!source.is_port()) {
                     fail(Category::Type, source.range, "a graph collection iterator needs a time-series value");
@@ -1280,18 +1309,14 @@ namespace hgl::wiring
                 const hir::TypeKind kind = module_.types[source_type.value].kind;
                 if ((kind != hir::TypeKind::List || source.port.schema->kind != hgraph::TSTypeKind::TSL) &&
                     (kind != hir::TypeKind::Map || source.port.schema->kind != hgraph::TSTypeKind::TSD)) {
-                    backend(range, "graph-phase iteration currently supports temporal maps and lists");
-                }
-                if (name == "keys") {
-                    backend(range, "graph-phase keys(...) traversal is not defined yet; use values(...) or items(...)");
+                    backend(range, "hgraph IR graph iterator schema does not match its collection type");
                 }
                 source.kind = Slot::Kind::Iterator;
                 source.type = source_type;
                 source.name = name;
                 return source;
             }
-            backend(range, "'" + std::string{name} +
-                               "' is a runtime traversal; it is not available in a composition body of the first pass");
+            backend(range, "hgraph IR intrinsic without a composition lowering: " + std::string{name});
         }
 
         Slot Compiler::eval_call(const gir::Value &expression, const gir::Call &call, Frame &frame) {
@@ -1309,6 +1334,12 @@ namespace hgl::wiring
                     {
                         std::string name =
                             expression.operation.registry_name.empty() ? callee.name : expression.operation.registry_name;
+                        if ((name == "map_" || name == "map") &&
+                            std::ranges::any_of(call.arguments, [&](const gir::Argument &argument) {
+                                return std::holds_alternative<gir::Lambda>(value(argument.value).node);
+                            })) {
+                            return eval_map_lambda_call(expression, call, name, frame);
+                        }
                         std::vector<hgraph::WiringArg> arguments;
                         for (const gir::Argument &argument : call.arguments) {
                             arguments.push_back(argument_of(eval_value(argument.value, frame), argument.name));
@@ -1444,7 +1475,7 @@ namespace hgl::wiring
                 const auto found = frame.bindings.find(slot.binding.value);
                 if (found == frame.bindings.end()) {
                     compiler.backend(context.range,
-                                     "a time-series conditional branch did not assign escaping result '" + slot.field_name + "'");
+                                     "hgraph IR conditional branch did not assign escaping result '" + slot.field_name + "'");
                 }
                 return found->second;
             };
@@ -1552,12 +1583,9 @@ namespace hgl::wiring
 
             for (const gir::ConditionalCapture &capture : plan.captures) {
                 const gir::Binding &captured = binding(capture.binding);
-                if (capture.phase != hir::Phase::Wiring) {
-                    backend(captured.range, "capturing scalar configuration in a dynamic graph 'for' body is not supported yet");
-                }
-                const auto outer = frame.bindings.find(capture.binding.value);
+                const auto          outer    = frame.bindings.find(capture.binding.value);
                 if (outer == frame.bindings.end() || !outer->second.is_port()) {
-                    backend(captured.range, "a dynamic graph traversal capture is not bound to a time-series port");
+                    backend(captured.range, "hgraph IR dynamic traversal capture is not bound to a time-series port");
                 }
                 context->bindings.push_back(capture.binding);
                 context->schemas.push_back(schema(capture.type));
@@ -1630,18 +1658,9 @@ namespace hgl::wiring
             const gir::ConditionalPlan plan    = gir::analyze_temporal_conditional(module_, id, std::move(continuation));
             const auto                 results = gir::plan_temporal_conditional_results(module_, plan, result_used);
             if (returns_from_callable != nullptr) { *returns_from_callable = plan.returns_from_callable; }
-            if (plan.has_otherwise && !plan.when_false) {
-                backend(range, "temporal 'else if' is not supported in this compiler stage; use a block 'else'");
-            }
-            if (!plan.returns_from_callable && (plan.when_true.returns || (plan.when_false && plan.when_false->returns))) {
-                backend(range, "return from a time-series 'if' branch is not supported in this compiler stage");
-            }
-            for (const gir::ConditionalCapture &capture : plan.captures) {
-                if (capture.phase != hir::Phase::Wiring) {
-                    backend(binding(capture.binding).range,
-                            "capturing scalar configuration in a time-series 'if' branch is not supported in this compiler stage");
-                }
-            }
+            // The plan carries every first-pass rule it breaks; the wording is
+            // owned by the shared analysis (control_flow.h, PlanIssue).
+            for (const gir::PlanIssue &issue : plan.issues) { backend(issue.range, issue.message); }
 
             if (!condition.is_port()) {
                 backend(value(plan.condition).range, "a temporal conditional needs a time-series condition");
@@ -1669,7 +1688,7 @@ namespace hgl::wiring
             for (const gir::ConditionalCapture &capture : plan.captures) {
                 const auto found = frame.bindings.find(capture.binding.value);
                 if (found == frame.bindings.end() || !found->second.is_port()) {
-                    backend(binding(capture.binding).range, "a temporal conditional capture is not bound to a time-series port");
+                    backend(binding(capture.binding).range, "hgraph IR conditional capture is not bound to a time-series port");
                 }
                 Slot       argument = found->second;
                 const bool forwards = gir::temporal_branch_forwards(plan, plan.when_true, capture.binding) ||
@@ -1782,7 +1801,7 @@ namespace hgl::wiring
                     } else if constexpr (std::is_same_v<T, gir::Tuple>) {
                         return eval_tuple(node, expression.range, frame);
                     } else if constexpr (std::is_same_v<T, gir::Lambda>) {
-                        backend(expression.range, "anonymous functions are not supported by the first pass");
+                        backend(expression.range, "hgraph IR lambda outside a planned map call");
                     } else if constexpr (std::is_same_v<T, gir::Conditional>) {
                         Slot condition = eval_value(node.condition, frame);
                         if (condition.is_port()) { return eval_temporal_conditional(id, condition, expression.range, frame); }
@@ -1915,7 +1934,7 @@ namespace hgl::wiring
                         const gir::Value &place     = value(node.place);
                         const auto       *reference = std::get_if<gir::Reference>(&place.node);
                         if (reference == nullptr || reference->kind != gir::ReferenceKind::Binding) {
-                            backend(place.range, "assignment targets a local in the first pass");
+                            backend(place.range, "hgraph IR assignment place is not a binding");
                         }
                         const gir::Binding &target = binding(reference->binding);
                         if (target.kind != gir::BindingKind::LocalVar) {
@@ -1981,16 +2000,15 @@ namespace hgl::wiring
                     } else if constexpr (std::is_same_v<T, gir::Traversal>) {
                         exec_traversal(node, statement.range, frame);
                     } else {
-                        backend(statement.range, "runtime statements are not evaluated by the first pass");
+                        backend(statement.range, "hgraph IR runtime statement in a composition body");
                     }
                 },
                 statement.node);
         }
 
         void Compiler::exec_traversal(const gir::Traversal &traversal, SourceRange range, Frame &frame) {
-            const gir::TraversalPlan plan = gir::analyze_traversal(module_, traversal);
-            if (!plan.assigned_outer.empty()) { backend(range, "assignment escaping a graph 'for' body is not defined yet"); }
-            if (plan.returns) { backend(range, "return from a graph 'for' body is not defined yet"); }
+            const gir::TraversalPlan plan = gir::analyze_traversal(module_, traversal, range);
+            for (const gir::PlanIssue &issue : plan.issues) { backend(issue.range, issue.message); }
 
             Slot iterator = eval_value(traversal.iterable, frame);
             if (iterator.kind != Slot::Kind::Iterator || iterator.port.schema == nullptr) {
@@ -2025,8 +2043,7 @@ namespace hgl::wiring
             }
 
             if (iterator.port.schema->kind != hgraph::TSTypeKind::TSD && iterator.port.schema->kind != hgraph::TSTypeKind::TSL) {
-                backend(value(traversal.iterable).range,
-                        "dynamic graph traversal currently supports temporal maps and unbounded lists");
+                backend(value(traversal.iterable).range, "hgraph IR dynamic traversal schema is not a temporal map or list");
             }
 
             const hgraph::WiredFn          function = traversal_function(traversal, plan, iterator, frame, range);
@@ -2037,11 +2054,178 @@ namespace hgl::wiring
             for (const gir::ConditionalCapture &capture : plan.captures) {
                 const auto found = frame.bindings.find(capture.binding.value);
                 if (found == frame.bindings.end() || !found->second.is_port()) {
-                    backend(binding(capture.binding).range, "a dynamic graph traversal capture is not bound to a time-series port");
+                    backend(binding(capture.binding).range,
+                            "hgraph IR dynamic traversal capture is not bound to a time-series port");
                 }
                 arguments.push_back(time_series_arg(found->second.port.with_arg_tag(hgraph::WiringPortRef::ArgTag::PassThrough)));
             }
             (void)wire("map_", std::move(arguments), range, false);
+        }
+
+        const hgraph::WiredFnOps &Compiler::map_lambda_ops() {
+            static constexpr hgraph::WiredFnOps ops{
+                &Compiler::wire_map_lambda,
+                &Compiler::compile_map_lambda,
+                nullptr,
+                [](const void *context) {
+                    const auto &lambda = *static_cast<const MapLambdaContext *>(context);
+                    return std::span<const std::string_view>{lambda.parameter_names};
+                },
+                [](const void *context, std::size_t index) -> const hgraph::TSValueTypeMetaData * {
+                    const auto &lambda = *static_cast<const MapLambdaContext *>(context);
+                    return index < lambda.schemas.size() ? lambda.schemas[index] : nullptr;
+                },
+                nullptr,
+                [](const void *context) -> const hgraph::TSValueTypeMetaData * {
+                    return static_cast<const MapLambdaContext *>(context)->result_schema;
+                },
+                nullptr,
+                nullptr,
+                [](const void *context) -> std::string_view { return static_cast<const MapLambdaContext *>(context)->label; },
+            };
+            return ops;
+        }
+
+        hgraph::WiredFn Compiler::map_lambda_function(const gir::Value &lambda_value, const gir::Lambda &lambda,
+                                                      std::span<const Slot> inputs, Frame &frame, SourceRange range) {
+            if (lambda.parameters.size() != inputs.size()) {
+                backend(lambda_value.range, "hgraph IR anonymous map parameter count differs from its inputs");
+            }
+            auto context              = std::make_unique<MapLambdaContext>();
+            context->compiler         = this;
+            context->callable         = frame.callable;
+            context->in_test          = frame.in_test;
+            context->body             = lambda.body;
+            context->range            = range;
+            const syntax::Location at = file_.location(range.begin);
+            context->label            = file_.path() + ":" + std::to_string(at.line) + ": anonymous map function";
+            context->parameters.reserve(lambda.parameters.size());
+            context->schemas.reserve(lambda.parameters.size());
+            context->parameter_names.reserve(lambda.parameters.size());
+            for (gir::BindingId parameter_id : lambda.parameters) {
+                const gir::Binding &parameter = binding(parameter_id);
+                if (parameter.kind != gir::BindingKind::LambdaParameter) {
+                    backend(parameter.range, "hgraph IR lambda parameter has the wrong binding kind");
+                }
+                context->parameters.push_back(parameter_id);
+                context->schemas.push_back(schema(parameter.type));
+                // Positional, like the generated helper's compose(): a source
+                // parameter name must not opt into map_'s `key`/`ndx` inputs.
+                context->parameter_names.emplace_back();
+            }
+            const gir::TypeId result_type = lambda.result.valid() ? lambda.result : value(lambda.body).type;
+            if (!result_type.valid()) { backend(lambda_value.range, "hgraph IR anonymous map result has no type"); }
+            context->result_schema         = schema(result_type);
+            const MapLambdaContext *stored = context.get();
+            map_lambdas_.push_back(std::move(context));
+            return hgraph::WiredFn{
+                .ops        = &map_lambda_ops(),
+                .context    = stored,
+                .identity   = &typeid(MapLambdaContext),
+                .arity      = stored->schemas.size(),
+                .has_output = true,
+            };
+        }
+
+        hgraph::WiringPortRef Compiler::wire_map_lambda(const void *opaque, hgraph::Wiring &child,
+                                                        std::span<const hgraph::WiringPortRef> arguments) {
+            const auto &context = *static_cast<const MapLambdaContext *>(opaque);
+            if (arguments.size() != context.parameters.size()) {
+                throw std::invalid_argument("an HGL anonymous map function received the wrong number of child arguments");
+            }
+
+            Compiler       &compiler = *context.compiler;
+            hgraph::Wiring *previous = compiler.wiring_;
+            compiler.wiring_         = &child;
+            auto restore_wiring      = hgraph::make_scope_exit([&]() noexcept { compiler.wiring_ = previous; });
+
+            Frame frame;
+            frame.callable = context.callable;
+            frame.in_test  = context.in_test;
+            for (std::size_t index = 0; index < arguments.size(); ++index) {
+                hgraph::WiringPortRef argument = arguments[index];
+                const auto           *expected = context.schemas[index];
+                if (!hgraph::graph_wiring_detail::input_accepts_output_schema(expected, argument.schema)) {
+                    throw std::invalid_argument("an HGL anonymous map function input does not match its declared schema");
+                }
+                argument.schema = expected;
+                frame.bindings.emplace(context.parameters[index].value, make_port(std::move(argument), context.range));
+            }
+            Slot result = compiler.eval_value(context.body, frame);
+            if (result.is_const()) {
+                result = compiler.wire_constant(make_const(compiler.convert(result.value, context.result_schema->value_schema,
+                                                                            result.range, "anonymous map function result"),
+                                                           result.range),
+                                                context.result_schema);
+            }
+            if (!result.is_port()) { compiler.backend(context.range, "hgraph IR anonymous map function produced no value"); }
+            hgraph::WiringPortRef adapted =
+                hgraph::graph_wiring_detail::adapt_source_for_input(child, context.result_schema, std::move(result.port));
+            return compiler.convert_port(make_port(std::move(adapted), result.range), context.result_schema).port;
+        }
+
+        hgraph::CompiledSubGraph Compiler::compile_map_lambda(const void *opaque, hgraph::Wiring *parent,
+                                                              std::span<const hgraph::TSValueTypeMetaData *const> input_schemas) {
+            const auto &context = *static_cast<const MapLambdaContext *>(opaque);
+            if (input_schemas.size() != context.schemas.size()) {
+                throw std::invalid_argument("an HGL anonymous map function received the wrong number of child schemas");
+            }
+            hgraph::Wiring child = parent != nullptr ? parent->child_wiring() : hgraph::Wiring{hgraph::WiringKind::SubGraph};
+            std::vector<const hgraph::TSValueTypeMetaData *> schemas{input_schemas.begin(), input_schemas.end()};
+            std::vector<hgraph::WiringPortRef>               arguments;
+            arguments.reserve(input_schemas.size());
+            for (std::size_t index = 0; index < input_schemas.size(); ++index) {
+                if (!hgraph::graph_wiring_detail::input_accepts_output_schema(context.schemas[index], input_schemas[index])) {
+                    throw std::invalid_argument("an HGL anonymous map function child schema does not match its parameter");
+                }
+                arguments.push_back(hgraph::WiringPortRef::boundary_source(index, {}, input_schemas[index]));
+            }
+            auto compile = [&] {
+                hgraph::WiringPortRef output = wire_map_lambda(opaque, child, arguments);
+                return std::move(child).finish_subgraph(std::move(output), std::move(schemas));
+            };
+            if (!child.has_wiring_observers()) { return compile(); }
+            return child.observe(hgraph::WiringScopeEvent{.kind      = hgraph::WiringScopeKind::NestedGraph,
+                                                          .label     = context.label,
+                                                          .signature = context.label},
+                                 compile);
+        }
+
+        Slot Compiler::eval_map_lambda_call(const gir::Value &expression, const gir::Call &call, std::string_view name,
+                                            Frame &frame) {
+            // The shape rules (one anonymous function, temporal map inputs, a
+            // matching parameter count) are reported once by hgraph IR
+            // lowering (control_flow.h); here the plan only has to hold.
+            gir::ValueId      lambda_id{};
+            std::vector<Slot> inputs;
+            for (const gir::Argument &argument : call.arguments) {
+                if (std::holds_alternative<gir::Lambda>(value(argument.value).node)) {
+                    if (lambda_id.valid()) {
+                        backend(value(argument.value).range, "hgraph IR map call has more than one anonymous function");
+                    }
+                    lambda_id = argument.value;
+                    continue;
+                }
+                Slot input = eval_value(argument.value, frame);
+                if (!input.is_port() || input.port.schema == nullptr || input.port.schema->kind != hgraph::TSTypeKind::TSD) {
+                    backend(input.range, "hgraph IR map call input is not a temporal map");
+                }
+                inputs.push_back(std::move(input));
+            }
+            if (!lambda_id.valid()) { backend(expression.range, "hgraph IR map call has no anonymous function"); }
+            if (inputs.empty()) { backend(expression.range, "hgraph IR map call has no mapped input"); }
+
+            const gir::Value              &lambda_value = value(lambda_id);
+            const gir::Lambda             &lambda       = std::get<gir::Lambda>(lambda_value.node);
+            const hgraph::WiredFn          function = map_lambda_function(lambda_value, lambda, inputs, frame, expression.range);
+            std::vector<hgraph::WiringArg> arguments;
+            arguments.reserve(1U + inputs.size());
+            arguments.push_back(scalar_arg(hgraph::Value{function}));
+            for (const Slot &input : inputs) { arguments.push_back(time_series_arg(input.port)); }
+            const hgraph::TSValueTypeMetaData *expected =
+                expression.phase == hir::Phase::Wiring && expression.value_kind != hir::ValueKind::Void ? schema(expression.type)
+                                                                                                        : nullptr;
+            return wire(name, std::move(arguments), expression.range, true, expected);
         }
 
         Slot Compiler::eval_harness(const gir::HarnessEval &eval, SourceRange range, Frame &caller) {

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -33,6 +33,15 @@ set_tests_properties(hgraph_language_backend_architecture_rejects_indirect_ast P
     PASS_REGULAR_EXPRESSION "bridge/ast_adapter.h contains forbidden frontend dependency syntax/ast"
 )
 
+# A language rule is reported once, from hgraph IR: the same diagnostic text
+# in both execution backends is a copy that will drift.
+add_test(
+    NAME hgraph_language_backend_diagnostics_shared_once
+    COMMAND ${CMAKE_COMMAND}
+        "-DHGL_LANGUAGE_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../src"
+        -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/backend_diagnostics.cmake"
+)
+
 # Every guide example parses (developer guide, "Documentation examples").
 file(GLOB _hgl_examples CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../examples/*.hgl)
 foreach(_example IN LISTS _hgl_examples)

--- a/language/tests/cmake/backend_diagnostics.cmake
+++ b/language/tests/cmake/backend_diagnostics.cmake
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 3.25)
+
+# The two execution backends consume one hgraph IR and must not carry their
+# own copies of a language rule: a fail-closed diagnostic belongs to the
+# shared analysis (hgraph_ir/control_flow.h) or to the frontend, and the
+# backends only forward it. This test fails when the same diagnostic text is
+# passed to `backend(`, `unsupported(`, `report(` or `type_error(` in both
+# backend sources.
+#
+# Two exemptions keep the check about language rules: literals shorter than
+# eight characters (punctuation fragments of a composed message) and messages
+# beginning with "hgraph IR " (internal invariants of the IR both consumers
+# legitimately assert, never a rule an author can hit).
+
+if(NOT DEFINED HGL_LANGUAGE_SOURCE_DIR)
+    message(FATAL_ERROR "HGL_LANGUAGE_SOURCE_DIR is required")
+endif()
+
+set(_direct "${HGL_LANGUAGE_SOURCE_DIR}/wiring/backend.cpp")
+set(_generated "${HGL_LANGUAGE_SOURCE_DIR}/codegen/cpp_emitter.cpp")
+
+function(_hgl_diagnostic_literals out_var source)
+    file(READ "${source}" _contents)
+    # Every call to one of the reporting helpers, up to its terminating `;`.
+    string(REGEX MATCHALL "[^A-Za-z_:](backend|unsupported|report|type_error)\\([^;]*" _calls "${_contents}")
+    set(_literals)
+    foreach(_call IN LISTS _calls)
+        # Every string literal in the call; the quoted text is recovered
+        # by stripping the surrounding quotes.
+        string(REGEX MATCHALL "\"([^\"\\\\]|\\\\.)*\"" _strings "${_call}")
+        foreach(_string IN LISTS _strings)
+            string(LENGTH "${_string}" _length)
+            math(EXPR _inner_length "${_length} - 2")
+            if(_inner_length LESS 8)
+                continue()
+            endif()
+            string(SUBSTRING "${_string}" 1 ${_inner_length} _text)
+            if(_text MATCHES "^hgraph IR ")
+                continue()
+            endif()
+            list(APPEND _literals "${_text}")
+        endforeach()
+    endforeach()
+    list(REMOVE_DUPLICATES _literals)
+    set(${out_var} "${_literals}" PARENT_SCOPE)
+endfunction()
+
+_hgl_diagnostic_literals(_direct_literals "${_direct}")
+_hgl_diagnostic_literals(_generated_literals "${_generated}")
+
+set(_shared)
+foreach(_literal IN LISTS _direct_literals)
+    if(_literal IN_LIST _generated_literals)
+        list(APPEND _shared "${_literal}")
+    endif()
+endforeach()
+
+list(LENGTH _direct_literals _direct_count)
+list(LENGTH _generated_literals _generated_count)
+message(STATUS "direct backend diagnostics: ${_direct_count}; generated backend diagnostics: ${_generated_count}")
+
+if(_shared)
+    list(JOIN _shared "\n  " _listed)
+    message(FATAL_ERROR
+        "the direct and generated backends both own these diagnostics; move the rule into hgraph IR "
+        "(control_flow.h) so it is reported once:\n  ${_listed}")
+endif()

--- a/language/tests/cmake/package/CMakeLists.txt
+++ b/language/tests/cmake/package/CMakeLists.txt
@@ -44,10 +44,12 @@ if(NOT _descriptors STREQUAL _expected_descriptor)
         "generated descriptor target property is '${_descriptors}', expected '${_expected_descriptor}'")
 endif()
 
-set(_bootstrap "${CMAKE_CURRENT_BINARY_DIR}/hgl/hgl_fixture/_fixture_module.cpp")
-file(READ "${_bootstrap}" _bootstrap_text)
-if(NOT _bootstrap_text MATCHES "pkg::new_::register_operators\\(\\)")
-    message(FATAL_ERROR "keyword module namespace was not escaped in '${_bootstrap}'")
+# The Python bootstrap is generated at build time from the descriptor, so the
+# namespace spelling of a reserved segment (`hgl_state`) is checked by
+# package_test.cmake after generation, not here.
+get_target_property(_bootstrap _fixture HGL_PYTHON_BOOTSTRAP)
+if(NOT _bootstrap STREQUAL "${CMAKE_CURRENT_BINARY_DIR}/hgl/hgl_fixture/_fixture_module.cpp")
+    message(FATAL_ERROR "python bootstrap property is '${_bootstrap}'")
 endif()
 
 add_custom_target(hgl_fixture_generate
@@ -55,4 +57,5 @@ add_custom_target(hgl_fixture_generate
         "${CMAKE_CURRENT_BINARY_DIR}/hgl/hgl_fixture/include/unit.h"
         "${CMAKE_CURRENT_BINARY_DIR}/hgl/hgl_fixture/src/unit.cpp"
         "${CMAKE_CURRENT_BINARY_DIR}/hgl/hgl_fixture/src/unit.hgl-module.json"
-        "${_package_dir}/unit.py")
+        "${_package_dir}/unit.py"
+        "${_bootstrap}")

--- a/language/tests/cmake/package/unit.hgl
+++ b/language/tests/cmake/package/unit.hgl
@@ -1,4 +1,4 @@
-module pkg.new
+module pkg.new.hgl_state
 
 use checks.native_dependency as native
 

--- a/language/tests/cmake/package_test.cmake
+++ b/language/tests/cmake/package_test.cmake
@@ -35,7 +35,7 @@ if(NOT EXISTS "${_descriptor}")
 endif()
 file(READ "${_descriptor}" _descriptor_text)
 if(NOT _descriptor_text MATCHES "\"format\"[ 	]*:[ 	]*\"hgl.module\"" OR
-   NOT _descriptor_text MATCHES "\"identity\"[ 	]*:[ 	]*\"pkg.new\"" OR
+   NOT _descriptor_text MATCHES "\"identity\"[ 	]*:[ 	]*\"pkg.new.hgl_state\"" OR
    NOT _descriptor_text MATCHES "\"schema\"[ 	]*:")
     message(FATAL_ERROR "generated package descriptor has the wrong envelope:\n${_descriptor_text}")
 endif()
@@ -43,6 +43,31 @@ set(_generated_header "${OUT}/build/hgl/hgl_fixture/include/unit.h")
 file(READ "${_generated_header}" _generated_header_text)
 if(NOT _generated_header_text MATCHES "checks::native_dependency::blend")
     message(FATAL_ERROR "installed helper did not pass the linked target descriptor:\n${_generated_header_text}")
+endif()
+# `new` is a C++ keyword and `hgl_state` a name the generated node code
+# reserves; the header, the descriptor's registration symbol and the Python
+# bootstrap must agree on the escaped namespace, and only the compiler spells it.
+if(NOT _generated_header_text MATCHES "namespace pkg::new_::hgl_state_")
+    message(FATAL_ERROR "reserved module segments were not escaped in the header:\n${_generated_header_text}")
+endif()
+set(_bootstrap "${OUT}/build/hgl/hgl_fixture/_fixture_module.cpp")
+if(NOT EXISTS "${_bootstrap}")
+    message(FATAL_ERROR "package generation did not produce the Python bootstrap '${_bootstrap}'")
+endif()
+file(READ "${_bootstrap}" _bootstrap_text)
+if(NOT _bootstrap_text MATCHES "pkg::new_::hgl_state_::register_operators\\(\\)" OR
+   NOT _bootstrap_text MATCHES "#include <unit.h>")
+    message(FATAL_ERROR "the Python bootstrap does not call the generated registration:\n${_bootstrap_text}")
+endif()
+execute_process(
+    COMMAND "${_installed_hgl}" emit-cpp "${SOURCE}/unit.hgl" --print-namespace
+        --module-descriptor "${NATIVE_DESCRIPTOR}"
+    RESULT_VARIABLE _namespace_result
+    OUTPUT_VARIABLE _namespace_out
+    ERROR_VARIABLE _namespace_err
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(NOT _namespace_result EQUAL 0 OR NOT _namespace_out STREQUAL "pkg::new_::hgl_state_")
+    message(FATAL_ERROR "emit-cpp --print-namespace printed '${_namespace_out}':\n${_namespace_err}")
 endif()
 execute_process(
     COMMAND "${PYTHON}" -m json.tool "${_descriptor}"

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -744,4 +744,30 @@ fn examine(value: f64) -> Quote {
         CHECK(has_message(lowered.diagnostics,
                           "clearing an optional struct field needs the distinct public hgraph clear-delta operation"));
     }
+
+    SECTION("a rule inside a nested temporal conditional is reported exactly once") {
+        // The enclosing plan's analysis and this pass's own descent both see
+        // the inner branch; the sink does not deduplicate (Codex on #783).
+        Lowered           lowered{R"(
+module checks.nested_capture_rule
+
+export fn choose(outer: bool, inner: bool, x: i64, y: i64, const n: i64 = 5) -> i64 {
+    if outer {
+        if inner {
+            x + n
+        } else {
+            y
+        }
+    } else {
+        y
+    }
+}
+)"};
+        const std::string rendered = lowered.diagnostics.render(lowered.file);
+        INFO(rendered);
+        const std::string message = "capturing scalar configuration in a time-series 'if' branch";
+        std::size_t       count   = 0;
+        for (std::size_t at = rendered.find(message); at != std::string::npos; at = rendered.find(message, at + 1)) { ++count; }
+        CHECK(count == 1);
+    }
 }

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -560,3 +560,188 @@ fn examine(book: map<str, f64>, offset: f64, const scale: f64) {
     CHECK(plan.assigned_outer.empty());
     CHECK_FALSE(plan.returns);
 }
+
+namespace
+{
+    bool has_message(const hgl::syntax::DiagnosticSink &diagnostics, std::string_view fragment) {
+        return std::ranges::any_of(diagnostics.diagnostics(), [&](const hgl::syntax::Diagnostic &diagnostic) {
+            return diagnostic.message.find(fragment) != std::string::npos;
+        });
+    }
+
+    bool has_issue(const std::vector<gir::PlanIssue> &issues, std::string_view fragment) {
+        return std::ranges::any_of(issues,
+                                   [&](const gir::PlanIssue &issue) { return issue.message.find(fragment) != std::string::npos; });
+    }
+}  // namespace
+
+TEST_CASE("traversal analysis owns the first-pass loop rules", "[hgraph-ir][control-flow][iteration][rules]") {
+    Lowered lowered{R"(
+module checks.traversal_rules
+
+fn examine(book: map<str, f64>, samples: list<f64, 3>, const scale: f64) -> f64 {
+    var result: f64 = 0.0
+    for value in values(book) {
+        result = value * scale
+    }
+    for key in keys(book) {
+        let seen = key
+    }
+    for sample in values(samples, modified) {
+        let seen = sample
+    }
+    return result
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+    std::vector<const gir::Traversal *> loops;
+    for (const gir::Statement &statement : lowered.graph->statements) {
+        if (const auto *loop = std::get_if<gir::Traversal>(&statement.node)) { loops.push_back(loop); }
+    }
+    REQUIRE(loops.size() == 3U);
+
+    const gir::TraversalPlan dynamic = gir::analyze_traversal(*lowered.graph, *loops[0]);
+    CHECK(has_issue(dynamic.issues, "assignment escaping a graph 'for' body is not defined yet"));
+    CHECK(has_issue(dynamic.issues, "capturing scalar configuration in a dynamic graph 'for' body"));
+    for (const gir::PlanIssue &issue : dynamic.issues) { CHECK(issue.context_free); }
+
+    const gir::TraversalPlan keyed = gir::analyze_traversal(*lowered.graph, *loops[1]);
+    CHECK(has_issue(keyed.issues, "graph-phase keys(...) traversal is not defined yet"));
+
+    const gir::TraversalPlan predicate = gir::analyze_traversal(*lowered.graph, *loops[2]);
+    CHECK(has_issue(predicate.issues, "graph-phase iterator predicates are not defined yet"));
+
+    // Lowering reported every context-free rule once, so `hgl check` already
+    // rejects the module before either backend runs.
+    CHECK(lowered.diagnostics.has_errors());
+    CHECK(has_message(lowered.diagnostics, "assignment escaping a graph 'for' body is not defined yet"));
+    CHECK(has_message(lowered.diagnostics, "capturing scalar configuration in a dynamic graph 'for' body"));
+    CHECK(has_message(lowered.diagnostics, "graph-phase keys(...) traversal is not defined yet"));
+    CHECK(has_message(lowered.diagnostics, "graph-phase iterator predicates are not defined yet"));
+}
+
+TEST_CASE("a fixed-list traversal may read scalar configuration", "[hgraph-ir][control-flow][iteration][rules]") {
+    Lowered lowered{R"(
+module checks.fixed_traversal_rules
+
+use hgraph.std::{null_sink}
+
+fn examine(samples: list<f64, 3>, const scale: f64) {
+    for sample in values(samples) {
+        null_sink(sample * scale)
+    }
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+    REQUIRE(traversal(*lowered.graph) != nullptr);
+    const gir::TraversalPlan plan = gir::analyze_traversal(*lowered.graph, *traversal(*lowered.graph));
+    CHECK(plan.issues.empty());
+    CHECK_FALSE(lowered.diagnostics.has_errors());
+}
+
+TEST_CASE("temporal conditional analysis owns the first-pass branch rules", "[hgraph-ir][control-flow][rules]") {
+    SECTION("else-if and scalar captures are context-free") {
+        Lowered lowered{R"(
+module checks.conditional_rules
+
+use hgraph.std::{null_sink}
+
+fn observe(first: bool, second: bool, value: f64, const offset: f64) {
+    if first {
+        null_sink(value + offset)
+    } else if second {
+        null_sink(value)
+    }
+}
+)"};
+        REQUIRE(lowered.graph);
+        const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(*lowered.graph, conditional_value(*lowered.graph));
+        CHECK(has_issue(plan.issues, "temporal 'else if' is not supported"));
+        CHECK(has_issue(plan.issues, "capturing scalar configuration in a time-series 'if' branch"));
+        for (const gir::PlanIssue &issue : plan.issues) { CHECK(issue.context_free); }
+        CHECK(has_message(lowered.diagnostics, "temporal 'else if' is not supported"));
+        CHECK(has_message(lowered.diagnostics, "capturing scalar configuration in a time-series 'if' branch"));
+    }
+
+    SECTION("a branch return depends on the continuation the backend supplies") {
+        Lowered lowered{R"(
+module checks.conditional_return_rule
+
+fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    if condition {
+        return x + 1
+    }
+    return y - 1
+}
+)"};
+        INFO(lowered.diagnostics.render(lowered.file));
+        REQUIRE(lowered.graph);
+        // Without a continuation the return cannot terminate the callable, so
+        // the plan carries the rule as context-dependent and lowering stays quiet.
+        const gir::ConditionalPlan bare = gir::analyze_temporal_conditional(*lowered.graph, conditional_value(*lowered.graph));
+        REQUIRE(has_issue(bare.issues, "return from a time-series 'if' branch"));
+        for (const gir::PlanIssue &issue : bare.issues) { CHECK_FALSE(issue.context_free); }
+        CHECK_FALSE(lowered.diagnostics.has_errors());
+
+        const ConditionalSite site = conditional_site(*lowered.graph);
+        REQUIRE(site.value.valid());
+        const gir::Callable                   &callable = lowered.graph->callables.at(site.callable.value);
+        const gir::ConditionalContinuationPlan continuation =
+            gir::plan_temporal_continuation(*lowered.graph, site.block, site.statement_index + 1U, callable.result, site.value);
+        const gir::ConditionalPlan planned = gir::analyze_temporal_conditional(*lowered.graph, site.value, continuation);
+        CHECK(planned.returns_from_callable);
+        CHECK(planned.issues.empty());
+    }
+}
+
+TEST_CASE("hgraph IR lowering reports the shared first-pass rules once", "[hgraph-ir][rules]") {
+    SECTION("an assignment place must be a plain binding") {
+        Lowered lowered{R"(
+module checks.assignment_rule
+
+struct Quote { bid: f64 }
+
+fn examine(value: f64) -> f64 {
+    var quote: Quote = Quote(bid: value)
+    quote.bid = value
+    value
+}
+)"};
+        CHECK(has_message(lowered.diagnostics, "assignment targets a local in the first pass"));
+    }
+
+    SECTION("map(...) with an anonymous function takes temporal map inputs of matching arity") {
+        Lowered lowered{R"(
+module checks.map_shape_rule
+
+use hgraph.std::{map}
+
+fn examine(prices: map<str, f64>, scale: f64) -> map<str, f64> =>
+    map(prices, scale, fn(price) => price * 2.0)
+)"};
+        CHECK(has_message(lowered.diagnostics, "the first anonymous map slice takes temporal map inputs"));
+        CHECK(has_message(lowered.diagnostics, "the map function parameter count must match its mapped inputs"));
+    }
+
+    SECTION("clearing an optional field through a sparse delta fails closed") {
+        Lowered lowered{R"(
+module checks.clear_rule
+
+struct Quote {
+    bid: f64
+    note: str = null
+}
+
+fn examine(value: f64) -> Quote {
+    when modified(value) {
+        return delta<Quote>(note: null)
+    }
+}
+)"};
+        INFO(lowered.diagnostics.render(lowered.file));
+        CHECK(has_message(lowered.diagnostics,
+                          "clearing an optional struct field needs the distinct public hgraph clear-delta operation"));
+    }
+}

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -75,6 +75,24 @@ namespace
         }
     };
 
+    // Each test registers its own operator once; a shared one would register
+    // twice and become an ambiguity.
+    struct map_lambda_book_operator : hgraph::Operator<"hgl_map_lambda_book", hgraph::In<"trigger", hgraph::TS<hgraph::Float>>,
+                                                       hgraph::Out<hgraph::TSD<hgraph::Str, hgraph::TS<hgraph::Float>>>>
+    {};
+
+    struct map_lambda_book_graph
+    {
+        static constexpr auto name = "hgl_map_lambda_book_graph";
+
+        static auto compose(hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Float>> trigger) {
+            static_cast<void>(trigger);
+            return hgraph::wire<hgraph::stdlib::const_, hgraph::TSD<hgraph::Str, hgraph::TS<hgraph::Float>>>(
+                w, hgraph::stdlib::make_map<hgraph::Str, hgraph::Float>(
+                       {{hgraph::Str{"A"}, hgraph::Float{1.0}}, {hgraph::Str{"B"}, hgraph::Float{2.0}}}));
+        }
+    };
+
     struct dynamic_iteration_list_operator
         : hgraph::Operator<"hgl_dynamic_iteration_list", hgraph::In<"trigger", hgraph::TS<hgraph::Float>>,
                            hgraph::Out<hgraph::TSL<hgraph::TS<hgraph::Float>>>>
@@ -748,8 +766,9 @@ test observe_sink {
     eval(observe, first: [false], second: [true], value: [1.0])
 }
 )"};
-    const TestResult result = only(unit.tests());
-    CHECK_FALSE(result.passed);
+    // The shared control-flow analysis reports the rule during hgraph IR
+    // lowering, before either backend runs (control_flow.h, PlanIssue).
+    CHECK(unit.diagnostics.has_errors());
     CHECK(unit.has(Category::Backend, "temporal 'else if' is not supported"));
 }
 
@@ -851,6 +870,31 @@ fn discard(trigger: f64, offset: f64) {
 
 test dynamic_iteration {
     eval(discard, trigger: [1.0], offset: [10.0])
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+}
+
+TEST_CASE("an anonymous map function wires one value-producing child graph per key", "[wiring][map]") {
+    ensure_session();
+    hgraph::register_graph_overload<map_lambda_book_operator, map_lambda_book_graph>();
+    Unit             unit{R"(
+module t
+
+use hgraph.std::{hgl_map_lambda_book, map, sum}
+
+// The book is {A: 1.0, B: 2.0}; each key's child adds the value to itself.
+fn doubled(trigger: f64) -> f64 {
+    let book: map<str, f64> = hgl_map_lambda_book(trigger)
+    let sums: map<str, f64> = map(book, book, fn(a, b) => a + b)
+    sum(sums)
+}
+
+test doubled_ticks {
+    assert eval(doubled, trigger: [1.0]) == [6.0]
 }
 )"};
     const TestResult result = only(unit.tests());
@@ -1071,8 +1115,7 @@ module suite.struct_clear
 struct Quote { note: str = null }
 test clear { delta<Quote>(note: null) }
 )"};
-        const TestResult result = only(unit.tests());
-        CHECK_FALSE(result.passed);
+        CHECK(unit.diagnostics.has_errors());
         CHECK(unit.has(Category::Backend, "distinct public hgraph clear-delta operation"));
     }
 


### PR DESCRIPTION
Corrective roadmap item 3 of #767: the two execution backends carried copies of the same language rules; now a rule has one owner and the backends only forward it.

## 1. Control-flow guards are reported once from shared IR

`hgraph_ir/control_flow.h` gains `PlanIssue` (range, message, `context_free`). `analyze_temporal_conditional` and `analyze_traversal` attach every first-pass rule the construct breaks to its plan: temporal `else if`, a branch return that cannot terminate the callable, scalar configuration captured by a temporal branch or a dynamic loop body, assignment escaping a loop, return from a loop, graph-phase iterator predicates, `keys(...)`, and unsupported collection kinds. A new `report_first_pass_rules`, run by `hgraph_ir::lower`, reports the context-free issues (plus the other shared rules below) so `hgl check` now rejects them before either backend runs. Both backends replaced their copies with `for (issue : plan.issues) backend(issue.range, issue.message)`. The one context-dependent rule (a branch `return` whose continuation only a backend can plan) stays in the plan and is forwarded by whichever backend runs.

Also moved behind one owner: assignment places that are not plain bindings, runtime-only intrinsics in a composition body, and the shape of a `map(...)` call with an anonymous function. Zoned/civil literals stay a backend decision (a literal folded into a constant comparison never reaches a backend) but with shared wording, `first_pass::unsupported_temporal_literal`.

`control_flow.h`'s "for the backends to diagnose" comment, `compiler-and-lowering.md` (new paragraph in the backend section) and `control-flow.md` describe the split.

## 2. Optional-clear wording unified

Clearing an optional field through `delta<S>(field: null)` is now reported once by lowering, in either phase, with the direct backend's wording (`...needs the distinct public hgraph clear-delta operation`); both backends keep only an `hgraph IR` invariant.

## 3. Stale guard removed

`cpp_emitter.cpp:2974` ("use if_then_else") is gone; a port condition reaching the scalar `if` emitter is now the invariant `hgraph IR scalar 'if' has a time-series condition`, since temporal conditions are planned through `switch_` before that path.

## 4. Reserved-name tables have one source

- `codegen/cpp_emitter.h` exposes `module_namespace(const hgraph_ir::Module &)`, the only place a module segment is escaped; `hgl emit-cpp <file> --print-namespace` prints it (usage text and `modules-and-tools.md` updated).
- `hgl_add_module()` no longer re-parses the `module` line or carries C++/Python keyword tables. The Python bootstrap is written at build time by `HglLanguage.cmake` in script mode from the descriptors `emit-cpp` produced (`build.registration.symbol`), so the spelling is the compiler's by construction. The CMake-side `PYTHON_MODULE` check keeps only the identifier shape; `emit-cpp --python-native` already owns the keyword rule.
- Package test: `tests/cmake/package/unit.hgl` is now `module pkg.new.hgl_state` (a C++ keyword and a reserved generated name); `package_test.cmake` checks the header namespace, the bootstrap call `pkg::new_::hgl_state_::register_operators()` and `--print-namespace` agree.

## 5. Direct-backend `map` lambda

`map(a, b, fn(x, y) => ...)` is now wired by the direct backend as one value-producing `WiredFn` child graph per key (`MapLambdaContext`, mirroring the generated `compose(...)` helper: positional parameters, result schema from the lambda), so `examples/structural-types.hgl`'s `notionals` behaves the same under `hgl test` and the generated fixture. New `backend_tests.cpp` case "an anonymous map function wires one value-producing child graph per key" asserts ticks (`sum` of the mapped book = 6.0). The emitter's map shape checks moved to the shared rules (§1).

## 6. Architecture test

`tests/cmake/backend_diagnostics.cmake`, registered as `hgraph_language_backend_diagnostics_shared_once`, extracts every string literal passed to `backend(`/`unsupported(`/`report(`/`type_error(` in `wiring/backend.cpp` and `codegen/cpp_emitter.cpp` and fails when one appears in both. Exemptions: literals under eight characters (punctuation fragments) and messages beginning with `hgraph IR ` (invariants of the IR both consumers legitimately assert). It found and drove out 21 shared literals; it passes now.

## Evidence

- `ctest -R hgraph_language`: 50/50 (macOS, Apple clang), including the new architecture test, the package test with the reserved segment, `hgraph_language_cmake_package`, native cache and REPL smoke.
- Catch2: hgraph IR 44 cases / 740 assertions (4 new: loop rules, fixed-list scalar capture allowed, branch rules incl. the context-dependent return, lowering reports the shared rules), wiring 42 / 167 (new map-lambda tick test), codegen 56 / 575.
- Every `language/examples/*.hgl` still passes `hgl check`; `git clang-format` clean on changed lines.

## Not done / follow-ups

- `fail(Category::Type, ...)` literals are not covered by the architecture test (the directive named the four helpers); a few type-level messages are still duplicated between the backends (e.g. "a graph 'for' loop needs values(...) or items(...)"). Extending the test to `fail(` is a natural next step.
- The frontend already rejects anonymous functions outside `map`'s contextual parameter, so no lowering rule for that was needed.
- A tick test for `notionals` on the generated side (`generated_structural_tests.cpp`) would complete the parity evidence; the generated fixture compiles it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
