### PR TITLE
Prototype backend-neutral runtime spec and HGL standard library

### DIFF
--- a/language/README.md
+++ b/language/README.md
@@ -88,11 +88,26 @@ The guides develop the first syntax and examples from both sides of the
 contract: what an author writes and observes, and how the compiler classifies
 and preserves those semantics through hgraph's public C++ APIs.
 
+Two deliberately non-executable discovery tracks sit beside the compiler:
+
+- [`runtime-spec`](runtime-spec/README.md) explores a backend-neutral DSL for
+  generating hgraph runtime and type contracts for C, C++, Rust, Swift, and
+  other implementations;
+- [`stdlib/hgl`](stdlib/hgl/README.md) is a conceptual HGL source root for the
+  current standard library, backed by a finite
+  [migration inventory](stdlib/inventory.md) and an explicit
+  [requirements ledger](stdlib/requirements.md).
+
+Neither is part of `hgraph_language` CTest coverage. Provisional syntax in the
+library prototype is visibly marked and must graduate through design and
+compiler implementation before it can enter production sources.
+
 ### Design records
 
 - [Architecture](docs/design/architecture.md)
 - [Language model](docs/design/language-model.md)
 - [Modules and native extensions](docs/design/modules.md)
+- [Backend-neutral runtime specification](docs/design/runtime-specification.md)
 - [Roadmap](docs/design/roadmap.md)
 - [Distribution and deployment](docs/design/distribution.md)
 

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -61,6 +61,10 @@ compatibility promise.
 13. [Iteration](design/iteration.md) — phase-dependent `for`, wiring-time values
    and fixed child connections, independent dynamic graph loops, runtime
    traversal, and deferred map/reduce accumulation.
+14. [Backend-neutral runtime specification](design/runtime-specification.md) —
+   an exploratory `.hgspec` contract for generating runtime type, ownership,
+   lifecycle, operator, and conformance surfaces across implementation
+   languages without turning HGL into a systems language.
 
 An accepted change should update the relevant guide and its owning design
 record together. The user guide is the source of truth for observable language
@@ -70,15 +74,19 @@ constraints.
 ## Standard-library design corpus
 
 The [standard-library folder](../stdlib/README.md) collects agreed HGL examples
-to drive core-library coverage and expose missing language features. It starts
-with conditional-result examples; the fixed-list and independent dynamic
-collection cases have graduated into the compiler's runnable example corpus. A
-single escaping conditional result and a bundle of several escaping results
-have also graduated, as have a used expression result combined with escaping
-assignments and reference-preserving forwarding of initialized results.
+to drive core-library coverage and expose missing language features. Its
+[migration inventory](../stdlib/inventory.md) and deliberately provisional
+[HGL source root](../stdlib/hgl/README.md) now provide a second, non-executable
+track for testing the whole native library against the language design. The
+agreed corpus starts with conditional-result examples; the fixed-list and
+independent dynamic collection cases have graduated into the compiler's
+runnable example corpus. A single escaping conditional result and a bundle of
+several escaping results have also graduated, as have a used expression result
+combined with escaping assignments and reference-preserving forwarding of
+initialized results.
 Value-producing temporal conditionals without `else` have also graduated with
 a typed never-ticking false path, and so have early-return continuations
 (`examples/conditional-early-return.hgl`). The `switch`, enum, `str(value)`,
 and `elements` fixtures remain in the design corpus. A complete component
-catalogue remains to be developed. Files left in the design corpus are not a
-claim of implemented support.
+catalogue remains to be developed. Files left in the design corpus or source
+prototype are not a claim of implemented support.

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -667,10 +667,36 @@ remaining predicate to a C++ `if` in source order. Later handlers observe state
 and output changes made by earlier handlers.
 
 `modified(a, b, ...)` is true when any listed input was modified, while
-`valid(a, b, ...)` is true only when every listed input is valid. Both require
-at least one argument. The compiler converts activation and validity predicates
-into hgraph input metadata whenever they are statically representable. Only
-residual conditions remain in the per-tick body.
+`valid(a, b, ...)` is true only when every listed input is valid. In a
+function-level `when` predicate, the empty forms select the complete temporal
+parameter list: `modified()` is the disjunction over that list and `valid()`
+is its top-level-valid conjunction. `const` parameters, state, injectables, and
+`out` are excluded.
+
+A handler that has no top-level `modified(...)` conjunction receives an
+implicit `modified()` selector. A handler with no top-level `valid(...)`
+conjunction receives an implicit `valid()` selector. Calls nested in a residual
+expression do not suppress the defaults. The canonical degenerate form is:
+
+```hgl
+when {
+    // Any temporal input activates this handler, after all are valid.
+}
+```
+
+It is equivalent to `when modified() && valid() { ... }`. The compiler
+converts activation and validity predicates into hgraph input metadata whenever
+they are statically representable. Only residual conditions remain in the
+per-tick body. This decision does not assign meaning to empty selector calls
+outside `when`. The behavior of a bare handler in a runtime function with no
+temporal parameters but an explicit scheduler also remains a separate
+lifecycle decision.
+
+Because empty `modified()` and `valid()` now mean the complete input list,
+they cannot also spell an explicitly empty activation or validity set. That
+source form remains open. It is required by scheduler-only handlers and native
+nodes that intentionally admit invalid inputs; the backend contract must keep
+its empty selector distinct from its default selector in the meantime.
 
 In a runtime function, `return value` writes the complete output and terminates
 the current evaluation. Reaching the end without a return or output mutation
@@ -729,16 +755,19 @@ modified(value)
 valid(value)
 modified(bid, ask)
 valid(bid, ask)
+modified()
+valid()
 all_valid(book)
 last_modified(value)
 delta(value)
 ```
 
 The language does not expose `value.modified`, `value.valid`, or `value.value`.
-Like `key_set`, the metadata calls follow the phase of their containing
+Like `key_set`, non-empty metadata calls follow the phase of their containing
 function: in composition they wire hgraph's standard `valid`, `modified`, and
 `last_modified_time` operators and yield time series; `modified` and `valid`
-are evaluator-local metadata in runtime functions. The
+are evaluator-local metadata in runtime functions. Empty `modified()` and
+`valid()` currently have meaning only in a function-level `when` predicate. The
 compiler may consume them as activation and admission policy rather than
 materializing Boolean time series. `valid(value)` tests top-level endpoint
 validity; recursive child validity is a distinct operation named

--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -271,7 +271,7 @@ its runtime implementation:
 use hgraph.native as native
 
 impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
-    when modified(value) && valid(value) {
+    when {
         return native::len(value)
     }
 }

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -596,6 +596,10 @@ Acceptance:
 
 Candidates, in risk order:
 
+- implement the agreed `when` selector defaults: empty `modified()` and
+  `valid()` over all temporal parameters, omitted selector categories, and the
+  equivalent bare `when { ... }` form; separately settle explicit empty
+  activation and validity policies for scheduler-only and unchecked nodes;
 - complete the implemented nominal `struct` prototype with nested temporal
   construction, runtime consumption of contextual `delta<S>` values, and
   atomic aggregation validity semantics;

--- a/language/docs/design/runtime-specification.md
+++ b/language/docs/design/runtime-specification.md
@@ -1,0 +1,223 @@
+# Backend-neutral runtime specification
+
+Status: exploratory prototype; no generator consumes this syntax
+
+## Purpose
+
+HGL describes graphs and nodes. It should not also become the source language
+for implementing the hgraph runtime. A separate, smaller specification language
+can describe the runtime's stable type, ownership, lifecycle, and operator
+contracts and generate the repetitive surface needed by a C, C++, Rust, Swift,
+or another implementation.
+
+The prototype lives in [`runtime-spec`](../../runtime-spec/README.md). Its
+examples use the provisional `.hgspec` syntax so the design can be tested
+against the existing C++ runtime before a parser or generator is selected.
+Unresolved syntax and semantics are indexed in its
+[`requirements ledger`](../../runtime-spec/requirements.md).
+
+The specification is intended to generate:
+
+- canonical schema records and their kind/capability enumerations;
+- storage-plan and erased-operation interfaces, without fixing their backing
+  representation;
+- owned and borrowed API surfaces with explicit lifetime relationships;
+- node, graph, and provider lifecycle interfaces;
+- node category, activation, structural-observation, and validity-readiness
+  metadata;
+- operator-contract descriptors and deterministic registration manifests;
+- backend conformance fixtures and stable descriptor data.
+
+It is not intended to generate algorithms, allocators, schedulers, collection
+representations, or language-specific performance strategies. Those remain
+backend implementations of the generated contracts.
+
+## Two languages, two responsibilities
+
+| Layer | Source | Responsibility |
+| --- | --- | --- |
+| Runtime contract | `.hgspec` | Defines portable semantic shapes, operations, ownership, lifecycle, and laws. |
+| Runtime backend | C, C++, Rust, Swift, ... | Implements storage, scheduling, erased dispatch, and platform integration. |
+| Graph library | `.hgl` | Implements operator candidates, nodes, and graphs over the runtime contract. |
+| User application | `.hgl` | Composes the public library and extension modules. |
+
+This separation is deliberate. HGL remains a graph DSL, while `.hgspec` is an
+IDL plus executable-contract language for runtime implementors.
+
+## Semantic model before physical layout
+
+The contract describes a sum type such as `ValueShape` or `TimeSeriesShape`.
+A backend maps that sum type to its preferred representation:
+
+- C may use tagged structs, generated function tables, and explicit owner
+  handles;
+- C++ may use interned metadata, storage plans, passive operation tables, and
+  RAII façades;
+- Rust may use enums for construction-time descriptions and thin erased
+  handles at runtime;
+- Swift may use value descriptors plus protocols and internal storage boxes.
+
+The specification does not expose `std::vector`, `Vec`, `Array`, raw pointers,
+reference counting, or a particular ABI. A separate profile may constrain a
+binary boundary when independently built modules must interoperate.
+
+The same rule applies to memory layout. `record`, `choice`, and `ops` describe
+semantics. `derive storage_plan` asks a backend to provide a layout satisfying
+the declared capabilities and laws; it does not prescribe field offsets.
+
+## Provisional source model
+
+Every new construct below is **provisional**. The examples deliberately make
+the proposed syntax concrete; acceptance requires a parser spike and at least
+two backend mappings.
+
+```ebnf
+spec            = "spec", qualified_name, "version", string, { declaration };
+declaration     = scalar | enum | flags | record | choice | interned
+                | ops | derive | law | scenario;
+record          = "record", name, [ generic_params ], "{", { field }, "}";
+choice          = "choice", name, [ generic_params ], "{", { variant }, "}";
+interned        = "interned", "schema", name, [ generic_params ], block;
+ops             = "ops", name, [ generic_params ], block;
+derive          = "derive", name, "for", type, block;
+law             = "law", name, parameter_list, block;
+scenario        = "scenario", name, block;
+ownership_type  = "owned", "<", type, ">"
+                | "borrowed", "<", type, [ ",", lifetime ], ">"
+                | "inout", "<", type, [ ",", lifetime ], ">"
+                | "shared", "<", type, ">";
+```
+
+The syntax borrows familiar shapes from Rust, Swift, and schema IDLs, but the
+semantics are narrower:
+
+- `record` is product data with no inheritance or methods;
+- `choice` is a closed tagged sum;
+- `interned schema` has canonical structural or nominal identity;
+- `ops` is a passive operation table, not object inheritance;
+- `derive` lists required generated surfaces, not arbitrary macros;
+- `law` is a universally quantified conformance property;
+- `scenario` is a finite trace with observable assertions;
+- `owned`, `borrowed`, and `shared` make lifetime transfer visible.
+
+## Identity and interning
+
+Schema identity must be explicit because pointer identity in C++ is an
+implementation optimization, not a portable semantic definition. Each
+`interned schema` declares a `key` expression built from stable values. A
+backend may represent a canonical schema with an address, index, hash-consed
+handle, or another token, but must satisfy:
+
+```text
+same canonical key  => same schema identity within one registry generation
+different nominal key => different identity even when structure is equal
+registry reset => new generation, equivalent semantic descriptions
+                 still compare by canonical key
+```
+
+Nominal and structural identity are separate constructors. A named Bundle, for
+example, retains its qualified name and ancestry while pointing to a structural
+Bundle with the same ordered fields.
+
+## Operations and capabilities
+
+An operation is present only when its schema declares the corresponding
+capability. This avoids nullable function pointers and keeps unsupported
+behavior out of hot paths. The generated façade performs capability checks at
+cold boundaries; a planned runtime path receives a non-null operation table
+whose shape is already selected.
+
+Operation declarations separate:
+
+- `cold` registry, planning, conversion, and diagnostic work;
+- `hot` evaluation operations that must not allocate or resolve types unless
+  the contract explicitly permits it;
+- `fallible` operations that return a typed error;
+- `noexcept` operations that cannot cross the runtime failure boundary;
+- mutation of `owned` storage from observation through `borrowed` views.
+
+These terms are semantic annotations. Backends map them to their own error and
+calling conventions.
+
+## Ownership and lifetimes
+
+The first prototype has four ownership constructors:
+
+- `owned<T>` transfers or uniquely controls the represented runtime value;
+- `borrowed<T, 'a>` cannot outlive the owner or evaluation scope named by
+  `'a`;
+- `inout<T, 'a>` is an exclusive mutable borrow for the named scope and does
+  not transfer ownership;
+- `shared<T>` retains a stable immutable value independently of a graph slot.
+
+Passing an owned value consumes it. An ordinary borrow never mutates. Repeated
+lifecycle and evaluation calls therefore receive `inout` access to an object;
+they do not consume and replace it on every cycle. Generated erased-operation
+references are non-null passive tables and carry no implementation inheritance.
+
+Borrowed runtime collection iterators carry the evaluation lifetime and cannot
+be stored in node state, returned across the API, or retained by callbacks.
+Provider code and metadata use leases: a graph plan or instance retaining a
+provider prevents physical unloading even after logical deregistration.
+
+The prototype deliberately does not specify raw references, weak ownership,
+pinning, tracing garbage collection, or a universal foreign pointer.
+
+## Generated artifacts
+
+A conforming generator should emit a backend package with four layers:
+
+1. **Descriptors** — kind enums, records, stable names, fingerprints, and
+   serialization.
+2. **Contracts** — operation tables or protocols plus owned/borrowed façades.
+3. **Registration** — canonical constructors, provider lifecycle, and operator
+   manifests.
+4. **Conformance** — generated law/property cases and finite lifecycle traces.
+
+Generated source should remain readable and checked in where the consuming
+project requires reviewable implementation inputs. Backend-specific code fills
+named extension points; regeneration must not overwrite those implementations.
+
+## Relationship to HGL library extraction
+
+The [`stdlib/hgl`](../../stdlib/hgl/README.md) prototype migrates real operator
+contracts and implementations. Its blockers feed this runtime specification.
+For example:
+
+- `pass_through_node` needs a portable capture/apply-delta operation;
+- collection nodes need borrowed full-value and delta-range views;
+- scheduler-driven nodes need an explicit scheduler capability;
+- higher-order graphs need child-plan, binding, and keyed-lifecycle contracts;
+- record/replay and module providers need leases and transactional removal.
+
+The runtime DSL should gain a construct only after one of those migrations
+requires a backend-neutral contract. It must not become a transcription of
+every current C++ class.
+
+## Validation strategy
+
+The first useful generator must target two structurally different backends.
+C++ plus Rust is the recommended pair because it exercises both passive erased
+tables and an ownership-checked implementation. Swift is the next useful
+mapping for protocol/value semantics; C is the ABI stress test.
+
+Acceptance for a contract slice is:
+
+1. the `.hgspec` parses into a deterministic semantic model;
+2. at least two backends generate equivalent descriptor identities;
+3. generated conformance cases observe the same value/delta/lifecycle traces;
+4. hand-written backend code is isolated behind explicit extension points;
+5. HGL generated against either backend needs no source changes.
+
+## Open decisions
+
+- Whether `.hgspec` is the final extension and whether specifications are one
+  file per domain or one package-level unit.
+- Whether ABI profiles belong in the core language or in backend manifests.
+- How laws quantify over generated nominal schemas and finite collection
+  shapes without turning the DSL into a theorem prover.
+- How version evolution distinguishes compatible field additions from semantic
+  changes requiring a new contract version.
+- Whether operator resolution is fully specified as portable rules or exposed
+  as a required service with shared conformance vectors.
+- Which runtime debug/introspection views are stable public contracts.

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -165,6 +165,9 @@ surface.
   not classify the function by itself.
 - Runtime `when` predicates are decomposed into activation, validity admission,
   and residual per-evaluation logic where possible.
+- A handler with no modification selector defaults to any temporal input; one
+  with no validity selector defaults to all temporal inputs being top-level
+  valid. Bare `when { ... }` supplies both defaults.
 - State declarations aggregate into one recordable state value; grouped
   inject declarations map approved capabilities to native selectors.
 - `return value` is terminating output, while `inject out` enables persistent

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -911,9 +911,29 @@ fn combined_total(a: f64, b: f64) -> f64 {
 
 For all ordered `when` predicates, the runtime semantic pass derives:
 
-1. the union of activation dependencies derived from `modified(...)` terms;
-2. validity admission requirements common to every executable handler;
-3. ordered residual predicates that remain in the per-evaluation body.
+1. an implicit `modified()` term when a handler has no top-level modification
+   selector, selecting every temporal input;
+2. an implicit `valid()` term when a handler has no top-level validity
+   selector, requiring every temporal input to be top-level valid;
+3. the union of activation dependencies derived from explicit or implicit
+   `modified(...)` terms;
+4. validity admission requirements common to every executable handler; and
+5. ordered residual predicates that remain in the per-evaluation body.
+
+For a single handler, the direct metadata cases are:
+
+| HGL handler | `active_inputs` | `valid_inputs` | Residual condition |
+| --- | --- | --- | --- |
+| `when { ... }` | `nullopt` | `nullopt` | none |
+| `when modified() && valid() { ... }` | `nullopt` | `nullopt` | none |
+| `when modified(a) { ... }` | `{a}` | `nullopt` | none |
+| `when valid(a) { ... }` | `nullopt` | `{a}` | none |
+| `when modified(a, b) && valid(a) { ... }` | `{a, b}` | `{a}` | none |
+
+Here `nullopt` deliberately means the hgraph runtime default, not an empty
+selector set. With multiple handlers the compiler still takes the activation
+union and common validity admission, retaining handler-specific checks as
+ordered residual conditions.
 
 An omitted `modified` term contributes every temporal parameter to that
 handler's activation set. An omitted `valid` term admits the handler only when
@@ -1590,10 +1610,12 @@ expression is read from the syntax tree.
 - **Runtime-node structs.** A runtime function in the supported scalar subset
   is an empty static node struct in the generated header. Its `eval` signature
   carries typed `In`, `Scalar`, `RecordableState`, and `Out` selectors. The
-  union of `modified(...)` parameters selects active inputs; other temporal
-  inputs are passive. A function with `when` conservatively admits unchecked
-  inputs and retains its complete ordered predicates in `eval`. A function
-  without `when` uses ordinary active/valid input policy.
+  union of explicit or defaulted `modified(...)` parameters selects active
+  inputs. A missing selector or `modified()` selects all temporal inputs; other
+  inputs are passive. A missing validity selector or `valid()` requires all
+  temporal inputs. Handler-specific checks remain in `eval`. A function
+  without `when` uses ordinary active/valid input policy. Bare `when` and empty
+  selector parsing/lowering are specified but not yet implemented.
 - **Bodies.** The same lowering the direct-wiring backend performs, printed:
   a constant expression folds into a C++ expression with the same rules
   (`/` on integers is a `Float` division, `Int` and `Float` mix to `Float`,
@@ -1617,7 +1639,9 @@ expression is read from the syntax tree.
 - **Runtime bodies.** Scalar payload expressions use the same checked type and
   widening rules, while `modified`, `valid`, and `all_valid` call selector
   metadata directly. `valid(a, b)` is an `&&` fold and `modified(a, b)` is
-  an `||` fold. Ordered `when` blocks become independent `if` statements.
+  an `||` fold. Within a handler, the empty forms fold over the complete
+  temporal parameter list and omitted selector categories default to those
+  empty forms. Ordered `when` blocks become independent `if` statements.
   `return value` sets the output and returns; assignment through `inject out`
   sets it and continues, so the final whole-output write wins. Scalar state
   fields form one named `TSB` behind `RecordableState`; `start` seeds only

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1072,6 +1072,16 @@ requires a state initializer and permits at most one `start` and one `stop`
 block. It permits multiple function-level `when` blocks and preserves their
 source order; a `when` nested in another block is rejected because it cannot
 contribute safely to the node's activation policy.
+
+An omitted `when` expression is the canonical default handler. It is
+equivalent to writing `modified() && valid()`: any temporal parameter may
+activate the node, and every temporal parameter must be top-level valid before
+the handler is admitted. The empty calls are contextual handler-selector
+forms. Whether empty metadata calls have meaning outside a handler remains a
+separate decision; they are not zero-argument graph-operator calls today.
+
+This grammar is the agreed target. The current parser still requires a `when`
+expression, and current semantic checking still rejects empty metadata calls.
 These are semantic restrictions rather than parser shortcuts so diagnostics
 can identify the misplaced or duplicate construct precisely.
 
@@ -1515,6 +1525,8 @@ modified(value)
 valid(value)
 modified(bid, ask)
 valid(bid, ask)
+modified()
+valid()
 all_valid(book)
 last_modified(value)
 delta(value)
@@ -1525,18 +1537,36 @@ intrinsic declarations. Source member spellings such as `value.modified`,
 `value.valid`, and `value.value` are not part of the language.
 
 These calls are phase-polymorphic in the same way as `key_set`. In a
-composition function they wire the standard hgraph operators of the same
-meaning: `valid` and `modified` produce a `bool` time series and
+composition function the non-empty calls wire the standard hgraph operators of
+the same meaning: `valid` and `modified` produce a `bool` time series and
 `last_modified` a `datetime` time series, with the multi-argument forms
 composing through the standard Boolean operators. In a runtime function,
 `modified` and `valid` inspect evaluator-local endpoint metadata rather than
-construct Boolean time series. Both require at least one
-argument and fold over their arguments with complementary rules:
+construct Boolean time series. Non-empty calls fold over their arguments with
+complementary rules:
 
 ```text
 modified(a, b, c) = modified(a) || modified(b) || modified(c)
 valid(a, b, c)    = valid(a) && valid(b) && valid(c)
 ```
+
+Within a function-level `when` predicate, `modified()` selects all temporal
+parameters and retains the ordinary disjunction, while `valid()` selects all
+temporal parameters and retains the ordinary conjunction. `const` parameters,
+state, injected capabilities, and `out` are not members of that implicit input
+list. Empty calls outside a `when` predicate remain unspecified.
+
+The handler also supplies either selector when its top-level conjunction omits
+it. Thus `when modified(a) { ... }` implicitly requires `valid()`, and
+`when valid(a) { ... }` implicitly uses `modified()` for activation. A bare
+`when { ... }` supplies both. These defaults test endpoint validity only;
+recursive structural validity still requires `all_valid(value)`.
+
+The source spelling for an explicitly empty activation or validity selector is
+not yet defined. It cannot reuse `modified()` or `valid()`, because the empty
+argument list now means all temporal parameters. The runtime representation
+must nevertheless preserve the difference between a default selector and an
+explicit empty selector.
 
 The compiler may consume these calls while deriving node input policies, so
 they need not remain as runtime calls in generated C++. `valid(value)` tests
@@ -1702,6 +1732,11 @@ and phase checking derive one safe node policy across the complete body:
   executable handler;
 - handler-specific activation, validity, and other predicates remain ordered
   runtime conditions.
+
+Before deriving that policy, each handler is normalized with its implicit
+selectors. A missing top-level `modified(...)` selector becomes `modified()`;
+a missing top-level `valid(...)` selector becomes `valid()`. Calls nested under
+`||`, `!`, or another residual expression do not suppress these defaults.
 
 A function classified as runtime by another node-only construct but containing
 no `when` uses hgraph's default policy: every ordinary temporal input is active

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -331,8 +331,14 @@ Runtime semantic tests additionally cover:
 
 - `modified(a, b)` activating when either input changes;
 - `valid(a, b)` requiring both inputs to be valid;
-- zero-argument `modified()` and `valid()` selecting all temporal inputs;
-- omitted activation and validity predicates, including compact `when {}`;
+- `modified()` selecting any temporal input and `valid()` requiring every
+  temporal input inside a `when` predicate;
+- omission of either selector category supplying its empty-list default;
+- bare `when { ... }` matching `when modified() && valid() { ... }`;
+- selector calls nested in residual Boolean expressions not suppressing a
+  missing top-level selector default;
+- a diagnostic for empty selector calls outside a `when` predicate until their
+  semantics are specified;
 - top-level `valid(value)` versus recursive `all_valid(value)` semantics;
 - statically admitted and unchecked-valid inputs;
 - flow-sensitive payload reads guarded by `valid(input)`;

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -456,6 +456,30 @@ Use `if valid(value) { ... }` inside a handler when only part of that handler
 needs a value. Validity guards follow normal left-to-right short-circuit order,
 so place `valid(value)` before reading `value` in the same `&&` condition.
 
+Handler selectors have defaults. An empty argument list means the complete
+temporal parameter list: `modified()` means any input was modified, while
+`valid()` means every input is top-level valid. Omitting either selector from a
+handler supplies that default automatically.
+
+| Handler | Activation | Validity admission |
+| --- | --- | --- |
+| `when { ... }` | Any temporal input | Every temporal input |
+| `when modified() && valid() { ... }` | Any temporal input | Every temporal input |
+| `when modified(a) { ... }` | `a` | Every temporal input |
+| `when valid(a) { ... }` | Any temporal input | `a` |
+| `when modified(a, b) && valid(a) { ... }` | `a` or `b` | `a` |
+
+The first two forms are equivalent. These defaults apply to temporal function
+parameters, not `const` parameters, state, injectables, or `out`. `valid()` is
+not recursive for structural inputs; use `all_valid(value)` when every child
+must be valid. This decision gives empty calls meaning inside `when` predicates;
+their use elsewhere remains open. The bare and empty-selector forms are agreed
+syntax but await parser, checking, and lowering support.
+
+There is not yet an agreed HGL spelling for “no input activation” or “no
+validity requirement.” Those explicit empty policies are different from
+`modified()` and `valid()`, which both select the complete temporal input list.
+
 Under the agreed [iteration model](../design/iteration.md), `for` and collection
 traversal follow the containing phase rather than forcing runtime
 classification. In a graph, a supported wiring-time iterable provides scalar

--- a/language/docs/user-guide/language-tour.md
+++ b/language/docs/user-guide/language-tour.md
@@ -189,6 +189,8 @@ modified(price)
 valid(price)
 modified(bid, ask)
 valid(bid, ask)
+modified()
+valid()
 all_valid(book)
 last_modified(price)
 delta(positions)
@@ -198,6 +200,11 @@ delta(positions)
 true only when every argument is valid. `valid(value)` tests the endpoint
 itself; use `all_valid(value)` when every child of a structural or collection
 endpoint must also be valid.
+
+Inside a `when` header, empty calls select all temporal parameters. Omitting
+the modification or validity selector supplies that same default, so
+`when { ... }` is shorthand for “any input modified and all inputs valid.”
+The shorthand is an agreed target and currently awaits compiler support.
 
 The agreed collection traversal surface uses `keys`, `values`, `elements`,
 and `items`. `elements` is the list/set spelling and awaits compiler support.

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -893,6 +893,8 @@ modified(value)
 valid(value)
 modified(bid, ask)
 valid(bid, ask)
+modified()
+valid()
 all_valid(book)
 last_modified(value)
 delta(value)
@@ -901,9 +903,15 @@ delta(value)
 Source does not expose `value.modified`, `value.valid`, or `value.value`.
 In a runtime `when` predicate, `modified(value)` and `valid(value)` inspect the
 input endpoint while ordinary expressions read its current payload. Both
-predicates accept one or more arguments: `modified(a, b, c)` is true when any
-argument was modified, while `valid(a, b, c)` is true only when every argument
-is valid. Calls without arguments are invalid.
+predicates accept one or more explicit arguments: `modified(a, b, c)` is true
+when any argument was modified, while `valid(a, b, c)` is true only when every
+argument is valid. In a function-level `when` predicate, an empty argument list
+selects all temporal parameters: `modified()` means any was modified and
+`valid()` means all are top-level valid. A handler that omits either selector
+receives the corresponding empty-list default; consequently `when { ... }`
+means any input may trigger once every input is valid. Empty calls outside
+`when` are not specified by this decision. Bare and empty-selector handlers
+are specified but not yet implemented by the compiler.
 
 For a structural or collection input, `valid(value)` tests the validity of the
 endpoint itself rather than recursively requiring every child to be valid.

--- a/language/runtime-spec/README.md
+++ b/language/runtime-spec/README.md
@@ -1,0 +1,41 @@
+# hgraph runtime specification prototype
+
+Status: exploratory; syntax and file layout are provisional
+
+This folder tests a small backend-neutral DSL for describing hgraph runtime and
+type-generation contracts. It complements HGL rather than extending it:
+
+- `.hgspec` describes the portable runtime contract;
+- a C, C++, Rust, Swift, or other backend implements that contract;
+- `.hgl` describes graph and node libraries which target the contract.
+
+Nothing in this folder is consumed by CMake or the HGL compiler. Every source
+file begins with a `PROVISIONAL` notice. The design and intended generation
+boundary are in the
+[backend-neutral runtime specification](../docs/design/runtime-specification.md).
+
+## Prototype files
+
+- [`values.hgspec`](spec/values.hgspec) describes canonical value schemas,
+  capabilities, storage, and erased value operations.
+- [`time-series.hgspec`](spec/time-series.hgspec) describes temporal shapes,
+  endpoint state, deltas, and evaluation-local collection views.
+- [`execution.hgspec`](spec/execution.hgspec) describes node/graph lifecycle,
+  scheduling, providers, and leases.
+- [`operators.hgspec`](spec/operators.hgspec) describes nominal operator
+  contracts, candidates, resolution, and registration transactions.
+- [`conformance.hgspec`](spec/conformance.hgspec) records portable behavioral
+  traces the generated backends must share.
+- [`backends.md`](backends.md) sketches mappings for C, C++, Rust, and Swift.
+- [`requirements.md`](requirements.md) is the searchable ledger for every
+  provisional language and generation decision.
+
+## Guardrails
+
+- Describe semantic data and operations, not one backend's member layout.
+- Keep algorithms and performance representations in backend code.
+- Make ownership, borrowed lifetimes, fallibility, and lifecycle explicit.
+- Generate readable contracts and tests; never generate opaque implementation
+  machinery that cannot be reviewed.
+- Add source constructs only in response to a real HGL library or runtime
+  migration requirement.

--- a/language/runtime-spec/backends.md
+++ b/language/runtime-spec/backends.md
@@ -1,0 +1,44 @@
+# Prototype backend mappings
+
+Status: exploratory; no generator implements these mappings
+
+The `.hgspec` model is semantic. A backend owns its representation, but must
+preserve canonical identities, operation availability, ownership, lifecycle,
+and conformance traces.
+
+| Runtime-spec construct | C | C++ | Rust | Swift |
+| --- | --- | --- | --- | --- |
+| `record` | generated struct | aggregate descriptor | struct | struct |
+| `choice` | tag plus union | descriptor tag plus payload | enum | enum |
+| `interned schema` | registry index/handle | stable metadata pointer | interned `Arc`/index | registry token |
+| `ops` | function-pointer table | passive ops table | trait-object vtable or generated table | protocol witness/internal table |
+| `owned<T>` | explicit destroyable handle | RAII owner | owning value | owning value/box |
+| `borrowed<T, 'a>` | documented scoped view | non-owning view | checked borrow | scoped non-owning façade |
+| `inout<T, 'a>` | exclusive mutable scoped handle | mutable non-owning view | checked `&mut` borrow | `inout`/scoped mutable façade |
+| `shared<T>` | retained immutable handle | shared arena handle | `Arc<T>`-like handle | immutable retained box |
+| `fallible` | status plus out value | result/exception boundary chosen by profile | `Result<T, E>` | `throws` or result value |
+| `law` / `scenario` | generated test functions | Catch2 fixtures | property/unit tests | XCTest fixtures |
+
+## C ABI profile
+
+C is the interoperability baseline, not necessarily the implementation model.
+A C ABI profile would constrain:
+
+- fixed-width discriminants and descriptor versions;
+- opaque owner and borrowed-view handles;
+- function tables with explicit contexts;
+- status values rather than cross-boundary exceptions;
+- provider init/deinit/query entry points;
+- byte/string/span views with caller-visible lifetime rules.
+
+The ABI profile must not leak backend container layouts or make all internal
+calls pay an FFI cost. C++, Rust, and Swift backends may use native façades
+inside one package and expose the C profile only at module boundaries.
+
+## Required spike
+
+The first generator experiment should implement `ValueKind`, `ValueShape`,
+`ValueType`, and the read-only portion of `ValueOps` for C++ and Rust. It should
+then run the same canonicality and nominal-identity conformance vectors. That
+slice is large enough to test the model without committing to node execution or
+storage mutation.

--- a/language/runtime-spec/requirements.md
+++ b/language/runtime-spec/requirements.md
@@ -1,0 +1,52 @@
+# Runtime-description language requirements
+
+Status: exploratory ledger; no entry is accepted syntax or implementation
+
+The `.hgspec` files refer to these identifiers from `PROVISIONAL` comments.
+They make invented syntax and unresolved semantics searchable during review.
+
+## RDL-001: source syntax and semantic model
+
+The entire `.hgspec` grammar is provisional. Before it becomes a language, a
+parser spike must prove deterministic parsing, qualified imports, source spans,
+diagnostics, and round-trip formatting. The parsed model must distinguish
+semantic contracts from backend configuration and reject executable algorithms.
+
+## RDL-002: versioning and ABI profiles
+
+Package compatibility, schema evolution, backend-source compatibility, and
+binary ABI compatibility are different concerns. Define them separately.
+Fixed-width C ABI details should live in an explicit profile rather than leak
+into every semantic declaration.
+
+## RDL-003: ownership and lifetime lowering
+
+`owned`, `borrowed`, `inout`, and `shared` need formal transfer, aliasing, and
+lifetime rules. At minimum, C++/Rust generation must prove that evaluation-local
+views cannot escape, repeated node evaluation does not consume the node, and a
+provider cannot unload while any plan or graph retains a lease.
+
+## RDL-004: executable laws and scenarios
+
+Define the finite domain over which a `law` is generated, and distinguish a
+property test from a `scenario` trace. Backends must report the same observable
+failure identity; the DSL is not intended to become a theorem prover.
+
+## RDL-005: canonical identity and fingerprints
+
+Specify canonical encoding, nominal versus structural identity, registry
+generations, stable fingerprints, and collision handling. Pointer identity may
+be a backend optimization but cannot be the portable contract.
+
+## RDL-006: shared operator resolution
+
+Operator patterns, substitutions, rejection reasons, ranking, and ambiguity
+must denote the existing hgraph semantics. HGL, generated backends, and native
+providers must not acquire independent resolution algorithms.
+
+## RDL-007: generated and hand-written boundaries
+
+Generated descriptors, façades, registration manifests, and tests must be
+readable. Backend algorithms and representation strategies occupy named
+extension points that regeneration never overwrites. A two-backend spike must
+demonstrate this boundary before broadening the model.

--- a/language/runtime-spec/spec/conformance.hgspec
+++ b/language/runtime-spec/spec/conformance.hgspec
@@ -1,0 +1,68 @@
+// PROVISIONAL RDL-001: finite traces intended for every generated backend.
+
+spec hgraph.conformance version "0.1"
+
+scenario scalar_tick {
+    let type = ts(i64)
+    let endpoint = output(type)
+
+    at @2026-01-01T00:00:00Z {
+        apply(endpoint, atomic(7))
+        assert endpoint.valid
+        assert endpoint.modified
+        assert endpoint.value == 7
+        assert endpoint.last_modified == now
+    }
+
+    next_cycle {
+        assert endpoint.valid
+        assert !endpoint.modified
+        assert endpoint.value == 7
+    }
+}
+scenario set_delta {
+    let endpoint = output(tss(str))
+
+    at @2026-01-01T00:00:00Z {
+        apply(endpoint, set(added: {"A", "B"}, removed: {}))
+        assert endpoint.value == {"A", "B"}
+        assert endpoint.delta.added == {"A", "B"}
+    }
+
+    next_cycle {
+        apply(endpoint, set(added: {"C"}, removed: {"A"}))
+        assert endpoint.value == {"B", "C"}
+        assert endpoint.delta.added == {"C"}
+        assert endpoint.delta.removed == {"A"}
+    }
+}
+
+scenario ordered_node_activation {
+    let graph = graph {
+        source a: ts(i64)
+        source b: ts(i64)
+        node sum = add(a, b)
+        sink observe(sum)
+    }
+
+    start graph
+    tick a = 2
+    tick b = 3
+    run_cycle
+
+    assert evaluations == [a, b, sum, observe]
+    assert observed == [5]
+    stop graph
+}
+
+scenario provider_removal {
+    let handle = register(provider: "example.math", candidate: "example.math::add_i64")
+    let lease = wire("example.math::add_i64")
+
+    remove handle
+    assert resolve("example.math::add_i64") is no_match
+    assert physical_unload(handle) is denied
+
+    drop lease
+    assert physical_unload(handle) is allowed
+}

--- a/language/runtime-spec/spec/execution.hgspec
+++ b/language/runtime-spec/spec/execution.hgspec
@@ -1,0 +1,156 @@
+// PROVISIONAL RDL-001: illustrative runtime-spec syntax; no parser exists.
+// The contracts capture ordering and ownership, not a scheduling algorithm.
+
+spec hgraph.execution version "0.1"
+
+use hgraph.time_series::{TimeSeriesType}
+use hgraph.values::{ValueType}
+
+enum LifecycleState: u8 {
+    created
+    starting
+    started
+    evaluating
+    stopping
+    stopped
+}
+
+enum EdgeSource: u8 {
+    output
+    error_output
+    recordable_state
+}
+
+enum NodeKind: u8 {
+    compute
+    push_source
+    pull_source
+    sink
+    nested
+}
+
+record Edge {
+    source_node: usize
+    source_endpoint: EdgeSource
+    source_path: vector<usize>
+    target_node: usize
+    target_path: vector<usize>
+}
+
+flags NodeCapability: u32 {
+    start
+    evaluate
+    stop
+    schedule
+    error_output
+    recordable_state
+    child_graphs
+    push_source
+    service
+    global_state
+    evaluation_clock
+    python_values
+    phase_runner
+}
+
+record NodeType {
+    identity: str
+    kind: NodeKind
+    inputs: vector<schema<TimeSeriesType>>
+    output: optional<schema<TimeSeriesType>>
+    error_output: optional<schema<TimeSeriesType>>
+    scalars: optional<schema<ValueType>>
+    state: optional<schema<ValueType>>
+    recordable_state: optional<schema<TimeSeriesType>>
+    capabilities: set<NodeCapability>
+
+    // none means the runtime default; some([]) is deliberately empty.
+    active_inputs: optional<vector<usize>>
+    structural_inputs: vector<usize>
+    valid_inputs: optional<vector<usize>>
+    all_valid_inputs: vector<usize>
+    schedule_on_start: bool
+}
+
+record GraphType {
+    identity: str
+    nodes: vector<schema<NodeType>>
+    edges: vector<Edge>
+    push_source_prefix: usize
+}
+
+ops NodeOps<N: schema<NodeType>> {
+    noexcept state(node: borrowed<node<N>, 'graph>) -> LifecycleState
+    fallible start(
+        node: inout<node<N>, 'run>,
+        context: borrowed<RunContext, 'run>
+    )
+    hot fallible evaluate(
+        node: inout<node<N>, 'evaluation>,
+        context: borrowed<EvaluationContext, 'evaluation>
+    ) -> EvaluationResult
+    fallible stop(
+        node: inout<node<N>, 'run>,
+        context: borrowed<RunContext, 'run>
+    )
+    cold child_graphs(node: borrowed<node<N>, 'graph>) -> borrowed<child_graph_view, 'call>
+        requires child_graphs in N.capabilities
+}
+
+ops GraphOps<G: schema<GraphType>> {
+    fallible start(
+        graph: inout<graph<G>, 'run>,
+        context: borrowed<RunContext, 'run>
+    )
+    hot fallible evaluate(
+        graph: inout<graph<G>, 'evaluation>,
+        at: datetime
+    ) -> EvaluationResult
+    fallible stop(graph: inout<graph<G>, 'run>, at: datetime)
+    noexcept schedule(graph: inout<graph<G>, 'run>, node: usize, at: datetime)
+    cold inspect(graph: borrowed<graph<G>, 'graph>) -> borrowed<graph_view, 'call>
+}
+
+record Provider {
+    identity: str
+    version: str
+    fingerprint: bytes
+    dependencies: vector<str>
+}
+
+ops ProviderLifecycle<P: Provider> {
+    fallible init(
+        provider: P,
+        registry: inout<RegistryTransaction, 'transaction>
+    )
+    fallible deinit(handle: inout<ProviderHandle, 'provider>)
+    noexcept lease(handle: borrowed<ProviderHandle, 'provider>) -> shared<ProviderLease>
+}
+
+derive ExecutionRuntime for NodeType {
+    metadata
+    storage_plan
+    erased_ops NodeOps
+    owned Node
+    borrowed NodeView
+}
+
+derive ExecutionRuntime for GraphType {
+    metadata
+    storage_plan
+    erased_ops GraphOps
+    owned Graph
+    borrowed GraphView
+}
+
+law graph_edges_are_type_compatible(graph: GraphType) {
+    for edge in graph.edges {
+        source_type(graph, edge) is_assignable_to target_type(graph, edge)
+    }
+}
+
+law provider_lease_prevents_unload(handle: ProviderHandle) {
+    while live_leases(handle) > 0 {
+        physical_unload(handle) == denied
+    }
+}

--- a/language/runtime-spec/spec/execution.hgspec
+++ b/language/runtime-spec/spec/execution.hgspec
@@ -64,7 +64,9 @@ record NodeType {
     recordable_state: optional<schema<TimeSeriesType>>
     capabilities: set<NodeCapability>
 
-    // none means the runtime default; some([]) is deliberately empty.
+    // none means the runtime default: every temporal input is active and must
+    // be top-level valid. some([]) is deliberately empty. HGL's bare `when`
+    // selects these defaults; recursive child validity is a separate policy.
     active_inputs: optional<vector<usize>>
     structural_inputs: vector<usize>
     valid_inputs: optional<vector<usize>>
@@ -146,6 +148,21 @@ derive ExecutionRuntime for GraphType {
 law graph_edges_are_type_compatible(graph: GraphType) {
     for edge in graph.edges {
         source_type(graph, edge) is_assignable_to target_type(graph, edge)
+    }
+}
+
+law default_node_input_policy(node: NodeType) {
+    if node.active_inputs == none {
+        effective_active_inputs(node) == indices(node.inputs)
+    }
+    if node.valid_inputs == none {
+        effective_valid_inputs(node) == indices(node.inputs)
+    }
+    if node.active_inputs == some([]) {
+        effective_active_inputs(node) == []
+    }
+    if node.valid_inputs == some([]) {
+        effective_valid_inputs(node) == []
     }
 }
 

--- a/language/runtime-spec/spec/operators.hgspec
+++ b/language/runtime-spec/spec/operators.hgspec
@@ -1,0 +1,105 @@
+// PROVISIONAL RDL-001: illustrative runtime-spec syntax; no parser exists.
+// Candidate ranking must be shared behavior, never declaration-order choice.
+
+spec hgraph.operators version "0.1"
+
+use hgraph.execution::{Provider}
+use hgraph.time_series::{TimeSeriesType}
+use hgraph.values::{ValueType}
+
+choice TypePattern {
+    exact(type: schema<TimeSeriesType>)
+    variable(name: str, category: optional<TypeCategory>)
+    scalar(name: str, category: optional<TypeCategory>)
+    applied(constructor: str, arguments: vector<TypePattern>)
+    reference(target: TypePattern)
+    signal
+}
+
+enum ParameterRole: u8 {
+    input
+    scalar
+    type_argument
+    variadic_input
+}
+
+record Parameter {
+    name: str
+    role: ParameterRole
+    type: TypePattern
+    default: optional<ConstantExpression>
+}
+
+record OperatorContract {
+    identity: str
+    parameters: vector<Parameter>
+    output: optional<TypePattern>
+}
+
+record Candidate {
+    identity: str
+    operator: str
+    provider: Provider
+    parameters: vector<Parameter>
+    output: optional<TypePattern>
+    constraints: ConstraintExpression
+    implementation: ImplementationKind
+}
+
+enum ImplementationKind: u8 {
+    node
+    graph
+    native_scalar
+}
+
+record Resolution {
+    candidate: Candidate
+    substitutions: map<str, ResolvedArgument>
+    output: optional<schema<TimeSeriesType>>
+}
+
+ops OperatorResolver {
+    cold fallible resolve(
+        contract: OperatorContract,
+        candidates: borrowed<vector<Candidate>, 'registry>,
+        arguments: vector<ResolvedArgument>
+    ) -> Resolution
+
+    cold rank(candidate: Candidate, arguments: vector<ResolvedArgument>) -> MatchRank
+    cold reject_reason(candidate: Candidate, arguments: vector<ResolvedArgument>) -> optional<Diagnostic>
+}
+
+ops Registry {
+    fallible begin(provider: Provider) -> owned<RegistryTransaction>
+    fallible add(
+        transaction: inout<RegistryTransaction, 'transaction>,
+        candidate: Candidate
+    )
+    fallible commit(transaction: owned<RegistryTransaction>) -> owned<ProviderHandle>
+    noexcept rollback(transaction: owned<RegistryTransaction>)
+    fallible remove(handle: inout<ProviderHandle, 'provider>)
+    fallible replay_installers()
+}
+
+law specificity_beats_generic(
+    contract: OperatorContract,
+    exact: Candidate,
+    generic: Candidate,
+    arguments: vector<ResolvedArgument>
+) {
+    if matches(exact, arguments) && matches(generic, arguments) && more_specific(exact, generic) {
+        resolve(contract, [generic, exact], arguments).candidate == exact
+        resolve(contract, [exact, generic], arguments).candidate == exact
+    }
+}
+
+law equal_rank_is_ambiguous(
+    contract: OperatorContract,
+    lhs: Candidate,
+    rhs: Candidate,
+    arguments: vector<ResolvedArgument>
+) {
+    if matches(lhs, arguments) && matches(rhs, arguments) && rank(lhs, arguments) == rank(rhs, arguments) {
+        resolve(contract, [lhs, rhs], arguments) is ambiguity
+    }
+}

--- a/language/runtime-spec/spec/time-series.hgspec
+++ b/language/runtime-spec/spec/time-series.hgspec
@@ -1,0 +1,108 @@
+// PROVISIONAL RDL-001: illustrative runtime-spec syntax; no parser exists.
+// Borrowed iterator lifetimes and delta algebra are semantic requirements.
+
+spec hgraph.time_series version "0.1"
+
+use hgraph.values::{StoragePlan, ValueType, ValueView}
+
+enum TimeSeriesKind: u8 {
+    ts
+    tss
+    tsd
+    tsl
+    tsw
+    tsb
+    ref
+    signal
+}
+
+record TimeSeriesField {
+    name: str
+    index: usize
+    type: schema<TimeSeriesType>
+}
+
+choice WindowSpec {
+    ticks(max: usize, min: usize)
+    duration(max: duration, min: duration)
+}
+
+choice TimeSeriesShape {
+    ts(value: schema<ValueType>)
+    tss(element: schema<ValueType>)
+    tsd(key: schema<ValueType>, value: schema<TimeSeriesType>)
+    tsl(element: schema<TimeSeriesType>, fixed_size: optional<usize>)
+    tsw(element: schema<ValueType>, window: WindowSpec)
+    tsb(fields: vector<TimeSeriesField>, nominal_name: optional<str>)
+    ref(target: schema<TimeSeriesType>)
+    signal
+}
+
+interned schema TimeSeriesType {
+    shape: TimeSeriesShape
+    value: optional<schema<ValueType>>
+    key: canonical(shape)
+}
+
+record EndpointState<T: schema<TimeSeriesType>> {
+    valid: bool
+    modified: bool
+    last_modified: datetime
+    value: optional<borrowed<ValueView, 'graph>>
+}
+
+choice Delta<T: schema<TimeSeriesType>> {
+    atomic(value: borrowed<ValueView, 'evaluation>)
+    set(added: borrowed<set_view, 'evaluation>,
+        removed: borrowed<set_view, 'evaluation>)
+    dict(added: borrowed<key_view, 'evaluation>,
+         modified: borrowed<entry_view, 'evaluation>,
+         removed: borrowed<key_view, 'evaluation>)
+    list(added: borrowed<index_view, 'evaluation>,
+         modified: borrowed<entry_view, 'evaluation>,
+         removed: borrowed<index_view, 'evaluation>)
+    bundle(modified: borrowed<field_view, 'evaluation>)
+    reference(target_changed: bool)
+    signal
+}
+
+ops TimeSeriesOps<T: schema<TimeSeriesType>> {
+    cold storage_plan(type: T) -> schema<StoragePlan>
+    hot state(endpoint: borrowed<endpoint<T>, 'graph>) -> EndpointState<T>
+    hot delta(endpoint: borrowed<endpoint<T>, 'evaluation>) -> borrowed<Delta<T>, 'evaluation>
+    hot apply(
+        endpoint: inout<endpoint<T>, 'evaluation>,
+        delta: borrowed<Delta<T>, 'evaluation>
+    )
+    hot subscribe(
+        input: inout<input<T>, 'graph>,
+        output: borrowed<output<T>, 'graph>
+    )
+    hot unsubscribe(input: inout<input<T>, 'graph>)
+    cold value_schema(type: T) -> optional<schema<ValueType>>
+}
+
+derive TimeSeriesRuntime for TimeSeriesType {
+    metadata
+    storage_plan
+    erased_ops TimeSeriesOps
+    borrowed InputView
+    borrowed OutputView
+    delta_views
+    descriptor_json
+    conformance_tests
+}
+
+law modified_implies_time_advance<T: schema<TimeSeriesType>>(
+    before: EndpointState<T>, after: EndpointState<T>
+) {
+    if after.modified {
+        after.last_modified >= before.last_modified
+    }
+}
+
+law signal_has_no_payload(type: TimeSeriesType) {
+    if type.shape is signal {
+        type.value == none
+    }
+}

--- a/language/runtime-spec/spec/values.hgspec
+++ b/language/runtime-spec/spec/values.hgspec
@@ -1,0 +1,129 @@
+// PROVISIONAL RDL-001: illustrative runtime-spec syntax; no parser exists.
+// This file describes semantics, not the C++ ValueTypeMetaData memory layout.
+
+spec hgraph.values version "0.1"
+
+enum ValueKind: u8 {
+    atomic
+    tuple
+    bundle
+    list
+    set
+    map
+    cyclic_buffer
+    queue
+    any
+}
+
+flags ValueCapability: u32 {
+    trivial_construct
+    trivial_destroy
+    trivial_copy
+    hash
+    equality
+    ordering
+    contiguous_buffer
+    variadic_tuple
+    mutable
+    nullable
+    enum_value
+    owned_indirect
+    shaped_array
+    shared_value
+    frame
+}
+
+record ValueField {
+    name: optional<str>
+    index: usize
+    type: schema<ValueType>
+}
+
+record EnumMember {
+    name: str
+    number: i64
+}
+
+record NominalBundle {
+    module: str
+    name: str
+    abstract: bool
+    parents: vector<schema<ValueType>>
+    type_arguments: vector<schema<ValueType>>
+    discriminator: str = "__type__"
+    discriminator_value: optional<str>
+}
+
+choice ValueShape {
+    atomic(native_name: str)
+    tuple(fields: vector<ValueField>)
+    bundle(fields: vector<ValueField>, nominal: optional<NominalBundle>)
+    list(element: schema<ValueType>, fixed_size: optional<usize>)
+    set(element: schema<ValueType>)
+    map(key: schema<ValueType>, value: schema<ValueType>)
+    cyclic_buffer(element: schema<ValueType>, capacity: usize)
+    queue(element: schema<ValueType>, capacity: usize)
+    any
+    enum(module: str, name: str, members: vector<EnumMember>)
+}
+
+interned schema ValueType {
+    shape: ValueShape
+    capabilities: set<ValueCapability>
+
+    // Structural shapes key recursively by shape. Nominal bundles and enums
+    // additionally key by module/name and cannot collapse onto equal fields.
+    key: canonical(shape, capabilities)
+}
+
+record StoragePlan {
+    size: usize
+    alignment: usize
+    components: vector<StorageComponent>
+}
+
+record StorageComponent {
+    name: optional<str>
+    offset: usize
+    plan: schema<StoragePlan>
+}
+
+ops ValueOps<T: schema<ValueType>> {
+    cold plan(type: T) -> schema<StoragePlan>
+    noexcept construct(storage: inout<storage<T>, 'call>)
+    noexcept destroy(storage: inout<storage<T>, 'call>)
+    fallible copy(
+        source: borrowed<value<T>, 'call>,
+        target: inout<storage<T>, 'call>
+    )
+    fallible move(
+        source: inout<value<T>, 'call>,
+        target: inout<storage<T>, 'call>
+    )
+    fallible equal(lhs: borrowed<value<T>>, rhs: borrowed<value<T>>) -> bool
+        requires equality in T.capabilities
+    fallible compare(lhs: borrowed<value<T>>, rhs: borrowed<value<T>>) -> ordering
+        requires ordering in T.capabilities
+    fallible hash(value: borrowed<value<T>>) -> u64
+        requires hash in T.capabilities
+}
+
+derive ValueRuntime for ValueType {
+    metadata
+    storage_plan
+    erased_ops ValueOps
+    owned Value
+    borrowed ValueView
+    descriptor_json
+    conformance_tests
+}
+
+law canonical_value_schema(description: ValueType) {
+    intern(description) === intern(description)
+}
+
+law nominal_identity(lhs: ValueType, rhs: ValueType) {
+    if nominal_name(lhs) != nominal_name(rhs) {
+        intern(lhs) !== intern(rhs)
+    }
+}

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -172,6 +172,18 @@ unsupported, not added here as a supported loop contract.
 are also deferred. The proposed predicate-to-switch conversion is not an
 agreed contract and has no corpus example; further loop design is paused.
 
+## Runtime handler defaults
+
+[when-defaults.hgl](examples/when-defaults.hgl) records the agreed relationship
+between explicit, empty, and omitted handler selectors. `modified()` means any
+temporal parameter was modified and `valid()` means every temporal parameter
+is top-level valid. Omitting either selector supplies that default, making
+`when { ... }` equivalent to `when modified() && valid() { ... }`.
+
+This is a design fixture rather than a compiler test. Parsing, semantic
+normalization, native selector extraction, and scripted/AOT parity remain to be
+implemented.
+
 ## Compiler status
 
 The smallest temporal graph conditional—an explicit two-branch expression with

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -1,13 +1,17 @@
 # HGL standard-library design corpus
 
-This folder will describe the core hgraph node and graph library in HGL as the
-required language contracts are agreed. It starts with worked examples that
-exercise those contracts; these example functions are not new public library
-components. The component inventory and HGL declarations remain to be added.
+This folder describes the core hgraph node and graph library in HGL as the
+required language contracts are agreed. The worked examples exercise focused
+language contracts; these example functions are not new public library
+components. The [migration inventory](inventory.md) now bounds the native
+surface, while the [HGL source prototype](hgl/README.md) tests representative
+contracts and implementations against it.
 
-Only agreed syntax belongs in the corpus. Open questions should be recorded
-in the owning design document, without filling gaps with speculative
-declarations or native-binding syntax.
+Only agreed syntax belongs in the existing `examples` corpus. The separate
+`hgl` prototype may use unresolved syntax when a real migration needs it, but
+every use is marked `PROVISIONAL` and linked to the central
+[requirements ledger](requirements.md). Those files are not compiler tests or
+claims of accepted language behavior.
 
 ## Conditional results
 

--- a/language/stdlib/examples/when-defaults.hgl
+++ b/language/stdlib/examples/when-defaults.hgl
@@ -1,0 +1,25 @@
+// DESIGN FIXTURE — bare when and empty selector lowering are not implemented.
+
+fn default_sum(a: f64, b: f64) -> f64 {
+    when {
+        return a + b
+    }
+}
+
+fn explicit_default_sum(a: f64, b: f64) -> f64 {
+    when modified() && valid() {
+        return a + b
+    }
+}
+
+fn on_a_when_all_valid(a: f64, b: f64) -> f64 {
+    when modified(a) {
+        return a + b
+    }
+}
+
+fn any_input_when_a_valid(a: f64, b: f64) -> f64 {
+    when valid(a) {
+        return a
+    }
+}

--- a/language/stdlib/hgl/README.md
+++ b/language/stdlib/hgl/README.md
@@ -27,12 +27,19 @@ shares one implementation body between `i64` and `f64` while still advertising
 and registering two concrete overload candidates. Those declarations exercise
 implemented HGL syntax rather than a provisional library spelling.
 
-That model is insufficient for truly open library candidates. `sample<T>` must
-also work for downstream nominal schemas, and `len_<T, size>` cannot enumerate
-every element type and fixed-list size when this provider is built. Such
-templates are deliberately left without a fake finite materialization list and
-marked `HGL-LIB-015` until the publication owner and portable representation of
-open generic candidates are settled.
+An `_` argument retains that generic in the published resolver signature. The
+collection part consequently uses
+`instantiate sum_<i64, _>, sum_<f64, _>`: its accumulator type must be concrete,
+but list size is only a type marker and one candidate accepts every resolved
+fixed size. Retention and body availability are independent. `len_<T, size>`
+reads `size`, so it needs deliberate reification of the selected wiring-time
+value rather than a signature-only marker.
+
+That model is still insufficient for every open library candidate. `sample<T>`
+must work for downstream nominal schemas, while `len_` needs body-visible
+generic metadata. Such templates are deliberately left without a fake finite
+materialization list and marked `HGL-LIB-015` until the publication owner and
+portable representation of reified open generics are settled.
 
 ## Why a separate source root
 

--- a/language/stdlib/hgl/README.md
+++ b/language/stdlib/hgl/README.md
@@ -12,6 +12,13 @@ Every provisional form references an entry in
 [`requirements.md`](../requirements.md). The compiler must reject unsupported
 forms until that requirement is designed and implemented.
 
+Runtime handlers use the most compact agreed selector form. `when { ... }`
+means any temporal input activates the handler after every temporal input is
+valid. A handler writes only its residual predicate when those two defaults
+still apply. Explicit `modified(...)` and `valid(...)` calls remain only where
+the implementation deliberately selects different input subsets, such as
+`sample` and the ordered per-input handlers in `merge`.
+
 ## Explicit materialization policy
 
 Closed implementation domains use generic source once and enumerate their

--- a/language/stdlib/hgl/README.md
+++ b/language/stdlib/hgl/README.md
@@ -12,6 +12,21 @@ Every provisional form references an entry in
 [`requirements.md`](../requirements.md). The compiler must reject unsupported
 forms until that requirement is designed and implemented.
 
+## Explicit materialization policy
+
+Closed implementation domains use generic source once and enumerate their
+generated candidates with `instantiate`. For example, the arithmetic part
+shares one implementation body between `i64` and `f64` while still advertising
+and registering two concrete overload candidates. Those declarations exercise
+implemented HGL syntax rather than a provisional library spelling.
+
+That model is insufficient for truly open library candidates. `sample<T>` must
+also work for downstream nominal schemas, and `len_<T, size>` cannot enumerate
+every element type and fixed-list size when this provider is built. Such
+templates are deliberately left without a fake finite materialization list and
+marked `HGL-LIB-015` until the publication owner and portable representation of
+open generic candidates are settled.
+
 ## Why a separate source root
 
 - [`examples`](../../examples/README.md) remains the executable compiler

--- a/language/stdlib/hgl/README.md
+++ b/language/stdlib/hgl/README.md
@@ -6,9 +6,12 @@ This folder is the proposed source root for the hgraph library implemented in
 HGL. Files under `hgraph/std` are parts of one logical `hgraph.std` module so
 operator identities remain compatible with the current native registry.
 
-The source is intentionally not compiled yet. It combines accepted HGL syntax
-with explicitly marked provisional forms needed to expose migration blockers.
-Every provisional form references an entry in
+The `hgraph.std` source is intentionally not compiled yet. It combines accepted
+HGL syntax with explicitly marked provisional forms needed to expose migration
+blockers. Its `hgraph.native` dependency is different: that module is compiled
+from HGL into a real C++ library, installed as `hgl::core_native`, and exercised
+by the package-backed [`core-native-library.hgl`](examples/core-native-library.hgl)
+consumer. Every remaining provisional form references an entry in
 [`requirements.md`](../requirements.md). The compiler must reject unsupported
 forms until that requirement is designed and implemented.
 
@@ -33,13 +36,15 @@ collection part consequently uses
 but list size is only a type marker and one candidate accepts every resolved
 fixed size. Retention and body availability are independent.
 
-`len_<T, size>` does not reify that marker. Its runtime body calls the native
-`len(value)` overload, which receives the live typed collection input view and
-reads its current size. The marker still participates in overload selection;
-it is neither stored in the node nor recovered from the schema each tick.
-Because the body also does not need the element, key, or value types, the
-prototype publishes its list, set, and map implementations with
-`instantiate len_<_, _>, len_<_>`.
+`len_<T, size>` does not reify that marker. Its runtime body calls the real
+native `len(value)` overload, which receives the live typed collection input
+view and reads its current size. The marker still participates in overload
+selection; it is neither stored in the node nor recovered from the schema each
+tick. The same substrate implements `is_empty`. Because these bodies do not
+need element, key, value, or window-bound generics, the prototype retains those
+positions with `instantiate len_<_, _>, len_<_>, len_<_, _, _>` and the
+equivalent `is_empty` declaration. Non-generic string candidates are published
+directly.
 
 That model is still insufficient for every open library candidate. `sample<T>`
 must work for downstream nominal schemas, and other implementations may

--- a/language/stdlib/hgl/README.md
+++ b/language/stdlib/hgl/README.md
@@ -1,0 +1,45 @@
+# HGL standard-library source prototype
+
+Status: conceptual migration corpus; not part of the compiler test suite
+
+This folder is the proposed source root for the hgraph library implemented in
+HGL. Files under `hgraph/std` are parts of one logical `hgraph.std` module so
+operator identities remain compatible with the current native registry.
+
+The source is intentionally not compiled yet. It combines accepted HGL syntax
+with explicitly marked provisional forms needed to expose migration blockers.
+Every provisional form references an entry in
+[`requirements.md`](../requirements.md). The compiler must reject unsupported
+forms until that requirement is designed and implemented.
+
+## Why a separate source root
+
+- [`examples`](../../examples/README.md) remains the executable compiler
+  corpus.
+- [`stdlib/examples`](../../examples) remains the language-design fixture
+  corpus.
+- `stdlib/hgl` is a prospective shippable library whose generated C++ will
+  eventually replace hand-written algorithmic nodes and graphs.
+
+Moving a file into the executable or production build requires its provisional
+markers to be removed, generated C++ to remain readable, and native/Python
+behavioral parity to pass.
+
+## Module layout
+
+The first extraction mirrors the public C++ operator families:
+
+- [`arithmetic.hgl`](hgraph/std/arithmetic.hgl)
+- [`comparison.hgl`](hgraph/std/comparison.hgl)
+- [`collection.hgl`](hgraph/std/collection.hgl)
+- [`control.hgl`](hgraph/std/control.hgl)
+- [`conversion.hgl`](hgraph/std/conversion.hgl)
+- [`stream.hgl`](hgraph/std/stream.hgl)
+- [`temporal.hgl`](hgraph/std/temporal.hgl)
+- [`text-io.hgl`](hgraph/std/text-io.hgl)
+- [`frames.hgl`](hgraph/std/frames.hgl)
+
+The declarations are an extraction aid, not a claim that every current C++
+signature has been fully reproduced. Defaults, output resolvers, keyword packs,
+policy constraints, and internal marker operators still require a declaration-
+by-declaration audit before a module can replace the native provider.

--- a/language/stdlib/hgl/README.md
+++ b/language/stdlib/hgl/README.md
@@ -31,15 +31,22 @@ An `_` argument retains that generic in the published resolver signature. The
 collection part consequently uses
 `instantiate sum_<i64, _>, sum_<f64, _>`: its accumulator type must be concrete,
 but list size is only a type marker and one candidate accepts every resolved
-fixed size. Retention and body availability are independent. `len_<T, size>`
-reads `size`, so it needs deliberate reification of the selected wiring-time
-value rather than a signature-only marker.
+fixed size. Retention and body availability are independent.
+
+`len_<T, size>` does not reify that marker. Its runtime body calls the native
+`len(value)` overload, which receives the live typed collection input view and
+reads its current size. The marker still participates in overload selection;
+it is neither stored in the node nor recovered from the schema each tick.
+Because the body also does not need the element, key, or value types, the
+prototype publishes its list, set, and map implementations with
+`instantiate len_<_, _>, len_<_>`.
 
 That model is still insufficient for every open library candidate. `sample<T>`
-must work for downstream nominal schemas, while `len_` needs body-visible
-generic metadata. Such templates are deliberately left without a fake finite
-materialization list and marked `HGL-LIB-015` until the publication owner and
-portable representation of reified open generics are settled.
+must work for downstream nominal schemas, and other implementations may
+genuinely need a selected generic as body-visible metadata. Such templates are
+deliberately left without a fake finite materialization list and marked
+`HGL-LIB-015` until the publication owner and portable representation of
+reified open generics are settled.
 
 ## Why a separate source root
 

--- a/language/stdlib/hgl/hgraph/std/arithmetic.hgl
+++ b/language/stdlib/hgl/hgraph/std/arithmetic.hgl
@@ -1,0 +1,79 @@
+// DESIGN PROTOTYPE — this file is not compiled.
+// PROVISIONAL HGL-LIB-001: several files contribute to one hgraph.std module.
+
+module hgraph.std part arithmetic
+
+operator add_<L, R, O>(lhs: L, rhs: R) -> O
+operator sub_<L, R, O>(lhs: L, rhs: R) -> O
+operator mul_<L, R, O>(lhs: L, rhs: R) -> O
+operator div_<L, R, O>(lhs: L, rhs: R) -> O
+operator floordiv_<L, R, O>(lhs: L, rhs: R) -> O
+operator mod_<L, R, O>(lhs: L, rhs: R) -> O
+operator divmod_<L, R, O>(lhs: L, rhs: R) -> O
+operator pow_<L, R, O>(lhs: L, rhs: R) -> O
+operator round_(value: f64, digits: i64) -> f64
+operator neg_<T, O>(value: T) -> O
+operator pos_<T, O>(value: T) -> O
+operator abs_<T, O>(value: T) -> O
+operator sign<T, O>(value: T) -> O
+operator ln(value: f64) -> f64
+
+// PROVISIONAL HGL-LIB-004: inside a RuntimeFn, scalar operators must lower to
+// direct scalar operations. They must not recursively wire these operators.
+
+impl fn add_(lhs: i64, rhs: i64) -> i64 {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        return lhs + rhs
+    }
+}
+
+impl fn add_(lhs: f64, rhs: f64) -> f64 {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        return lhs + rhs
+    }
+}
+
+impl fn sub_(lhs: i64, rhs: i64) -> i64 {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        return lhs - rhs
+    }
+}
+
+impl fn sub_(lhs: f64, rhs: f64) -> f64 {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        return lhs - rhs
+    }
+}
+
+impl fn mul_(lhs: i64, rhs: i64) -> i64 {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        return lhs * rhs
+    }
+}
+
+impl fn mul_(lhs: f64, rhs: f64) -> f64 {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        return lhs * rhs
+    }
+}
+
+impl fn div_(lhs: i64, rhs: i64) -> f64 {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        return lhs / rhs
+    }
+}
+
+impl fn div_(lhs: f64, rhs: f64) -> f64 {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        return lhs / rhs
+    }
+}
+
+// PROVISIONAL HGL-LIB-003: algebraic properties belong to a candidate and a
+// concrete type domain. This illustrative form is not current HGL syntax:
+// properties add_(i64, i64) -> i64 { associative, commutative }
+// Floating-point add deliberately has no associative property.
+
+// floordiv_, mod_, divmod_, pow_, round_, abs_, sign, and ln need precise
+// error/overflow behavior or reviewed scalar kernels before source candidates
+// can replace the native implementations.

--- a/language/stdlib/hgl/hgraph/std/arithmetic.hgl
+++ b/language/stdlib/hgl/hgraph/std/arithmetic.hgl
@@ -24,7 +24,7 @@ operator ln(value: f64) -> f64
 impl fn add_<T>(lhs: T, rhs: T) -> T
 requires T in {i64, f64}
 {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
+    when {
         return lhs + rhs
     }
 }
@@ -34,7 +34,7 @@ instantiate add_<i64>, add_<f64>
 impl fn sub_<T>(lhs: T, rhs: T) -> T
 requires T in {i64, f64}
 {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
+    when {
         return lhs - rhs
     }
 }
@@ -44,7 +44,7 @@ instantiate sub_<i64>, sub_<f64>
 impl fn mul_<T>(lhs: T, rhs: T) -> T
 requires T in {i64, f64}
 {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
+    when {
         return lhs * rhs
     }
 }
@@ -54,7 +54,7 @@ instantiate mul_<i64>, mul_<f64>
 impl fn div_<T>(lhs: T, rhs: T) -> f64
 requires T in {i64, f64}
 {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
+    when {
         return lhs / rhs
     }
 }

--- a/language/stdlib/hgl/hgraph/std/arithmetic.hgl
+++ b/language/stdlib/hgl/hgraph/std/arithmetic.hgl
@@ -21,53 +21,45 @@ operator ln(value: f64) -> f64
 // PROVISIONAL HGL-LIB-004: inside a RuntimeFn, scalar operators must lower to
 // direct scalar operations. They must not recursively wire these operators.
 
-impl fn add_(lhs: i64, rhs: i64) -> i64 {
+impl fn add_<T>(lhs: T, rhs: T) -> T
+requires T in {i64, f64}
+{
     when modified(lhs, rhs) && valid(lhs, rhs) {
         return lhs + rhs
     }
 }
 
-impl fn add_(lhs: f64, rhs: f64) -> f64 {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
-        return lhs + rhs
-    }
-}
+instantiate add_<i64>, add_<f64>
 
-impl fn sub_(lhs: i64, rhs: i64) -> i64 {
+impl fn sub_<T>(lhs: T, rhs: T) -> T
+requires T in {i64, f64}
+{
     when modified(lhs, rhs) && valid(lhs, rhs) {
         return lhs - rhs
     }
 }
 
-impl fn sub_(lhs: f64, rhs: f64) -> f64 {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
-        return lhs - rhs
-    }
-}
+instantiate sub_<i64>, sub_<f64>
 
-impl fn mul_(lhs: i64, rhs: i64) -> i64 {
+impl fn mul_<T>(lhs: T, rhs: T) -> T
+requires T in {i64, f64}
+{
     when modified(lhs, rhs) && valid(lhs, rhs) {
         return lhs * rhs
     }
 }
 
-impl fn mul_(lhs: f64, rhs: f64) -> f64 {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
-        return lhs * rhs
-    }
-}
+instantiate mul_<i64>, mul_<f64>
 
-impl fn div_(lhs: i64, rhs: i64) -> f64 {
+impl fn div_<T>(lhs: T, rhs: T) -> f64
+requires T in {i64, f64}
+{
     when modified(lhs, rhs) && valid(lhs, rhs) {
         return lhs / rhs
     }
 }
 
-impl fn div_(lhs: f64, rhs: f64) -> f64 {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
-        return lhs / rhs
-    }
-}
+instantiate div_<i64>, div_<f64>
 
 // PROVISIONAL HGL-LIB-003: algebraic properties belong to a candidate and a
 // concrete type domain. This illustrative form is not current HGL syntax:

--- a/language/stdlib/hgl/hgraph/std/collection.hgl
+++ b/language/stdlib/hgl/hgraph/std/collection.hgl
@@ -3,6 +3,10 @@
 
 module hgraph.std part collection
 
+// BLOCKED HGL-LIB-015: these implementations are intentionally left as open
+// templates. Element types and fixed-list sizes are not a closed set that this
+// provider can enumerate with `instantiate`.
+
 operator sum_<S, O>(values: S) -> O
 operator mean<S, O>(values: S) -> O
 operator union<S, O>(values: S) -> O

--- a/language/stdlib/hgl/hgraph/std/collection.hgl
+++ b/language/stdlib/hgl/hgraph/std/collection.hgl
@@ -3,9 +3,13 @@
 
 module hgraph.std part collection
 
+// PROVISIONAL HGL-LIB-004: the descriptor-backed hgraph.native package is not
+// yet shipped as a standard-library dependency.
+use hgraph.native as native
+
 // PARTIAL HGL-LIB-015: `_` can retain a signature-only resolver marker, so a
 // candidate such as sum_<i64, _> does not enumerate fixed-list sizes. Open
-// element/output types and retained values used by a body remain unresolved.
+// element/output types remain unresolved.
 
 operator sum_<S, O>(values: S) -> O
 operator mean<S, O>(values: S) -> O
@@ -41,25 +45,25 @@ operator dereference<S>(value: ref<S>) -> S
 
 impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
     when {
-        return size
+        return native::len(value)
     }
 }
 
-// BLOCKED HGL-LIB-015: unlike sum_, len_ reads `size`. Publishing
-// len_<T, _> therefore needs the selected resolver value to be reified for the
-// body; retaining it as a signature-only marker is insufficient.
-
-// PROVISIONAL HGL-LIB-006: `elements` in runtime code and its borrowed
-// lifetime are agreed target behavior but are not fully implemented.
 impl fn len_<T>(value: set<T>) -> i64 {
     when {
-        var count: i64 = 0
-        for element in elements(value) {
-            count += 1
-        }
-        return count
+        return native::len(value)
     }
 }
+
+impl fn len_<K, V>(value: map<K, V>) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+
+// All generic positions are signature-only: the selected native overload
+// consumes one erased typed input view.
+instantiate len_<_, _>, len_<_>
 
 impl fn sum_<T, const size: i64>(values: list<T, size>) -> T
 requires T in {i64, f64}
@@ -75,9 +79,8 @@ requires T in {i64, f64}
 
 instantiate sum_<i64, _>, sum_<f64, _>
 
-// BLOCKED HGL-LIB-015: `size` is body-visible here, as it is for len_.
 impl fn mean<const size: i64>(values: list<f64, size>) -> f64 =>
-    sum_(values) / size
+    sum_(values) / len_(values)
 
 // PROVISIONAL HGL-LIB-006: set output mutation spellings are illustrative.
 impl fn union<T>(lhs: set<T>, rhs: set<T>) -> set<T> {

--- a/language/stdlib/hgl/hgraph/std/collection.hgl
+++ b/language/stdlib/hgl/hgraph/std/collection.hgl
@@ -40,7 +40,7 @@ operator is_empty<S>(value: S) -> bool
 operator dereference<S>(value: ref<S>) -> S
 
 impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
-    when modified(value) && valid(value) {
+    when {
         return size
     }
 }
@@ -48,7 +48,7 @@ impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
 // PROVISIONAL HGL-LIB-006: `elements` in runtime code and its borrowed
 // lifetime are agreed target behavior but are not fully implemented.
 impl fn len_<T>(value: set<T>) -> i64 {
-    when modified(value) && valid(value) {
+    when {
         var count: i64 = 0
         for element in elements(value) {
             count += 1
@@ -58,7 +58,7 @@ impl fn len_<T>(value: set<T>) -> i64 {
 }
 
 impl fn sum_<const size: i64>(values: list<i64, size>) -> i64 {
-    when modified(values) && valid(values) {
+    when {
         var total: i64 = 0
         for value in elements(values) {
             total += value
@@ -96,7 +96,7 @@ impl fn union<T>(lhs: set<T>, rhs: set<T>) -> set<T> {
 // PROVISIONAL HGL-LIB-007: the exact standalone native pass-through node can
 // be expressed once delta(value) has a type-preserving result.
 fn pass_through<T>(value: T) -> T {
-    when modified(value) {
+    when {
         return delta(value)
     }
 }

--- a/language/stdlib/hgl/hgraph/std/collection.hgl
+++ b/language/stdlib/hgl/hgraph/std/collection.hgl
@@ -3,8 +3,9 @@
 
 module hgraph.std part collection
 
-// PROVISIONAL HGL-LIB-004: the descriptor-backed hgraph.native package is not
-// yet shipped as a standard-library dependency.
+// hgraph.native is the compiled, descriptor-backed C++ substrate. This file
+// remains a design prototype because multi-file hgraph.std modules and several
+// collection algorithms below still use unresolved forms.
 use hgraph.native as native
 
 // PARTIAL HGL-LIB-015: `_` can retain a signature-only resolver marker, so a
@@ -43,7 +44,19 @@ operator index_of<S, I>(value: S, item: I) -> i64
 operator is_empty<S>(value: S) -> bool
 operator dereference<S>(value: ref<S>) -> S
 
+impl fn len_(value: str) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+
 impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+
+impl fn len_<T>(value: list<T, unbounded>) -> i64 {
     when {
         return native::len(value)
     }
@@ -61,9 +74,57 @@ impl fn len_<K, V>(value: map<K, V>) -> i64 {
     }
 }
 
+impl fn len_<T, const max_size: i64, const min_size: i64>(
+    value: rolling<T, max_size, min_size>
+) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+
 // All generic positions are signature-only: the selected native overload
 // consumes one erased typed input view.
-instantiate len_<_, _>, len_<_>
+instantiate len_<_, _>, len_<_>, len_<_, _, _>
+
+impl fn is_empty(value: str) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+impl fn is_empty<T, const size: i64>(value: list<T, size>) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+impl fn is_empty<T>(value: list<T, unbounded>) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+impl fn is_empty<T>(value: set<T>) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+impl fn is_empty<K, V>(value: map<K, V>) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+impl fn is_empty<T, const max_size: i64, const min_size: i64>(
+    value: rolling<T, max_size, min_size>
+) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+instantiate is_empty<_, _>, is_empty<_>, is_empty<_, _, _>
 
 impl fn sum_<T, const size: i64>(values: list<T, size>) -> T
 requires T in {i64, f64}

--- a/language/stdlib/hgl/hgraph/std/collection.hgl
+++ b/language/stdlib/hgl/hgraph/std/collection.hgl
@@ -1,0 +1,98 @@
+// DESIGN PROTOTYPE — this file is not compiled.
+// PROVISIONAL HGL-LIB-001: several files contribute to one hgraph.std module.
+
+module hgraph.std part collection
+
+operator sum_<S, O>(values: S) -> O
+operator mean<S, O>(values: S) -> O
+operator union<S, O>(values: S) -> O
+operator intersection<S, O>(values: S) -> O
+operator difference<S, O>(values: S) -> O
+operator symmetric_difference<S, O>(values: S) -> O
+operator keys_<S, O>(values: S) -> O
+operator values_<S, O>(values: S) -> O
+operator rekey<S, K, O>(values: S, new_keys: K) -> O
+operator flip<S, O>(values: S) -> O
+operator partition<S, P, O>(values: S, partitions: P) -> O
+operator combine_tsd<K, V, O>(keys: K, values: V) -> O
+operator combine_cs<S, O>(values: S) -> O
+operator make_tsd<K, V, O>(key: K, value: V) -> O
+operator min_ts_list<S, O>(values: S) -> O
+operator max_ts_list<S, O>(values: S) -> O
+operator combine_map<K, V, O>(keys: K, values: V) -> O
+operator unpartition<S, O>(values: S) -> O
+operator flip_keys<S, O>(values: S) -> O
+operator filter_tsd_by_matches<S, M, O>(values: S, matches: M) -> O
+operator collapse_keys<S, O>(values: S) -> O
+operator uncollapse_keys<S, O>(values: S) -> O
+
+operator getitem_<S, K, O>(value: S, key: K) -> O
+operator getattr_<S, O>(value: S, const attr: str) -> O
+operator setattr_<S, V, O>(value: S, const attr: str, replacement: V) -> O
+operator contains_<S, I>(value: S, item: I) -> bool
+operator len_<S>(value: S) -> i64
+operator index_of<S, I>(value: S, item: I) -> i64
+operator is_empty<S>(value: S) -> bool
+operator dereference<S>(value: ref<S>) -> S
+
+impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
+    when modified(value) && valid(value) {
+        return size
+    }
+}
+
+// PROVISIONAL HGL-LIB-006: `elements` in runtime code and its borrowed
+// lifetime are agreed target behavior but are not fully implemented.
+impl fn len_<T>(value: set<T>) -> i64 {
+    when modified(value) && valid(value) {
+        var count: i64 = 0
+        for element in elements(value) {
+            count += 1
+        }
+        return count
+    }
+}
+
+impl fn sum_<const size: i64>(values: list<i64, size>) -> i64 {
+    when modified(values) && valid(values) {
+        var total: i64 = 0
+        for value in elements(values) {
+            total += value
+        }
+        return total
+    }
+}
+
+impl fn mean<const size: i64>(values: list<f64, size>) -> f64 =>
+    sum_(values) / size
+
+// PROVISIONAL HGL-LIB-006: set output mutation spellings are illustrative.
+impl fn union<T>(lhs: set<T>, rhs: set<T>) -> set<T> {
+    inject out
+
+    when modified(lhs) && valid(lhs) {
+        for value in elements(lhs, added) {
+            insert(out, value)
+        }
+        for value in elements(lhs, removed) {
+            erase(out, value)
+        }
+    }
+
+    when modified(rhs) && valid(rhs) {
+        for value in elements(rhs, added) {
+            insert(out, value)
+        }
+        // Correct union removal needs membership in the other input. This is
+        // intentionally left incomplete until collection-view membership and
+        // simultaneous-delta semantics are specified.
+    }
+}
+
+// PROVISIONAL HGL-LIB-007: the exact standalone native pass-through node can
+// be expressed once delta(value) has a type-preserving result.
+fn pass_through<T>(value: T) -> T {
+    when modified(value) {
+        return delta(value)
+    }
+}

--- a/language/stdlib/hgl/hgraph/std/collection.hgl
+++ b/language/stdlib/hgl/hgraph/std/collection.hgl
@@ -3,9 +3,9 @@
 
 module hgraph.std part collection
 
-// BLOCKED HGL-LIB-015: these implementations are intentionally left as open
-// templates. Element types and fixed-list sizes are not a closed set that this
-// provider can enumerate with `instantiate`.
+// PARTIAL HGL-LIB-015: `_` can retain a signature-only resolver marker, so a
+// candidate such as sum_<i64, _> does not enumerate fixed-list sizes. Open
+// element/output types and retained values used by a body remain unresolved.
 
 operator sum_<S, O>(values: S) -> O
 operator mean<S, O>(values: S) -> O
@@ -45,6 +45,10 @@ impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
     }
 }
 
+// BLOCKED HGL-LIB-015: unlike sum_, len_ reads `size`. Publishing
+// len_<T, _> therefore needs the selected resolver value to be reified for the
+// body; retaining it as a signature-only marker is insufficient.
+
 // PROVISIONAL HGL-LIB-006: `elements` in runtime code and its borrowed
 // lifetime are agreed target behavior but are not fully implemented.
 impl fn len_<T>(value: set<T>) -> i64 {
@@ -57,9 +61,11 @@ impl fn len_<T>(value: set<T>) -> i64 {
     }
 }
 
-impl fn sum_<const size: i64>(values: list<i64, size>) -> i64 {
+impl fn sum_<T, const size: i64>(values: list<T, size>) -> T
+requires T in {i64, f64}
+{
     when {
-        var total: i64 = 0
+        var total: T = 0
         for value in elements(values) {
             total += value
         }
@@ -67,6 +73,9 @@ impl fn sum_<const size: i64>(values: list<i64, size>) -> i64 {
     }
 }
 
+instantiate sum_<i64, _>, sum_<f64, _>
+
+// BLOCKED HGL-LIB-015: `size` is body-visible here, as it is for len_.
 impl fn mean<const size: i64>(values: list<f64, size>) -> f64 =>
     sum_(values) / size
 

--- a/language/stdlib/hgl/hgraph/std/comparison.hgl
+++ b/language/stdlib/hgl/hgraph/std/comparison.hgl
@@ -1,0 +1,75 @@
+// DESIGN PROTOTYPE — this file is not compiled.
+// PROVISIONAL HGL-LIB-001: several files contribute to one hgraph.std module.
+
+module hgraph.std part comparison
+
+operator eq_<T>(lhs: T, rhs: T) -> bool
+operator ne_<T>(lhs: T, rhs: T) -> bool
+operator lt_<T>(lhs: T, rhs: T) -> bool
+operator le_<T>(lhs: T, rhs: T) -> bool
+operator gt_<T>(lhs: T, rhs: T) -> bool
+operator ge_<T>(lhs: T, rhs: T) -> bool
+operator cmp_<T, O>(lhs: T, rhs: T) -> O
+operator min_<L, R, O>(lhs: L, rhs: R) -> O
+operator max_<L, R, O>(lhs: L, rhs: R) -> O
+
+operator and_<T>(lhs: T, rhs: T) -> bool
+operator or_<T>(lhs: T, rhs: T) -> bool
+operator not_<T>(value: T) -> bool
+operator invert_<T, O>(value: T) -> O
+operator bit_and<L, R, O>(lhs: L, rhs: R) -> O
+operator bit_or<L, R, O>(lhs: L, rhs: R) -> O
+operator bit_xor<L, R, O>(lhs: L, rhs: R) -> O
+operator lshift_<L, R, O>(lhs: L, rhs: R) -> O
+operator rshift_<L, R, O>(lhs: L, rhs: R) -> O
+
+// These candidates test that comparison syntax is scalar within a runtime
+// handler and temporal only while composing a graph (HGL-LIB-004).
+
+impl fn eq_(lhs: i64, rhs: i64) -> bool {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        return lhs == rhs
+    }
+}
+
+impl fn eq_(lhs: str, rhs: str) -> bool {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        return lhs == rhs
+    }
+}
+
+impl fn lt_(lhs: f64, rhs: f64) -> bool {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        return lhs < rhs
+    }
+}
+
+impl fn min_(lhs: f64, rhs: f64) -> f64 {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        if lhs <= rhs {
+            return lhs
+        } else {
+            return rhs
+        }
+    }
+}
+
+impl fn max_(lhs: f64, rhs: f64) -> f64 {
+    when modified(lhs, rhs) && valid(lhs, rhs) {
+        if lhs >= rhs {
+            return lhs
+        } else {
+            return rhs
+        }
+    }
+}
+
+impl fn not_(value: bool) -> bool {
+    when modified(value) && valid(value) {
+        return !value
+    }
+}
+
+// cmp_ needs a nominal result enum. Bitwise and shift implementations need
+// source operators or constrained scalar-kernel calls; neither is invented
+// here.

--- a/language/stdlib/hgl/hgraph/std/comparison.hgl
+++ b/language/stdlib/hgl/hgraph/std/comparison.hgl
@@ -29,7 +29,7 @@ operator rshift_<L, R, O>(lhs: L, rhs: R) -> O
 impl fn eq_<T>(lhs: T, rhs: T) -> bool
 requires T in {i64, str}
 {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
+    when {
         return lhs == rhs
     }
 }
@@ -37,13 +37,13 @@ requires T in {i64, str}
 instantiate eq_<i64>, eq_<str>
 
 impl fn lt_(lhs: f64, rhs: f64) -> bool {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
+    when {
         return lhs < rhs
     }
 }
 
 impl fn min_(lhs: f64, rhs: f64) -> f64 {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
+    when {
         if lhs <= rhs {
             return lhs
         } else {
@@ -53,7 +53,7 @@ impl fn min_(lhs: f64, rhs: f64) -> f64 {
 }
 
 impl fn max_(lhs: f64, rhs: f64) -> f64 {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
+    when {
         if lhs >= rhs {
             return lhs
         } else {
@@ -63,7 +63,7 @@ impl fn max_(lhs: f64, rhs: f64) -> f64 {
 }
 
 impl fn not_(value: bool) -> bool {
-    when modified(value) && valid(value) {
+    when {
         return !value
     }
 }

--- a/language/stdlib/hgl/hgraph/std/comparison.hgl
+++ b/language/stdlib/hgl/hgraph/std/comparison.hgl
@@ -26,17 +26,15 @@ operator rshift_<L, R, O>(lhs: L, rhs: R) -> O
 // These candidates test that comparison syntax is scalar within a runtime
 // handler and temporal only while composing a graph (HGL-LIB-004).
 
-impl fn eq_(lhs: i64, rhs: i64) -> bool {
+impl fn eq_<T>(lhs: T, rhs: T) -> bool
+requires T in {i64, str}
+{
     when modified(lhs, rhs) && valid(lhs, rhs) {
         return lhs == rhs
     }
 }
 
-impl fn eq_(lhs: str, rhs: str) -> bool {
-    when modified(lhs, rhs) && valid(lhs, rhs) {
-        return lhs == rhs
-    }
-}
+instantiate eq_<i64>, eq_<str>
 
 impl fn lt_(lhs: f64, rhs: f64) -> bool {
     when modified(lhs, rhs) && valid(lhs, rhs) {

--- a/language/stdlib/hgl/hgraph/std/control.hgl
+++ b/language/stdlib/hgl/hgraph/std/control.hgl
@@ -1,0 +1,48 @@
+// DESIGN PROTOTYPE — this file is not compiled.
+// PROVISIONAL HGL-LIB-001: several files contribute to one hgraph.std module.
+// PROVISIONAL HGL-LIB-002: ...T is a variadic temporal input pack.
+
+module hgraph.std part control
+
+operator merge<S>(inputs: ...S) -> S
+operator race<S>(inputs: ...S) -> S
+operator all_(inputs: ...bool) -> bool
+operator any_(inputs: ...bool) -> bool
+operator if_<S, O>(condition: bool, value: S) -> O
+operator route_by_index<S, O>(index: i64, value: S) -> O
+operator if_true(condition: bool, const tick_once_only: bool) -> bool
+operator if_then_else<S>(condition: bool, true_value: S, false_value: S) -> S
+operator if_cmp<S, O>(comparison: S, less: O, equal: O, greater: O) -> O
+operator merge_tsd_disjoint<S>(values: S) -> S
+operator reduce_tsd_with_race<S>(values: S) -> S
+operator reduce_tsd_of_bundles_with_race<S>(values: S) -> S
+
+// PROVISIONAL HGL-LIB-002/HGL-LIB-011: callable and argument packs.
+operator reduce<S, O>(values: S, operation: fn(O, O) -> O) -> O
+operator switch_<K, O>(selector: K, cases: ...{K: fn() -> O}) -> O
+operator dispatch_<K, O>(selector: K, cases: ...{K: fn() -> O}) -> O
+operator map_<S, O>(operation: fn(S) -> O, values: S) -> O
+operator mesh_<K, S, O>(keys: K, operation: fn(S) -> O, values: S) -> O
+operator try_except<S, O>(operation: fn(S) -> O, values: S) -> O
+
+// This graph candidate should lower to the native temporal switch. The body
+// does not inspect the current condition while wiring.
+impl fn if_then_else<T>(condition: bool, true_value: T, false_value: T) -> T =>
+    if condition { true_value } else { false_value }
+
+// PROVISIONAL HGL-LIB-010: a fixed binary candidate refines the variadic
+// merge contract. Ordered when blocks make the right input win when both tick.
+impl fn merge<T>(left: T, right: T) -> T {
+    when modified(left) && valid(left) {
+        return left
+    }
+
+    when modified(right) && valid(right) {
+        return right
+    }
+}
+
+// map_, reduce, switch_, dispatch_, mesh_, and try_except are principally
+// compiler/runtime-kernel contracts. HGL convenience candidates should be
+// added only after HGL-LIB-011 separates source composition from child-owner
+// machinery.

--- a/language/stdlib/hgl/hgraph/std/control.hgl
+++ b/language/stdlib/hgl/hgraph/std/control.hgl
@@ -4,6 +4,9 @@
 
 module hgraph.std part control
 
+// BLOCKED HGL-LIB-015: the source candidates below are schema-polymorphic and
+// cannot be published by enumerating a closed `instantiate` list here.
+
 operator merge<S>(inputs: ...S) -> S
 operator race<S>(inputs: ...S) -> S
 operator all_(inputs: ...bool) -> bool

--- a/language/stdlib/hgl/hgraph/std/conversion.hgl
+++ b/language/stdlib/hgl/hgraph/std/conversion.hgl
@@ -1,0 +1,32 @@
+// DESIGN PROTOTYPE — this file is not compiled.
+// PROVISIONAL HGL-LIB-001: several files contribute to one hgraph.std module.
+
+module hgraph.std part conversion
+
+operator convert<S, O>(value: S) -> O
+operator combine<S, O>(value: S) -> O
+operator collect<S, O>(value: S) -> O
+operator emit<S, O>(value: S) -> O
+operator cast_<S, O>(value: S) -> O
+operator downcast_<S, O>(value: S) -> O
+operator downcast_ref<S, O>(value: ref<S>) -> ref<O>
+operator str_<S>(value: S) -> str
+operator type_<S, O>(value: S) -> O
+operator zero<O>(operation: fn(O, O) -> O) -> O
+operator nothing<O>() -> O
+operator combine_tss_from_tsl<S, O>(value: S) -> O
+
+// The current library operator named `emit` is retained above. It is unrelated
+// to the removed HGL output statement: function bodies produce output with
+// `return` or through `inject out`.
+
+// BLOCKED HGL-LIB-009: the stable native registry names `const` and `default`
+// are HGL keywords. Their source declarations need an explicit identity map.
+// The following signatures are the contracts, not proposed source spellings:
+//
+// native-name "const": (const value: T, const delay: duration) -> T
+// native-name "default": (value: T, default_value: T) -> T
+
+// PROVISIONAL HGL-LIB-008: most candidates in this family require declarative
+// output resolution. A repeated unconstrained O records the relationship but
+// is not enough to make calls infer or select the output.

--- a/language/stdlib/hgl/hgraph/std/frames.hgl
+++ b/language/stdlib/hgl/hgraph/std/frames.hgl
@@ -1,0 +1,62 @@
+// DESIGN PROTOTYPE — this file is not compiled.
+// PROVISIONAL HGL-LIB-001: several files contribute to one hgraph.std module.
+
+module hgraph.std part frames
+
+// PROVISIONAL HGL-LIB-004: `frame` is supplied by the reviewed Arrow/native
+// descriptor boundary; it is not a new HGL-owned storage representation.
+use hgraph.kernel::{frame}
+
+operator to_table<S, O>(value: S, mode: i64) -> O
+operator from_table<T, O>(value: T) -> O
+operator from_table_const<O>(const value: frame) -> O
+
+operator from_data_frame<O>(
+    const value: frame,
+    const datetime_column: str,
+    const key_column: str,
+    const value_column: str,
+    const offset: duration
+) -> O
+operator from_data_frame_batches<O>(
+    batches: frame,
+    const datetime_column: str,
+    const key_column: str,
+    const value_column: str,
+    const offset: duration
+) -> O
+operator replay_data_frame<O>(const value: frame, const as_of: datetime) -> O
+operator to_data_frame<S, O>(
+    value: S,
+    const datetime_column: str,
+    const key_column: str,
+    const value_column: str
+) -> O
+operator group_by<F, K, O>(value: F, const by: K) -> O
+operator sorted_<F>(value: F, const by: str, const descending: bool) -> F
+operator concat<F>(lhs: F, rhs: F) -> F
+operator filter_frame<F, P>(value: F, predicate: P) -> F
+operator filter_cs<F, P>(value: F, predicate: P) -> F
+operator ungroup<S, O>(value: S) -> O
+operator with_columns<F, C, O>(value: F, columns: C) -> O
+
+// `join` is already declared by the string part under the same native
+// operator identity. The frame candidate has a different call shape:
+//
+// impl fn join<L, R, K, O>(
+//     lhs: L,
+//     rhs: R,
+//     const on: K,
+//     const how: str,
+//     const suffix: str
+// ) -> O => native frame join
+//
+// PROVISIONAL HGL-LIB-008/HGL-LIB-010: the candidate needs a resolved output
+// row schema and implementation-specific scalar parameters. This is also a
+// useful test that one nominal operator family can span string and frame
+// candidates without source-order dispatch.
+
+// Arrow builders, row-schema synthesis, table codecs, sorting, grouping, and
+// joins are native primitives. The HGL library can own higher-level graph
+// composition around them once constrained borrowed/owned frame functions are
+// exposed by a descriptor (HGL-LIB-004).

--- a/language/stdlib/hgl/hgraph/std/stream.hgl
+++ b/language/stdlib/hgl/hgraph/std/stream.hgl
@@ -1,0 +1,74 @@
+// DESIGN PROTOTYPE — this file is not compiled.
+// PROVISIONAL HGL-LIB-001: several files contribute to one hgraph.std module.
+
+module hgraph.std part stream
+
+operator sample<T>(trigger: signal, value: T) -> T
+operator lag<T>(value: T, const period: i64) -> T
+operator schedule(const delay: duration) -> bool
+operator request_id(const hash: i64) -> i64
+operator dedup<T>(value: T) -> T
+operator filter_<T>(condition: bool, value: T) -> T
+operator filter_by<T>(value: T) -> T
+operator until_true<T>(value: T) -> bool
+operator freeze<T>(predicate: bool, value: T) -> T
+operator throttle<T>(value: T, period: duration) -> T
+operator take<T>(value: T, const count: i64) -> T
+operator drop<T>(value: T, const count: i64) -> T
+operator window<S, O>(value: S, const period: i64) -> O
+operator to_window<S, O>(value: S, const period: i64, const min_period: i64) -> O
+operator gate<T>(condition: bool, value: T, const buffer_length: i64) -> T
+operator batch<S, O>(condition: bool, value: S) -> O
+operator step<T>(value: T, const step_size: i64) -> T
+operator slice_<T>(value: T, const start: i64, const stop: i64, const step: i64) -> T
+
+// Internal native marker `__lag_proxy` is intentionally not a public HGL
+// operator. The lag composition may target it as a compiler-selected kernel.
+
+impl fn sample<T>(trigger: signal, value: T) -> T {
+    when modified(trigger) && valid(value) {
+        return value
+    }
+}
+
+impl fn filter_<T>(condition: bool, value: T) -> T {
+    when modified(condition, value) && valid(condition, value) && condition {
+        return value
+    }
+}
+
+impl fn dedup<T>(value: T) -> T
+requires eq_(T, T) -> bool
+{
+    inject out
+
+    when modified(value) && valid(value) {
+        if !valid(out) || value != out {
+            out = value
+        }
+    }
+}
+
+impl fn take<T>(value: T, const count: i64) -> T {
+    state emitted: i64 = 0
+
+    when modified(value) && valid(value) && emitted < count {
+        emitted += 1
+        return value
+    }
+}
+
+impl fn drop<T>(value: T, const count: i64) -> T {
+    state observed: i64 = 0
+
+    when modified(value) && valid(value) {
+        observed += 1
+        if observed > count {
+            return value
+        }
+    }
+}
+
+// lag, schedule, throttle, gate, batch, window, and to_window require an
+// explicit scheduler/buffer or native child-owner contract (HGL-LIB-005,
+// HGL-LIB-011, HGL-LIB-012).

--- a/language/stdlib/hgl/hgraph/std/stream.hgl
+++ b/language/stdlib/hgl/hgraph/std/stream.hgl
@@ -71,4 +71,5 @@ impl fn drop<T>(value: T, const count: i64) -> T {
 
 // lag, schedule, throttle, gate, batch, window, and to_window require an
 // explicit scheduler/buffer or native child-owner contract (HGL-LIB-005,
-// HGL-LIB-011, HGL-LIB-012).
+// HGL-LIB-011, HGL-LIB-012). Scheduler-only activation also needs the explicit
+// empty input-policy form in HGL-LIB-014.

--- a/language/stdlib/hgl/hgraph/std/stream.hgl
+++ b/language/stdlib/hgl/hgraph/std/stream.hgl
@@ -3,6 +3,9 @@
 
 module hgraph.std part stream
 
+// BLOCKED HGL-LIB-015: the source candidates below must accept downstream
+// nominal and structural types, not only a finite built-in materialization set.
+
 operator sample<T>(trigger: signal, value: T) -> T
 operator lag<T>(value: T, const period: i64) -> T
 operator schedule(const delay: duration) -> bool

--- a/language/stdlib/hgl/hgraph/std/stream.hgl
+++ b/language/stdlib/hgl/hgraph/std/stream.hgl
@@ -35,7 +35,7 @@ impl fn sample<T>(trigger: signal, value: T) -> T {
 }
 
 impl fn filter_<T>(condition: bool, value: T) -> T {
-    when modified(condition, value) && valid(condition, value) && condition {
+    when condition {
         return value
     }
 }
@@ -45,7 +45,7 @@ requires eq_(T, T) -> bool
 {
     inject out
 
-    when modified(value) && valid(value) {
+    when {
         if !valid(out) || value != out {
             out = value
         }
@@ -55,7 +55,7 @@ requires eq_(T, T) -> bool
 impl fn take<T>(value: T, const count: i64) -> T {
     state emitted: i64 = 0
 
-    when modified(value) && valid(value) && emitted < count {
+    when emitted < count {
         emitted += 1
         return value
     }
@@ -64,7 +64,7 @@ impl fn take<T>(value: T, const count: i64) -> T {
 impl fn drop<T>(value: T, const count: i64) -> T {
     state observed: i64 = 0
 
-    when modified(value) && valid(value) {
+    when {
         observed += 1
         if observed > count {
             return value

--- a/language/stdlib/hgl/hgraph/std/temporal.hgl
+++ b/language/stdlib/hgl/hgraph/std/temporal.hgl
@@ -1,0 +1,71 @@
+// DESIGN PROTOTYPE — this file is not compiled.
+// PROVISIONAL HGL-LIB-001: several files contribute to one hgraph.std module.
+
+module hgraph.std part temporal
+
+// PROVISIONAL HGL-LIB-004: these names are provided by a reviewed native type
+// descriptor rather than by a second HGL runtime implementation.
+use hgraph.kernel::{instant_range}
+
+operator day_of_month(value: date) -> i64
+operator month_of_year(value: date) -> i64
+operator year<T>(value: T) -> i64
+operator month<T>(value: T) -> i64
+operator day<T>(value: T) -> i64
+operator weekday<T>(value: T) -> i64
+operator isoweekday<T>(value: T) -> i64
+operator days(value: duration) -> i64
+operator seconds(value: duration) -> i64
+operator microseconds(value: duration) -> i64
+operator total_seconds(value: duration) -> f64
+operator hour<T>(value: T) -> i64
+operator minute<T>(value: T) -> i64
+operator second<T>(value: T) -> i64
+operator microsecond<T>(value: T) -> i64
+operator datepart(value: datetime) -> datetime
+operator timestamp(value: datetime) -> f64
+operator evaluation_time_in_range<A, B, O>(start: A, end: B) -> O
+operator isoformat<T>(value: T) -> str
+operator explode<T, O>(value: T) -> O
+
+// These names are phase-polymorphic HGL intrinsics as well as native operator
+// contracts. Their implementation boundary must remain explicit.
+operator valid<T>(value: T) -> bool
+operator modified(value: signal) -> bool
+operator last_modified_time(value: signal) -> datetime
+operator last_modified_wall_clock_time(value: signal) -> datetime
+operator last_modified_date(value: signal) -> date
+
+operator at_zone(value: datetime, zone: timezone) -> zoned_datetime
+operator resolve_civil(
+    value: civil_datetime,
+    zone: timezone,
+    const ambiguous: i64,
+    const nonexistent: i64
+) -> zoned_datetime
+operator convert_zone(value: zoned_datetime, zone: timezone) -> zoned_datetime
+operator to_instant(value: zoned_datetime) -> datetime
+operator to_civil(value: zoned_datetime) -> civil_datetime
+
+operator range_contains<R, V>(range: R, value: V) -> bool
+operator range_intersection<R>(lhs: R, rhs: R) -> R
+operator range_overlaps<R>(lhs: R, rhs: R) -> bool
+operator range_touches<R>(lhs: R, rhs: R) -> bool
+operator range_adjacent<R>(lhs: R, rhs: R) -> bool
+operator range_mergeable<R>(lhs: R, rhs: R) -> bool
+operator range_difference<R, O>(lhs: R, rhs: R) -> O
+operator range_union<R, O>(lhs: R, rhs: R) -> O
+operator range_merge<R>(lhs: R, rhs: R) -> R
+operator range_hull<R>(lhs: R, rhs: R) -> R
+operator range_shift<R, D>(range: R, offset: D, const month_end_policy: i64) -> R
+operator range_extent(range: instant_range) -> duration
+operator temporal_floor<T>(value: T, quantum: duration) -> T
+operator temporal_ceil<T>(value: T, quantum: duration) -> T
+operator temporal_round<T>(value: T, quantum: duration) -> T
+operator temporal_bucket(value: datetime, width: duration) -> instant_range
+
+// Component extraction, timezone resolution, ISO formatting, and range
+// arithmetic need reviewed scalar primitives (HGL-LIB-004). Scheduler-aware
+// evaluation_time_in_range additionally needs an approved scheduler capability
+// (HGL-LIB-012). Policy parameters should become nominal enums once imported
+// enum mapping is defined; i64 above is only a visible placeholder.

--- a/language/stdlib/hgl/hgraph/std/text-io.hgl
+++ b/language/stdlib/hgl/hgraph/std/text-io.hgl
@@ -42,7 +42,7 @@ operator from_json<O>(value: str) -> O
 // __json_array remain compiler-selected kernels rather than public HGL names.
 
 impl fn null_sink<T>(value: T) {
-    when modified(value) {
+    when {
     }
 }
 
@@ -51,7 +51,7 @@ impl fn null_sink<T>(value: T) {
 impl fn debug_print<T>(const label: str, value: T) {
     inject logger
 
-    when modified(value) && valid(value) {
+    when {
         logger.info(label, value)
     }
 }

--- a/language/stdlib/hgl/hgraph/std/text-io.hgl
+++ b/language/stdlib/hgl/hgraph/std/text-io.hgl
@@ -4,6 +4,9 @@
 
 module hgraph.std part text_io
 
+// BLOCKED HGL-LIB-015: the generic sink candidates below are deliberately not
+// given a misleading finite list of materializations.
+
 operator match_<O>(pattern: str, value: str) -> O
 operator replace(pattern: str, replacement: str, value: str) -> str
 operator substr(value: str, start: i64, end: i64) -> str

--- a/language/stdlib/hgl/hgraph/std/text-io.hgl
+++ b/language/stdlib/hgl/hgraph/std/text-io.hgl
@@ -1,0 +1,58 @@
+// DESIGN PROTOTYPE — this file is not compiled.
+// PROVISIONAL HGL-LIB-001: several files contribute to one hgraph.std module.
+// PROVISIONAL HGL-LIB-002: ...T and ...{str: T} are input packs.
+
+module hgraph.std part text_io
+
+operator match_<O>(pattern: str, value: str) -> O
+operator replace(pattern: str, replacement: str, value: str) -> str
+operator substr(value: str, start: i64, end: i64) -> str
+operator split<O>(value: str, const separator: str) -> O
+operator join<S>(values: S, const separator: str) -> str
+operator format_<A>(format: str, args: ...A, kwargs: ...{str: A}) -> str
+
+operator debug_print<T>(const label: str, value: T)
+operator null_sink<T>(value: T)
+operator stop_engine(value: signal, const message: str)
+operator apply<F, A, O>(function: F, args: ...A, kwargs: ...{str: A}) -> O
+operator call<F, A>(function: F, args: ...A, kwargs: ...{str: A})
+operator print_<A>(format: str, args: ...A, kwargs: ...{str: A})
+operator log_<A>(format: str, args: ...A, kwargs: ...{str: A}, const level: i64)
+operator assert_(condition: bool, const message: str)
+operator record<T>(value: T, const key: str)
+operator replay<O>(const key: str) -> O
+operator replay_const<O>(const key: str) -> O
+operator compare<T>(lhs: T, rhs: T, const recordable_id: str)
+
+operator to_json<T>(value: T, const delta_only: bool) -> str
+operator combine_json<S, O>(values: S) -> O
+operator json_encode<J>(value: J) -> str
+operator json_decode<J>(value: str) -> J
+operator json_as_int<J>(value: J) -> i64
+operator json_as_float<J>(value: J) -> f64
+operator json_as_str<J>(value: J) -> str
+operator json_as_bool<J>(value: J) -> bool
+operator from_json<O>(value: str) -> O
+
+// Internal registry names __print_sink, __log_sink, __assert_fmt,
+// __apply_value_callable, __call_value_callable, __json_object, and
+// __json_array remain compiler-selected kernels rather than public HGL names.
+
+impl fn null_sink<T>(value: T) {
+    when modified(value) {
+    }
+}
+
+// PROVISIONAL HGL-LIB-012/HGL-LIB-013: logger formatting and the generic
+// value-to-text contract need structured effects and documentation metadata.
+impl fn debug_print<T>(const label: str, value: T) {
+    inject logger
+
+    when modified(value) && valid(value) {
+        logger.info(label, value)
+    }
+}
+
+// Regex, dynamic callable, JSON, record/replay, standard-output, engine
+// control, and formatted logging behavior remain constrained native kernels.
+// HGL graph wrappers may assemble their arguments once packs and effects exist.

--- a/language/stdlib/inventory.md
+++ b/language/stdlib/inventory.md
@@ -73,8 +73,8 @@ The source prototype deliberately starts with:
    operators inside an implementation of the corresponding temporal operator;
 2. `sample`, `filter_`, `dedup`, `take`, and `drop`, testing activation,
    recordable state, prior output, and generic equality;
-3. fixed-list `len_`, `sum_`, and `mean`, testing constant generics and
-   evaluation-time traversal;
+3. collection `len_`, fixed-list `sum_`, and `mean`, testing constant generics,
+   live native collection views, and evaluation-time traversal;
 4. `if_then_else` and binary `merge`, testing graph versus node selection;
 5. `pass_through_node`, testing portable delta capture/apply;
 6. contract-only declarations for the remaining families, exposing variadic,
@@ -86,9 +86,11 @@ The blockers discovered by these files are maintained in
 The first extraction also demonstrates that concrete materialization is not a
 complete replacement for open generic registration. A retained `_` slot now
 lets `sum_` publish concrete numeric element types without enumerating fixed
-list sizes. Schema-polymorphic candidates and generics whose selected value is
-used by the body remain source templates under `HGL-LIB-015` until a portable
-publication and reification model is agreed.
+list sizes. `len_` obtains runtime collection metadata through a typed native
+input view without reifying that marker. Schema-polymorphic candidates and
+generics whose selected value is genuinely used by the body remain source
+templates under `HGL-LIB-015` until a portable publication and reification
+model is agreed.
 
 ## Definition of migrated
 

--- a/language/stdlib/inventory.md
+++ b/language/stdlib/inventory.md
@@ -1,6 +1,6 @@
 # Standard-library migration inventory
 
-Status: baseline inventory from hgraph `baa51d58e`; migration not started
+Status: baseline inventory refreshed at hgraph `8ab0c9438`; migration not started
 
 This inventory makes the current C++ library finite before any implementation
 is removed. The public headers contain 212 operator marker declarations with
@@ -68,8 +68,9 @@ No item in this inventory is yet `migrated`.
 
 The source prototype deliberately starts with:
 
-1. scalar arithmetic/comparison candidates, testing runtime scalar operators
-   inside an implementation of the corresponding temporal operator;
+1. scalar arithmetic/comparison candidates, using explicit concrete
+   materializations for closed type domains and testing runtime scalar
+   operators inside an implementation of the corresponding temporal operator;
 2. `sample`, `filter_`, `dedup`, `take`, and `drop`, testing activation,
    recordable state, prior output, and generic equality;
 3. fixed-list `len_`, `sum_`, and `mean`, testing constant generics and
@@ -81,6 +82,11 @@ The source prototype deliberately starts with:
 
 The blockers discovered by these files are maintained in
 [`requirements.md`](requirements.md).
+
+The first extraction also demonstrates that closed materialization is not a
+complete replacement for open generic registration. Schema-polymorphic and
+arbitrary-size candidates remain source templates under `HGL-LIB-015` until a
+portable publication model is agreed.
 
 ## Definition of migrated
 

--- a/language/stdlib/inventory.md
+++ b/language/stdlib/inventory.md
@@ -83,10 +83,12 @@ The source prototype deliberately starts with:
 The blockers discovered by these files are maintained in
 [`requirements.md`](requirements.md).
 
-The first extraction also demonstrates that closed materialization is not a
-complete replacement for open generic registration. Schema-polymorphic and
-arbitrary-size candidates remain source templates under `HGL-LIB-015` until a
-portable publication model is agreed.
+The first extraction also demonstrates that concrete materialization is not a
+complete replacement for open generic registration. A retained `_` slot now
+lets `sum_` publish concrete numeric element types without enumerating fixed
+list sizes. Schema-polymorphic candidates and generics whose selected value is
+used by the body remain source templates under `HGL-LIB-015` until a portable
+publication and reification model is agreed.
 
 ## Definition of migrated
 

--- a/language/stdlib/inventory.md
+++ b/language/stdlib/inventory.md
@@ -1,0 +1,97 @@
+# Standard-library migration inventory
+
+Status: baseline inventory from hgraph `baa51d58e`; migration not started
+
+This inventory makes the current C++ library finite before any implementation
+is removed. The public headers contain 212 operator marker declarations with
+207 distinct native registry names. Repeated names include multiple marker
+shapes and the cross-family `join` overload family. Registration helpers and
+templates expand this into a substantially larger candidate set, so marker
+count is not candidate count.
+
+## Public operator contracts
+
+| Native family | Distinct names | Registry names |
+| --- | ---: | --- |
+| arithmetic | 14 | `abs_`, `add_`, `div_`, `divmod_`, `floordiv_`, `ln`, `mod_`, `mul_`, `neg_`, `pos_`, `pow_`, `round_`, `sign`, `sub_` |
+| collection | 22 | `collapse_keys`, `combine_cs`, `combine_map`, `combine_tsd`, `difference`, `filter_tsd_by_matches`, `flip`, `flip_keys`, `intersection`, `keys_`, `make_tsd`, `max_ts_list`, `mean`, `min_ts_list`, `partition`, `rekey`, `sum_`, `symmetric_difference`, `uncollapse_keys`, `union`, `unpartition`, `values_` |
+| comparison | 9 | `cmp_`, `eq_`, `ge_`, `gt_`, `le_`, `lt_`, `max_`, `min_`, `ne_` |
+| container | 8 | `contains_`, `dereference`, `getattr_`, `getitem_`, `index_of`, `is_empty`, `len_`, `setattr_` |
+| control | 12 | `all_`, `any_`, `if_`, `if_cmp`, `if_then_else`, `if_true`, `merge`, `merge_tsd_disjoint`, `race`, `reduce_tsd_of_bundles_with_race`, `reduce_tsd_with_race`, `route_by_index` |
+| conversion | 14 | `cast_`, `collect`, `combine`, `combine_tss_from_tsl`, `const`, `convert`, `default`, `downcast_`, `downcast_ref`, `emit`, `nothing`, `str_`, `type_`, `zero` |
+| data frame | 12 | `concat`, `filter_cs`, `filter_frame`, `from_data_frame`, `from_data_frame_batches`, `group_by`, `join`, `replay_data_frame`, `sorted_`, `to_data_frame`, `ungroup`, `with_columns` |
+| higher order | 6 | `dispatch_`, `map_`, `mesh_`, `reduce`, `switch_`, `try_except` |
+| I/O and record/replay | 17 | `apply`, `__apply_value_callable`, `assert_`, `__assert_fmt`, `call`, `__call_value_callable`, `compare`, `debug_print`, `log_`, `__log_sink`, `null_sink`, `print_`, `__print_sink`, `record`, `replay`, `replay_const`, `stop_engine` |
+| JSON | 11 | `combine_json`, `from_json`, `__json_array`, `json_as_bool`, `json_as_float`, `json_as_int`, `json_as_str`, `json_decode`, `json_encode`, `__json_object`, `to_json` |
+| logical and bitwise | 9 | `and_`, `bit_and`, `bit_or`, `bit_xor`, `invert_`, `lshift_`, `not_`, `or_`, `rshift_` |
+| stream | 19 | `batch`, `dedup`, `drop`, `filter_`, `filter_by`, `freeze`, `gate`, `lag`, `__lag_proxy`, `request_id`, `sample`, `schedule`, `slice_`, `step`, `take`, `throttle`, `to_window`, `until_true`, `window` |
+| string | 6 | `format_`, `join`, `match_`, `replace`, `split`, `substr` |
+| table | 3 | `from_table`, `from_table_const`, `to_table` |
+| temporal | 46 | `at_zone`, `convert_zone`, `datepart`, `day`, `day_of_month`, `days`, `evaluation_time_in_range`, `explode`, `hour`, `isoformat`, `isoweekday`, `last_modified_date`, `last_modified_time`, `last_modified_wall_clock_time`, `microsecond`, `microseconds`, `minute`, `modified`, `month`, `month_of_year`, `range_adjacent`, `range_contains`, `range_difference`, `range_extent`, `range_hull`, `range_intersection`, `range_merge`, `range_mergeable`, `range_overlaps`, `range_shift`, `range_touches`, `range_union`, `resolve_civil`, `second`, `seconds`, `temporal_bucket`, `temporal_ceil`, `temporal_floor`, `temporal_round`, `timestamp`, `to_civil`, `to_instant`, `total_seconds`, `valid`, `weekday`, `year` |
+
+The authoritative contracts remain the headers under
+`include/hgraph/lib/std/operators`. This table is a migration checkpoint and
+must be refreshed when that surface changes.
+
+The HGL prototype declares 197 distinct source-visible names. The ten public-
+header registry names not declared as HGL operators are the keyword collisions
+`const` and `default`, plus the compiler-selected internal markers
+`__apply_value_callable`, `__assert_fmt`, `__call_value_callable`,
+`__json_array`, `__json_object`, `__lag_proxy`, `__log_sink`, and
+`__print_sink`. The implementation-only `__tick_count` marker is not declared
+in a public operator header and is outside this contract inventory.
+
+## Other library surfaces
+
+| Surface | Current implementation | Initial classification |
+| --- | --- | --- |
+| Standard scalar/type registration | `standard_types.h`, `standard_scalar_bindings.cpp` | Runtime/type-spec generated contract plus backend implementation. |
+| Scalar kernels and lifting | `lifted_kernels.h` | Split: scalar algorithms may remain reviewed native functions; temporal lifting should be generated from HGL candidates. |
+| `pass_through_node` | `std_nodes.h` | HGL runtime candidate, blocked on a first-class delta capture/apply contract. |
+| `component` | `component.h` | HGL graph/library feature, blocked on record/replay scopes, variadic named inputs, and graph metadata. |
+| `lower` | `lower.h`, `lower.cpp` | Host execution API, not an HGL graph/node implementation. |
+| Higher-order map/reduce/switch/mesh | public operators plus runtime nodes | Compiler/runtime kernel. User-facing specializations may be HGL; child ownership and scheduling remain native contracts. |
+| Data-frame, table, JSON, I/O | operator families and native implementations | Mostly constrained native primitives with HGL graph wrappers where composition adds behavior. |
+
+## Migration states
+
+- **contract** — public operator declaration represented in HGL.
+- **source candidate** — an HGL `impl fn` describes the current behavior.
+- **blocked** — the exact missing language or public runtime contract is named.
+- **kernel** — reviewed reason the implementation remains native.
+- **migrated** — HGL source builds the shipped candidate, parity passes, and the
+  former hand-written implementation is removed or delegates to it.
+
+No item in this inventory is yet `migrated`.
+
+## First extraction slice
+
+The source prototype deliberately starts with:
+
+1. scalar arithmetic/comparison candidates, testing runtime scalar operators
+   inside an implementation of the corresponding temporal operator;
+2. `sample`, `filter_`, `dedup`, `take`, and `drop`, testing activation,
+   recordable state, prior output, and generic equality;
+3. fixed-list `len_`, `sum_`, and `mean`, testing constant generics and
+   evaluation-time traversal;
+4. `if_then_else` and binary `merge`, testing graph versus node selection;
+5. `pass_through_node`, testing portable delta capture/apply;
+6. contract-only declarations for the remaining families, exposing variadic,
+   keyword-pack, output-resolution, native-view, and resource boundaries.
+
+The blockers discovered by these files are maintained in
+[`requirements.md`](requirements.md).
+
+## Definition of migrated
+
+An implementation is migrated only when:
+
+- the HGL source contains no unresolved provisional syntax;
+- it compiles through the shared HGraph IR and formatted C++ backend;
+- the generated code uses public hgraph contracts and is readable;
+- native C++ and Python behavior/parity tests pass through the public operator;
+- lifecycle, delta, invalid-input, and performance behavior is preserved;
+- the generated module participates in the same provider transaction and
+  operator registry; and
+- the hand-written C++ implementation is removed or becomes an explicitly
+  classified native primitive.

--- a/language/stdlib/requirements.md
+++ b/language/stdlib/requirements.md
@@ -153,21 +153,25 @@ selecting `some([])` remain unresolved.
 
 ## HGL-LIB-015: open generic implementation publication
 
-`instantiate op<A, ...>` gives a module a precise, closed set of concrete
-operator candidates. That is enough for finite domains such as the current
-`i64` and `f64` arithmetic candidates, and the prototype now uses one generic
-body plus explicit materializations for those cases.
+`instantiate op<A, ...>` gives a module a precise set of operator candidates.
+A concrete argument closes that generic position; `_` retains it in the
+candidate signature for the resolver to select. This is enough for finite
+element domains with open marker dimensions: `sum_` publishes
+`sum_<i64, _>` and `sum_<f64, _>`, requiring a concrete accumulator type while
+accepting every fixed-list size through one candidate per element type.
 
 Several core-library implementations are intentionally open. `sample<T>`,
 `filter_<T>`, `merge<T>`, and the generic sinks must accept types declared by a
-downstream module. Fixed-list candidates such as `len_<T, const size>` also
-range over an unbounded set of compile-time sizes. The standard-library
-provider cannot enumerate either domain when it is compiled.
+downstream module. Retention also does not imply body availability. A fixed-list
+`len_<T, const size>` implementation reads `size`, so `len_<T, _>` would require
+the resolver-selected value to be deliberately reified for the body. A
+signature-only `SIZE<"size">` marker cannot satisfy that use.
 
-The design must choose who owns those later materializations and how they enter
-the shared resolver: a consuming AOT module, a portable descriptor-backed
-implementation factory, or a deliberately retained symbolic candidate. The
-choice must preserve one operator identity, ordinary overload ranking, module
-lifecycle removal, readable generated code, and compatibility across backend
-languages. Until that is settled, the prototype keeps these templates visibly
-unmaterialized rather than implying that a short built-in type list is complete.
+The design must choose who owns later open-type materializations and how
+resolver-selected generics are reified when a body needs them: a consuming AOT
+module, a portable descriptor-backed implementation factory, or an explicit
+body-availability contract on a retained candidate. The choice must preserve
+one operator identity, ordinary overload ranking, module lifecycle removal,
+readable generated code, and compatibility across backend languages. Until
+that is settled, the prototype keeps those templates visibly unmaterialized
+rather than implying that a short built-in type list is complete.

--- a/language/stdlib/requirements.md
+++ b/language/stdlib/requirements.md
@@ -1,0 +1,140 @@
+# Requirements discovered by the HGL library extraction
+
+Status: active prototype ledger; entries are questions, not accepted syntax
+
+The HGL files reference these identifiers from `PROVISIONAL` comments. A source
+form is illustrative until its entry is accepted and implemented.
+
+## HGL-LIB-001: multi-file modules
+
+The current native operator identities live in one `hgraph.std` namespace, but
+one source file for 207 names is not maintainable. The prototype writes:
+
+```hgl
+module hgraph.std part arithmetic
+```
+
+Required semantics include one nominal declaration scope, deterministic part
+ordering for diagnostics only, duplicate-declaration checks across files, one
+descriptor/provider identity, and no declaration re-export. An alternative is
+a package manifest that declares several source files as one module without new
+source syntax.
+
+## HGL-LIB-002: variadic and keyword parameter packs
+
+`merge`, `all_`, `any_`, `race`, `format_`, `print_`, `log_`, `map_`, and
+other current contracts accept variadic inputs or keyword bundles. The
+prototype uses `...T` and `...{str: T}`. It still needs rules for minimum
+arity, heterogeneous packs, name preservation, type unification, defaults,
+ranking, and generated C++ signatures.
+
+## HGL-LIB-003: operator algebra properties
+
+Associative reductions cannot be inferred from an operator spelling. The
+prototype uses an illustrative declaration clause:
+
+```hgl
+operator add_<T>(lhs: T, rhs: T) -> T
+properties associative, commutative
+```
+
+Properties must apply to a precise candidate/type domain and state numerical
+exceptions. For example, mathematical addition is associative while floating-
+point addition is not exactly associative. This metadata affects legal graph
+transformations and therefore needs verification rather than trust.
+
+## HGL-LIB-004: runtime scalar primitive boundary
+
+An HGL implementation of temporal `add_` naturally evaluates `lhs + rhs`
+inside a node. The compiler must define that runtime scalar expression as a
+direct scalar operation, not recursively wire or resolve the temporal `add_`
+candidate being implemented. Error, overflow, and conversion behavior must be
+the same in scripted and generated modes.
+
+Complex scalar algorithms such as regular expressions, JSON codecs, timezone
+resolution, Arrow operations, and optimized numeric kernels remain constrained
+native functions described by module descriptors. The existing native
+interface must be extended deliberately when a primitive needs a borrowed
+endpoint or collection view rather than canonical owned scalar values.
+
+## HGL-LIB-005: generic recordable state
+
+`dedup`, `take`, and `drop` can use existing output/state syntax. Other stream
+nodes need generic state with no natural default, sparse validity, queues, or
+windows. Decide whether this is expressed through optional state cells,
+constructor functions, or an admitted native opaque state type. State that
+affects later output remains recordable; scratch caches and external resources
+must not be disguised as recordable state.
+
+## HGL-LIB-006: collection output mutation and delta ranges
+
+The target iterator design describes `added`, `modified`, and `removed` ranges,
+but the compiler does not yet implement every `elements`/predicate form.
+Incremental set/map/list implementations also need typed output mutations such
+as insert, erase, update, clear, and resize. The prototype uses function-shaped
+`insert(out, value)` and `erase(out, value)` placeholders rather than member
+methods.
+
+These operations must preserve last-write-wins per child, accumulate distinct
+child updates, distinguish removal from invalidation, and never expose borrowed
+iterators beyond the evaluation.
+
+## HGL-LIB-007: delta capture and forwarding
+
+`pass_through_node` requires the complete input delta, including structural and
+collection removals, and applies it to an output of the same temporal schema.
+`delta(value)` currently has an open result shape. The migration needs a
+first-class, type-preserving delta value or a dedicated `forward_delta` effect;
+it must work through the public runtime contract and across alternative
+backends.
+
+## HGL-LIB-008: output and type resolution
+
+Many operators determine an output not expressible as a simple repeated generic
+parameter: `convert`, `combine`, `collect`, `split`, frame joins, structural
+field access, and higher-order calls. Current C++ candidates use type patterns,
+type arguments, `resolve_default_types`, and result resolvers.
+
+The HGL contract needs associated type expressions or declarative resolution
+functions that lower to the shared hgraph resolver. It must not add a second
+ranking or type-inference algorithm.
+
+## HGL-LIB-009: source names versus native registry names
+
+Native operator names include HGL keywords (`const`, `default`) and internal
+names beginning with `__`. The library needs an explicit, reviewable mapping
+between a legal source declaration and the stable native operator identity.
+Renaming a source symbol must not accidentally create a new overload family.
+
+The prototype leaves keyword-colliding declarations commented out rather than
+inventing an attribute spelling.
+
+## HGL-LIB-010: graph/runtime implementation arity
+
+Native operator candidates may refine a variadic contract with fixed arity or
+add implementation-specific scalar parameters. Define how an `impl fn`
+declares that relationship, how calls discover extra parameters, and how
+candidate ranking compares fixed and packed forms.
+
+## HGL-LIB-011: compiler-owned higher-order forms
+
+`map_`, `reduce`, `switch_`, `dispatch_`, `mesh_`, and `try_except` carry
+callables, child graphs, binding modes, and lifecycle semantics. Much of their
+behavior is a compiler lowering rather than an ordinary library function.
+Specify the minimal kernel contracts they target and which public convenience
+overloads can still be implemented in HGL.
+
+## HGL-LIB-012: effects and approved capabilities
+
+I/O, logging, engine control, scheduling, record/replay, and exception capture
+need effects visible to checking and optimization. `inject logger` is already
+available, but arbitrary file/network access remains outside HGL. The library
+needs a closed capability/effect vocabulary shared with native descriptors and
+the backend-neutral runtime specification.
+
+## HGL-LIB-013: library documentation and compatibility metadata
+
+The native headers currently own operator documentation, parameter meanings,
+complexity notes, defaults, and Python examples. A migrated HGL declaration
+needs structured documentation and stability metadata from which C++, Python,
+and HGL surfaces can be generated without making comments executable.

--- a/language/stdlib/requirements.md
+++ b/language/stdlib/requirements.md
@@ -150,3 +150,24 @@ scheduler and for implementations that intentionally admit invalid inputs.
 The backend-neutral runtime model already distinguishes `none` (runtime
 default) from `some([])` (explicitly empty); HGL syntax and flow analysis for
 selecting `some([])` remain unresolved.
+
+## HGL-LIB-015: open generic implementation publication
+
+`instantiate op<A, ...>` gives a module a precise, closed set of concrete
+operator candidates. That is enough for finite domains such as the current
+`i64` and `f64` arithmetic candidates, and the prototype now uses one generic
+body plus explicit materializations for those cases.
+
+Several core-library implementations are intentionally open. `sample<T>`,
+`filter_<T>`, `merge<T>`, and the generic sinks must accept types declared by a
+downstream module. Fixed-list candidates such as `len_<T, const size>` also
+range over an unbounded set of compile-time sizes. The standard-library
+provider cannot enumerate either domain when it is compiled.
+
+The design must choose who owns those later materializations and how they enter
+the shared resolver: a consuming AOT module, a portable descriptor-backed
+implementation factory, or a deliberately retained symbolic candidate. The
+choice must preserve one operator identity, ordinary overload ranking, module
+lifecycle removal, readable generated code, and compatibility across backend
+languages. Until that is settled, the prototype keeps these templates visibly
+unmaterialized rather than implying that a short built-in type list is complete.

--- a/language/stdlib/requirements.md
+++ b/language/stdlib/requirements.md
@@ -54,8 +54,10 @@ the same in scripted and generated modes.
 Complex scalar algorithms such as regular expressions, JSON codecs, timezone
 resolution, Arrow operations, and optimized numeric kernels remain constrained
 native functions described by module descriptors. The existing native
-interface must be extended deliberately when a primitive needs a borrowed
-endpoint or collection view rather than canonical owned scalar values.
+interface now supports explicitly declared list, set, map, and rolling input
+views. The prototype's `hgraph.native` dependency and its concrete `len`
+overloads still need to be packaged and shipped; other borrowed endpoint shapes
+must be admitted deliberately rather than inferred from C++ headers.
 
 ## HGL-LIB-005: generic recordable state
 
@@ -162,10 +164,17 @@ accepting every fixed-list size through one candidate per element type.
 
 Several core-library implementations are intentionally open. `sample<T>`,
 `filter_<T>`, `merge<T>`, and the generic sinks must accept types declared by a
-downstream module. Retention also does not imply body availability. A fixed-list
-`len_<T, const size>` implementation reads `size`, so `len_<T, _>` would require
-the resolver-selected value to be deliberately reified for the body. A
-signature-only `SIZE<"size">` marker cannot satisfy that use.
+downstream module. Retention also does not imply body availability. A
+signature-only `SIZE<"size">` marker cannot satisfy an implementation that
+genuinely reads the selected value.
+
+Collection length does not require such reification. The `len_` prototype calls
+the native `len(value)` overload, which receives the live typed input view and
+reads its current size. Its retained list-size generic remains selection-only.
+This solves collection metadata access without turning every generic marker
+into a runtime value or adding per-tick schema inspection. Since its element,
+key, and value types are also selection-only, `instantiate len_<_, _>, len_<_>`
+publishes the list/map and set candidates without enumerating user types.
 
 The design must choose who owns later open-type materializations and how
 resolver-selected generics are reified when a body needs them: a consuming AOT

--- a/language/stdlib/requirements.md
+++ b/language/stdlib/requirements.md
@@ -138,3 +138,15 @@ The native headers currently own operator documentation, parameter meanings,
 complexity notes, defaults, and Python examples. A migrated HGL declaration
 needs structured documentation and stability metadata from which C++, Python,
 and HGL surfaces can be generated without making comments executable.
+
+## HGL-LIB-014: explicit empty input policies
+
+The agreed handler defaults give `modified()` and `valid()` the complete
+temporal parameter list, and omitted selectors receive those same defaults.
+They therefore cannot also represent hgraph's explicit empty selector sets.
+
+A separate source form is required for nodes that are activated only by a
+scheduler and for implementations that intentionally admit invalid inputs.
+The backend-neutral runtime model already distinguishes `none` (runtime
+default) from `some([])` (explicitly empty); HGL syntax and flow analysis for
+selecting `some([])` remain unresolved.

--- a/language/stdlib/requirements.md
+++ b/language/stdlib/requirements.md
@@ -53,11 +53,12 @@ the same in scripted and generated modes.
 
 Complex scalar algorithms such as regular expressions, JSON codecs, timezone
 resolution, Arrow operations, and optimized numeric kernels remain constrained
-native functions described by module descriptors. The existing native
-interface now supports explicitly declared list, set, map, and rolling input
-views. The prototype's `hgraph.native` dependency and its concrete `len`
-overloads still need to be packaged and shipped; other borrowed endpoint shapes
-must be admitted deliberately rather than inferred from C++ headers.
+native functions described by module descriptors. The compiled and installed
+`hgraph.native` module now supplies concrete `len` and `is_empty` overloads for
+strings and explicitly declared list, set, map, and tick-count rolling input
+views. Other borrowed endpoint shapes must be admitted deliberately rather than
+inferred from C++ headers. Duration rolling windows also remain outside
+descriptor ABI v1 because its constant generic values are integral.
 
 ## HGL-LIB-005: generic recordable state
 
@@ -169,12 +170,14 @@ signature-only `SIZE<"size">` marker cannot satisfy an implementation that
 genuinely reads the selected value.
 
 Collection length does not require such reification. The `len_` prototype calls
-the native `len(value)` overload, which receives the live typed input view and
-reads its current size. Its retained list-size generic remains selection-only.
-This solves collection metadata access without turning every generic marker
-into a runtime value or adding per-tick schema inspection. Since its element,
-key, and value types are also selection-only, `instantiate len_<_, _>, len_<_>`
-publishes the list/map and set candidates without enumerating user types.
+the compiled native `len(value)` overload, which receives the live typed input
+view and reads its current size. Its retained list-size and rolling-bound
+generics remain selection-only. This solves collection metadata access without
+turning every generic marker into a runtime value or adding per-tick schema
+inspection. Since element, key, and value types are also selection-only,
+`instantiate len_<_, _>, len_<_>, len_<_, _, _>` publishes fixed-list/map,
+dynamic-list/set, and tick-count rolling candidates without enumerating user
+types. `is_empty` uses the same materialization model.
 
 The design must choose who owns later open-type materializations and how
 resolver-selected generics are reified when a body needs them: a consuming AOT


### PR DESCRIPTION
# Summary

- introduce an exploratory `.hgspec` language for backend-neutral value, time-series, execution, ownership, lifecycle, operator-registration, and conformance contracts
- add a conceptual `language/stdlib/hgl` source tree covering all 197 source-visible standard-library operator names, with representative HGL implementations
- use compact handler defaults: bare `when { ... }` means any temporal input modified and every temporal input valid
- publish closed numeric implementations with `instantiate`, retaining signature-only generic dimensions with `_`
- model `len_` and `is_empty` for strings, fixed and unbounded lists, sets, maps, and tick-count rolling windows over the compiled `hgraph.native` C++ substrate
- keep collection element/key/value types, list sizes, and rolling bounds selection-only for these helpers; no per-tick schema inspection or fake finite type list is required
- distinguish that solved metadata case from body-visible generic reification and downstream open-type publication, which remain `HGL-LIB-015` work
- maintain searchable `RDL-*` and `HGL-LIB-*` ledgers for unresolved syntax, runtime contracts, and migration requirements

# Stack

This draft is the top of stack #793:

1. #786 implements explicit and partially retained generic operator implementation materialization.
2. #789 implements native canonical-value and generic collection-input-view overloads.
3. #791 implements inline C++ `native fn` declarations and compact `when` defaults.
4. #792 builds and installs the real `hgraph.native` C++ library and its descriptor-backed consumer.
5. This PR contains the backend-neutral runtime spec and conceptual `hgraph.std` migration corpus, updated to consume #792.

# Prototype status

This is a design checkpoint, not a production standard library or runtime-spec compiler.

- No `.hgspec` parser or generator exists.
- The multi-file `hgraph.std` source remains deliberately excluded from CMake and compiler tests.
- The `hgraph.native` dependency is real, compiled, installed, and runtime-tested in #792.
- Every remaining speculative source form is marked `DESIGN PROTOTYPE`, `PROVISIONAL`, `PARTIAL`, or `BLOCKED`.
- Explicit empty activation and validity policies remain open as `HGL-LIB-014`; they are distinct from the implemented all-input defaults.
- Body-level generic reification and downstream open-type publication remain unresolved as `HGL-LIB-015`; `len_` and `is_empty` do not require either because their native views supply runtime size.
- Multi-file module parts, parameter packs, delta forwarding, type resolution, effects, and native-name mapping remain explicit requirements rather than implied language decisions.
- Duration rolling windows remain outside descriptor ABI v1; the current real native surface covers tick-count windows.

# Validation

- rebased branch build and complete configured CTest suite: 1,791/1,791 passed
- #792 local gates: 56/56 language tests, installed native-package consumer, 1,735/1,735 prescribed native tests, and 3,284 passed / 10 skipped Python 3.14 compatibility tests
- native/HGL operator-set comparison: 207 native public names, 197 HGL declarations, and exactly 10 documented exclusions
- `git diff --check`
- provisional-marker audit
- HGL source audit for lowercase `signal` and no semicolon-terminated statements

The multi-file `hgraph.std` prototype itself remains conceptual and is not represented as executable compiler coverage. Its low-level `hgraph.native` dependency and package-backed example are executable compiler/runtime coverage in #792.
