### PR TITLE
Add explicit HGL operator implementation instantiation

### DIFF
--- a/language/docs/design/architecture.md
+++ b/language/docs/design/architecture.md
@@ -18,6 +18,8 @@ the directory into a separate repository without changing hgraph core.
   registered operators.
 - Express nominal generic operator contracts whose `impl fn` implementations
   reuse hgraph candidate matching and ranking.
+- Materialize generic implementation templates into an explicit finite set of
+  concrete candidates for reproducible module registration.
 - Expose ordinary exact functions explicitly with `export fn`, while treating
   operator contracts and their bound implementation candidates as public by
   definition.
@@ -146,8 +148,9 @@ The frontend owns language diagnostics, lexical scope, public declaration
 exposure, package membership, canonical types and struct hierarchies, function
 classification, phase rules, type checking, and selection of a nominal
 operator identity through local declarations, selective imports, or qualified
-module aliases. Every `impl fn` in the resolved target closure contributes a
-candidate.
+module aliases. Every concrete `impl fn` in the resolved target closure
+contributes a candidate; a generic implementation contributes only its explicit
+materializations.
 Candidate selection within that identity delegates to the hgraph resolver; the
 language project must not clone its matching or ranking rules.
 

--- a/language/docs/design/decisions/0004-json-module-descriptors.md
+++ b/language/docs/design/decisions/0004-json-module-descriptors.md
@@ -24,7 +24,7 @@ Use UTF-8 JSON with the format identity `hgl.module` and an integer
 - generic and ordinary parameters, results, default values, struct parents and
   effective fields;
 - canonical type, compile-time-expression, and constraint records reachable
-  from those public declarations and concrete implementation candidates;
+  from those public declarations and requested implementation candidates;
 - implementation-to-operator bindings and required provider identities;
 - generated public headers, known CMake packages and imported targets; and
 - the generated C++ registration symbol.

--- a/language/docs/design/decisions/0004-json-module-descriptors.md
+++ b/language/docs/design/decisions/0004-json-module-descriptors.md
@@ -24,7 +24,7 @@ Use UTF-8 JSON with the format identity `hgl.module` and an integer
 - generic and ordinary parameters, results, default values, struct parents and
   effective fields;
 - canonical type, compile-time-expression, and constraint records reachable
-  from those public declarations and implementation candidates;
+  from those public declarations and concrete implementation candidates;
 - implementation-to-operator bindings and required provider identities;
 - generated public headers, known CMake packages and imported targets; and
 - the generated C++ registration symbol.

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -33,6 +33,8 @@ The bespoke behavior is semantic:
   field requirements;
 - bodyless nominal `operator` declarations define generic callable contracts;
 - `impl fn` declarations supply operator implementations explicitly;
+- `instantiate op<A, ...>` requests concrete candidates from generic
+  implementation templates;
 - operators and their implementation candidates are public by definition,
   while an ordinary exact function requires `export fn` for public exposure;
 - name resolution selects an operator before hgraph ranks its implementations;
@@ -72,6 +74,8 @@ The agreed declaration forms are:
 - `operator` for a bodyless nominal generic contract;
 - `fn` for module-internal named functions;
 - `impl fn` for an implementation of an operator in scope;
+- `instantiate` for concrete materializations of generic operator
+  implementations;
 - `export fn` for a public ordinary exact function;
 - `struct` for a module-internal nominal structured type;
 - `abstract struct` for a module-internal abstract data family;
@@ -358,6 +362,34 @@ ordinary composition-versus-runtime rules. Candidate-specific requirements may
 further restrict an implementation; dispatch applies the conjunction of the
 mapped contract and candidate requirements.
 
+A generic `impl fn` is a hidden implementation template rather than a runtime
+candidate with unresolved source generics. A module requests concrete
+candidates explicitly:
+
+```hgl
+operator combine<T>(lhs: T, rhs: T) -> T
+
+impl fn combine<T>(lhs: T, rhs: T) -> T
+requires T in {i64, f64}
+=> lhs + rhs
+
+instantiate combine<i64>, combine<f64>
+```
+
+The argument list binds the implementation template's generic parameters in
+declaration order. Type and `const` arguments are checked against their kinds,
+the implementation requirements, and the mapped operator contract. One
+request materializes every local template of that operator which accepts the
+complete argument list; a request with no match and a duplicate concrete
+materialization are errors. The generic origin remains valid without any
+request but contributes no candidate. This is declaration-time
+materialization, not explicit generic application at an operator call.
+
+The current compiler implements this rule for a contract declared in the same
+module. Applying it to an implementation of a selectively imported contract
+is part of the descriptor-backed imported-contract work; the source form fails
+closed until that metadata can identify and emit the external C++ contract.
+
 Two operator contracts with the same short name but different defining modules
 are unrelated. A namespace import such as `use my.module as mm` permits an
 explicit `mm::my_op(...)` call without introducing `my_op` as an unqualified
@@ -377,10 +409,11 @@ adds that exact declaration to the public module interface; it does not create
 an overload set. Other modules may selectively import it or call it through a
 module alias.
 
-An operator contract is public by definition. Every `impl fn` bound to that
-operator contributes a public implementation candidate, but the candidate is
-not independently importable through its provider module. `export` on an
-`impl fn` is therefore invalid rather than a second visibility axis.
+An operator contract is public by definition. Every concrete `impl fn`, and
+every requested concrete materialization of a generic `impl fn`, contributes a
+public implementation candidate. The source implementation itself is not
+independently importable through its provider module. `export` on an `impl fn`
+is therefore invalid rather than a second visibility axis.
 
 There are no declaration re-exports in the initial design. An operator has one
 defining module and one canonical import identity even when implementations
@@ -402,7 +435,8 @@ AOT output currently provides its descriptor and explicit
 `register_operators()` entry point while the linked application owns its
 lifetime. Completing the AOT lifecycle bootstrap remains compiler work.
 Initialization records a keyed installer for all type and operator
-contributions; the installer can be replayed after an hgraph registry reset
+contributions, including the concrete candidates produced by `instantiate`;
+the installer can be replayed after an hgraph registry reset
 without repeating one-time module initialization. The final application
 explicitly initializes the complete target closure before wiring.
 

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -74,8 +74,8 @@ The agreed declaration forms are:
 - `operator` for a bodyless nominal generic contract;
 - `fn` for module-internal named functions;
 - `impl fn` for an implementation of an operator in scope;
-- `instantiate` for concrete materializations of generic operator
-  implementations;
+- `instantiate` for explicit concrete or partially retained materializations of
+  generic operator implementations;
 - `export fn` for a public ordinary exact function;
 - `struct` for a module-internal nominal structured type;
 - `abstract struct` for a module-internal abstract data family;
@@ -376,14 +376,23 @@ requires T in {i64, f64}
 instantiate combine<i64>, combine<f64>
 ```
 
-The argument list binds the implementation template's generic parameters in
-declaration order. Type and `const` arguments are checked against their kinds,
-the implementation requirements, and the mapped operator contract. One
+The argument list classifies the implementation template's generic parameters
+in declaration order. Type and `const` arguments bind concrete values; `_`
+retains that slot as a resolver variable. Arguments are checked against their
+kinds, the implementation requirements, and the mapped operator contract. One
 request materializes every local template of that operator which accepts the
-complete argument list; a request with no match and a duplicate concrete
-materialization are errors. The generic origin remains valid without any
-request but contributes no candidate. This is declaration-time
-materialization, not explicit generic application at an operator call.
+argument pattern; a request with no match and a duplicate pattern are errors.
+The generic origin remains valid without any request but contributes no
+candidate. This is declaration-time materialization, not explicit generic
+application at an operator call.
+
+Retention does not imply that a resolved generic value is available to the
+body. A retained marker used only in a signature is type-erased after resolver
+matching; a retained generic referenced by the body must be reified through a
+defined read-only contract. The first implemented retained marker is a fixed
+list size, lowered to hgraph's named `SIZE` variable. Generic reification and
+residual constraints are deliberately unresolved rather than simulated by
+runtime schema inspection.
 
 The current compiler implements this rule for a contract declared in the same
 module. Applying it to an implementation of a selectively imported contract
@@ -410,7 +419,7 @@ an overload set. Other modules may selectively import it or call it through a
 module alias.
 
 An operator contract is public by definition. Every concrete `impl fn`, and
-every requested concrete materialization of a generic `impl fn`, contributes a
+every requested materialization of a generic `impl fn`, contributes a
 public implementation candidate. The source implementation itself is not
 independently importable through its provider module. `export` on an `impl fn`
 is therefore invalid rather than a second visibility axis.
@@ -533,8 +542,8 @@ tuple maps to hgraph's un-named bundle with index-named fields (`_0`, `_1`,
 ...), which is why heterogeneous tuples need no new runtime shape. A list size
 is part of the type identity; a `const` generic in a list-size position binds
 the argument's actual size, including the `unbounded` sentinel, so an
-implementation indifferent to fixedness declares one generic candidate rather
-than two.
+implementation indifferent to a fixed size can retain that resolver slot in
+one requested candidate.
 
 ## Function abstraction
 

--- a/language/docs/design/modules.md
+++ b/language/docs/design/modules.md
@@ -21,8 +21,8 @@ A native package that supports the language supplies a descriptor containing:
 - compatible hgraph SDK and descriptor-format versions;
 - automatically public nominal operator contracts, explicitly exported exact
   functions, and exported concrete and abstract struct declarations;
-- concrete operator implementation candidates, including explicit generic
-  materializations, indexed by canonical operator identity,
+- operator implementation candidates, including explicit generic
+  materializations with any retained resolver parameters, indexed by canonical operator identity,
   provider module, implementation kind, and generic signature;
 - canonical types, schema declarations, generic struct-family parameters and
   constraints, and abstract-family relationships;
@@ -75,9 +75,9 @@ and parent expressions. A downstream target can therefore validate and create
 the same fully applied nominal specializations without loading user code.
 
 An `impl fn` is neither a private helper nor an independently exported exact
-function. A concrete implementation contributes a public candidate to its
+function. A non-generic implementation contributes a public candidate to its
 operator's implementation inventory; a generic implementation contributes
-only the concrete candidates requested with `instantiate`. Applying `export`
+only the candidates requested with `instantiate`. Applying `export`
 to an `impl fn` is rejected as redundant and misleading.
 
 The initial design has no declaration re-export. In particular, an
@@ -147,11 +147,11 @@ other definitions remain callable through qualified names such as
 
 A compatible non-generic `impl fn` is an externally visible candidate of its
 selected operator. A generic `impl fn` is instead a hidden source template;
-each concrete candidate requested by `instantiate op<A, ...>` is externally
-visible. Neither form is directly importable as an exact function. The
-provider module and each complete candidate signature are part of the
-descriptor; the unresolved generic template is not advertised as a runtime
-candidate.
+each candidate requested by `instantiate op<A, ...>` is externally visible.
+An `_` argument retains that slot in the candidate signature. Neither form is
+directly importable as an exact function. The provider module and each
+requested candidate signature are part of the descriptor; the unrestricted
+generic template is not advertised as a runtime candidate.
 
 Explicit materialization currently requires the operator contract to be
 declared in the same module. Supporting `instantiate` for a selectively
@@ -210,8 +210,8 @@ cross-mode regression test.
 User-defined functions without a local operator binding retain exact typed
 declarations and do not form overload sets. Only those declared `export fn`
 enter the public declaration surface. `impl fn` declarations are registered
-as their operator's candidates when concrete; generic implementations register
-only their explicit materializations. Their source bodies still determine
+as their operator's candidates when non-generic; generic implementations
+register only their explicit materializations. Their source bodies still determine
 whether each candidate lowers as composition or a runtime node.
 Exported structs enter the same declaration surface as nominal types rather
 than callable candidates. Their parent relationships also enter the target's
@@ -251,8 +251,8 @@ The scripted lifecycle has three separate responsibilities:
 
 1. `init` attaches one module instance to an application and records its keyed
    registry installer;
-2. the installer materializes that module's types, concrete operator
-   candidates (including `instantiate` requests), and
+2. the installer materializes that module's types, requested operator
+   candidates (including `instantiate` patterns), and
    native associations for the current registry generation;
 3. `deinit` removes the module's active contributions and installer intent,
    releases owned resources, and permits later unloading when safe.

--- a/language/docs/design/modules.md
+++ b/language/docs/design/modules.md
@@ -21,7 +21,8 @@ A native package that supports the language supplies a descriptor containing:
 - compatible hgraph SDK and descriptor-format versions;
 - automatically public nominal operator contracts, explicitly exported exact
   functions, and exported concrete and abstract struct declarations;
-- operator implementation candidates indexed by canonical operator identity,
+- concrete operator implementation candidates, including explicit generic
+  materializations, indexed by canonical operator identity,
   provider module, implementation kind, and generic signature;
 - canonical types, schema declarations, generic struct-family parameters and
   constraints, and abstract-family relationships;
@@ -74,9 +75,10 @@ and parent expressions. A downstream target can therefore validate and create
 the same fully applied nominal specializations without loading user code.
 
 An `impl fn` is neither a private helper nor an independently exported exact
-function. It contributes a public candidate to its operator's implementation
-inventory. Applying `export` to an `impl fn` is rejected as redundant and
-misleading.
+function. A concrete implementation contributes a public candidate to its
+operator's implementation inventory; a generic implementation contributes
+only the concrete candidates requested with `instantiate`. Applying `export`
+to an `impl fn` is rejected as redundant and misleading.
 
 The initial design has no declaration re-export. In particular, an
 implementation module does not create another import route for the operator it
@@ -143,9 +145,20 @@ resolution. An aliased module does not create an implementation binding, so
 other definitions remain callable through qualified names such as
 `other::my_op(...)`.
 
-Every compatible `impl fn` is an externally visible candidate of its selected
-operator, even though it is not directly importable as an exact function. Its
-provider module and complete candidate signature are part of the descriptor.
+A compatible non-generic `impl fn` is an externally visible candidate of its
+selected operator. A generic `impl fn` is instead a hidden source template;
+each concrete candidate requested by `instantiate op<A, ...>` is externally
+visible. Neither form is directly importable as an exact function. The
+provider module and each complete candidate signature are part of the
+descriptor; the unresolved generic template is not advertised as a runtime
+candidate.
+
+Explicit materialization currently requires the operator contract to be
+declared in the same module. Supporting `instantiate` for a selectively
+imported contract requires the versioned descriptor to expose the external C++
+contract marker as well as its nominal identity and full signature. Until that
+boundary lands, such a request fails during source checking rather than
+producing an incomplete registration.
 
 The semantic IR records the canonical operator identity on every implementation
 candidate and operator call. It never reconstructs that identity later from a
@@ -197,8 +210,9 @@ cross-mode regression test.
 User-defined functions without a local operator binding retain exact typed
 declarations and do not form overload sets. Only those declared `export fn`
 enter the public declaration surface. `impl fn` declarations are registered
-as their operator's candidates. Their source bodies still determine whether
-each candidate lowers as composition or a runtime node.
+as their operator's candidates when concrete; generic implementations register
+only their explicit materializations. Their source bodies still determine
+whether each candidate lowers as composition or a runtime node.
 Exported structs enter the same declaration surface as nominal types rather
 than callable candidates. Their parent relationships also enter the target's
 type-registration inventory. The complete linked module closure, rather than
@@ -237,7 +251,8 @@ The scripted lifecycle has three separate responsibilities:
 
 1. `init` attaches one module instance to an application and records its keyed
    registry installer;
-2. the installer materializes that module's types, operator candidates, and
+2. the installer materializes that module's types, concrete operator
+   candidates (including `instantiate` requests), and
    native associations for the current registry generation;
 3. `deinit` removes the module's active contributions and installer intent,
    releases owned resources, and permits later unloading when safe.

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -113,6 +113,12 @@ their local operator contract. Every implementation now also retains its
 resolved nominal operator symbol, with imported defining-module identity kept
 separate from native registry spelling.
 
+Typed HIR also owns explicit `instantiate op<A, ...>` requests for local
+generic operator implementations. It validates type/constant argument kinds,
+candidate and contract constraints, and duplicate materializations before
+retaining complete substitutions. Unrequested generic implementation templates
+remain valid but are not concrete candidates.
+
 The defined source constraint language is closed: equality, membership, type
 categories, structural reflection, nominal operator requirements, and Boolean
 composition. An arbitrary residual `const` predicate has no agreed source or
@@ -179,6 +185,8 @@ planning is implemented.
   independent `values` and `items` bodies over fixed temporal lists.
 - [x] lower independent `values` and `items` bodies over maps and unbounded
   lists to native sink child graphs with explicit temporal captures.
+- [x] retain explicit generic implementation materializations and their
+  complete substitutions through HIR and hgraph IR.
 
 Acceptance: direct-wiring behavior and diagnostics remain equivalent, and the
 wiring target no longer includes syntax AST headers.
@@ -226,6 +234,8 @@ wiring target no longer includes syntax AST headers.
   routing with selector-aware activation and validity analysis.
 - [x] emit readable native `map_sink_` helpers for independent dynamic map and
   unbounded-list graph traversal, matching direct-wiring behavior.
+- [x] emit one readable concrete graph or node struct per requested generic
+  implementation materialization and register only those concrete candidates.
 
 Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
@@ -299,11 +309,12 @@ today (#767, "Readiness").
 | `module`, selective and aliased `use`, `export`, canonical JSON descriptors, generated registration | implemented | Only `hgraph.std`, `hgraph.analytics`, and modules named by `--module-descriptor` resolve; any other `use` is a `module` diagnostic. No wildcard imports or re-exports; dependency closure and lock files are not implemented. |
 | `fn`, `export fn`, anonymous `fn`, bodyless `operator`, `impl fn` | partial | Both backends. `emit-cpp` rejects an `impl fn` of an imported operator; direct wiring reaches an `impl fn` only through a loaded native image and rejects a direct call; direct wiring rejects a call to a generic plain `fn` ("generic functions are not supported by the first pass"); a concise `map(..., fn(a) => ...)` lambda is lowered by `emit-cpp` but rejected by direct wiring ("anonymous functions are not supported by the first pass"), #767 item 3. |
 | Generics and `requires` | partial | Closed constraint language (equality, membership, categories, reflection, nominal operator requirements, Boolean composition) in typed HIR. Residual `const` predicates, imported-contract conformance, native nominal-struct metadata, and source-candidate ranking fail closed; explicit generic arguments on calls are undefined. |
+| `instantiate op<A, ...>` | implemented for local contracts | Produces concrete graph/node candidates from matching generic `impl fn` templates, carries complete substitutions through both IRs, emits and registers readable concrete C++, and advertises concrete descriptor signatures. Materializing an `impl fn` of a selectively imported operator is blocked on descriptor-backed external contract metadata. |
 | Canonical scalars, the eight temporal types, `@` and duration literals | partial | Lexer, parser, HIR, and both backends for `bool`, `i64`, `f64`, `str`, `date`, `time`, `datetime`, `duration`. Zoned and civil literals are rejected by both backends. Of the arithmetic table in the language reference only `str + str`, `duration ± duration`, `datetime ± duration`, `datetime - datetime`, and `duration * i64` are typed; `date ± duration`, `date - date`, `duration * f64`, and `duration / ...` are "arithmetic operands must both be numeric" (#767 item 2b: the emitter needs temporal arithmetic helpers before the checker admits them). |
 | `zoned_time` scalar; `Time` and `CivilDateTime` ordering | blocked | hgraph-side asks recorded under Slice 2 with no RFC in `docs/source/rfc/` yet; both backends fail closed meanwhile. |
 | `tuple`, `list`, `set`, `map` | partial | `list<T, n>`, `set<T>`, and `map<K, V>` map to TSL, TSS, and TSD. `eval` drives scalar and `atomic` parameters only; a structural `tuple` has no time-series schema in direct wiring; time-series tuple and list literals, and compound constant literals in generated defaults, are rejected. A fixed list size must be a positive constant (or a `const` generic of type `i64`), checked by typed HIR (`type: list size must be a positive constant or 'unbounded'`, PR #780); non-scalar map keys have no language rule yet (#767 item 6). |
 | `atomic<T>` | implemented | Whether `atomic<f64>` is normalized to `f64` is not fixed (types-and-expressions.md). |
-| `rolling<T, max[, min]>` | partial | Both backends for concrete tick-count and duration windows. Not accepted as a runtime-node parameter; window iteration and an either-kind parameter spelling are undefined; kind agreement and the size ranges (tick sizes positive, a duration minimum may be `0s`, no minimum above its maximum) are typed HIR diagnostics (PR #780); a size given by a `const` generic is an `emit-cpp` limitation. |
+| `rolling<T, max[, min]>` | partial | Both backends for concrete tick-count and duration windows. Not accepted as a runtime-node parameter; window iteration and an either-kind parameter spelling are undefined; kind agreement and the size ranges (tick sizes positive, a duration minimum may be `0s`, no minimum above its maximum) are typed HIR diagnostics (PR #780). A `const` size generic is concrete in an explicitly materialized operator implementation; unresolved generic plain functions remain an `emit-cpp` limitation. |
 | Named TSW size generics | blocked | `emit-cpp` binds a size-generic window to `TSWAny<T>`; hgraph's `TypePattern` carries concrete sizes and an any-window wildcard but no named size variable (Slice 2 ask, no RFC). |
 | `ref<T>` | partial | Explicit contracts, descriptors, guarded fixed-list reference routing, and forwarded conditional captures in both backends. Wiring-time dereference, `map<K, ref<V>>`, and `ref<ref<T>>` are rejected. |
 | `signal` | implemented | Input-only, payload-erased, no default value. |

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -116,8 +116,9 @@ separate from native registry spelling.
 Typed HIR also owns explicit `instantiate op<A, ...>` requests for local
 generic operator implementations. It validates type/constant argument kinds,
 candidate and contract constraints, and duplicate materializations before
-retaining complete substitutions. Unrequested generic implementation templates
-remain valid but are not concrete candidates.
+retaining a classified substitution for every slot. `_` explicitly retains a
+slot as a resolver variable; other arguments are concrete. Unrequested generic
+implementation templates remain valid but are not candidates.
 
 The defined source constraint language is closed: equality, membership, type
 categories, structural reflection, nominal operator requirements, and Boolean
@@ -186,7 +187,7 @@ planning is implemented.
 - [x] lower independent `values` and `items` bodies over maps and unbounded
   lists to native sink child graphs with explicit temporal captures.
 - [x] retain explicit generic implementation materializations and their
-  complete substitutions through HIR and hgraph IR.
+  concrete/retained substitutions through HIR and hgraph IR.
 
 Acceptance: direct-wiring behavior and diagnostics remain equivalent, and the
 wiring target no longer includes syntax AST headers.
@@ -234,8 +235,9 @@ wiring target no longer includes syntax AST headers.
   routing with selector-aware activation and validity analysis.
 - [x] emit readable native `map_sink_` helpers for independent dynamic map and
   unbounded-list graph traversal, matching direct-wiring behavior.
-- [x] emit one readable concrete graph or node struct per requested generic
-  implementation materialization and register only those concrete candidates.
+- [x] emit one readable graph or node struct per requested generic
+  implementation materialization, including retained fixed-list size markers,
+  and register only those candidates.
 
 Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
@@ -309,12 +311,12 @@ today (#767, "Readiness").
 | `module`, selective and aliased `use`, `export`, canonical JSON descriptors, generated registration | implemented | Only `hgraph.std`, `hgraph.analytics`, and modules named by `--module-descriptor` resolve; any other `use` is a `module` diagnostic. No wildcard imports or re-exports; dependency closure and lock files are not implemented. |
 | `fn`, `export fn`, anonymous `fn`, bodyless `operator`, `impl fn` | partial | Both backends. `emit-cpp` rejects an `impl fn` of an imported operator; direct wiring reaches an `impl fn` only through a loaded native image and rejects a direct call; direct wiring rejects a call to a generic plain `fn` ("generic functions are not supported by the first pass"); a concise `map(..., fn(a) => ...)` lambda is lowered by `emit-cpp` but rejected by direct wiring ("anonymous functions are not supported by the first pass"), #767 item 3. |
 | Generics and `requires` | partial | Closed constraint language (equality, membership, categories, reflection, nominal operator requirements, Boolean composition) in typed HIR. Residual `const` predicates, imported-contract conformance, native nominal-struct metadata, and source-candidate ranking fail closed; explicit generic arguments on calls are undefined. |
-| `instantiate op<A, ...>` | implemented for local contracts | Produces concrete graph/node candidates from matching generic `impl fn` templates, carries complete substitutions through both IRs, emits and registers readable concrete C++, and advertises concrete descriptor signatures. Materializing an `impl fn` of a selectively imported operator is blocked on descriptor-backed external contract metadata. |
+| `instantiate op<A, ...>` | partial for local contracts | Concrete arguments specialize a matching generic `impl fn`; `_` retains a resolver slot. Both IRs distinguish the cases, descriptors retain residual generics, and `emit-cpp` maps a retained fixed-list size to `SIZE<"name">`. Constraints over retained slots and retained values read by a body require residual-constraint/reification designs and fail closed. Materializing an `impl fn` of a selectively imported operator is blocked on descriptor-backed external contract metadata. |
 | Canonical scalars, the eight temporal types, `@` and duration literals | partial | Lexer, parser, HIR, and both backends for `bool`, `i64`, `f64`, `str`, `date`, `time`, `datetime`, `duration`. Zoned and civil literals are rejected by both backends. Of the arithmetic table in the language reference only `str + str`, `duration ± duration`, `datetime ± duration`, `datetime - datetime`, and `duration * i64` are typed; `date ± duration`, `date - date`, `duration * f64`, and `duration / ...` are "arithmetic operands must both be numeric" (#767 item 2b: the emitter needs temporal arithmetic helpers before the checker admits them). |
 | `zoned_time` scalar; `Time` and `CivilDateTime` ordering | blocked | hgraph-side asks recorded under Slice 2 with no RFC in `docs/source/rfc/` yet; both backends fail closed meanwhile. |
 | `tuple`, `list`, `set`, `map` | partial | `list<T, n>`, `set<T>`, and `map<K, V>` map to TSL, TSS, and TSD. `eval` drives scalar and `atomic` parameters only; a structural `tuple` has no time-series schema in direct wiring; time-series tuple and list literals, and compound constant literals in generated defaults, are rejected. A fixed list size must be a positive constant (or a `const` generic of type `i64`), checked by typed HIR (`type: list size must be a positive constant or 'unbounded'`, PR #780); non-scalar map keys have no language rule yet (#767 item 6). |
 | `atomic<T>` | implemented | Whether `atomic<f64>` is normalized to `f64` is not fixed (types-and-expressions.md). |
-| `rolling<T, max[, min]>` | partial | Both backends for concrete tick-count and duration windows. Not accepted as a runtime-node parameter; window iteration and an either-kind parameter spelling are undefined; kind agreement and the size ranges (tick sizes positive, a duration minimum may be `0s`, no minimum above its maximum) are typed HIR diagnostics (PR #780). A `const` size generic is concrete in an explicitly materialized operator implementation; unresolved generic plain functions remain an `emit-cpp` limitation. |
+| `rolling<T, max[, min]>` | partial | Both backends for concrete tick-count and duration windows. Not accepted as a runtime-node parameter; window iteration and an either-kind parameter spelling are undefined; kind agreement and the size ranges (tick sizes positive, a duration minimum may be `0s`, no minimum above its maximum) are typed HIR diagnostics (PR #780). A `const` size generic may be concretely materialized; retained named rolling sizes remain blocked because hgraph has no corresponding named-size marker. Unresolved generic plain functions remain an `emit-cpp` limitation. |
 | Named TSW size generics | blocked | `emit-cpp` binds a size-generic window to `TSWAny<T>`; hgraph's `TypePattern` carries concrete sizes and an any-window wildcard but no named size variable (Slice 2 ask, no RFC). |
 | `ref<T>` | partial | Explicit contracts, descriptors, guarded fixed-list reference routing, and forwarded conditional captures in both backends. Wiring-time dereference, `map<K, ref<V>>`, and `ref<ref<T>>` are rejected. |
 | `signal` | implemented | Input-only, payload-erased, no default value. |

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -108,8 +108,10 @@ surface.
 
 - `fn` is the only implementation declaration; `operator` declares a bodyless
   nominal callable contract, and `impl fn` is the only way to implement one.
-- Every `operator` and `impl fn` candidate is public by definition;
-  an ordinary exact function is module-internal unless declared `export fn`.
+- Every `operator` and concrete `impl fn` candidate is public by definition;
+  generic implementations contribute only their explicit `instantiate`
+  materializations, and an ordinary exact function is module-internal unless
+  declared `export fn`.
 - Imports expose names but do not activate providers; the locked package target
   defines the complete candidate universe without declaration re-exports.
 - Ordinary parameters and results use canonical recursively temporal types.

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -108,10 +108,10 @@ surface.
 
 - `fn` is the only implementation declaration; `operator` declares a bodyless
   nominal callable contract, and `impl fn` is the only way to implement one.
-- Every `operator` and concrete `impl fn` candidate is public by definition;
+- Every `operator` and non-generic `impl fn` candidate is public by definition;
   generic implementations contribute only their explicit `instantiate`
-  materializations, and an ordinary exact function is module-internal unless
-  declared `export fn`.
+  materializations, whose `_` arguments may retain resolver slots, and an
+  ordinary exact function is module-internal unless declared `export fn`.
 - Imports expose names but do not activate providers; the locked package target
   defines the complete candidate universe without declaration re-exports.
 - Ordinary parameters and results use canonical recursively temporal types.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -147,8 +147,10 @@ port, or wiring object. A call whose wiring-time value is not yet known (for
 example a `const` function parameter) and a higher-order call awaiting callable
 erasure retain their complete HGL result type and nominal identity but are
 marked `deferred`. Likewise, a sole concrete source `impl fn` may be named
-directly. A generic implementation is concrete only for a substitution retained
-by an `instantiate` declaration; its unresolved template is never selected.
+directly. A generic implementation participates only through a candidate
+requested by an `instantiate` declaration; its unrestricted source template is
+never selected. A requested candidate may bind every slot or retain selected
+slots as resolver variables.
 Two or more candidates remain deferred for hgraph ranking rather than being
 ranked by a compiler-private matcher. The current slice also checks that a sole
 source candidate is applicable before naming it.
@@ -386,13 +388,23 @@ so neither type checking nor later descriptor generation reconstructs a
 contract from the implementation's short name.
 
 An `InstantiateDecl` retains the selected local operator symbol and its ordered
-type/value arguments. Typed HIR checks each request against every generic
-implementation template of that operator, evaluates implementation and mapped
-contract requirements, rejects duplicates, and records explicit
-`Materialization` records containing the implementation symbol and complete
-substitution. Hgraph IR translates those records to stable callable and binding
-IDs. The descriptor and C++ backends consume the same materialization table;
-neither re-parses source syntax or independently decides which templates exist.
+type/value/retain arguments. Typed HIR checks each request against every
+generic implementation template of that operator, evaluates implementation
+and mapped contract requirements, rejects duplicates, and records explicit
+`Materialization` records containing the implementation symbol and one
+classified substitution per generic. A substitution is either concrete or
+explicitly retained; an absent binding is never interpreted as a wildcard.
+Hgraph IR translates those records to stable callable and binding IDs. The
+descriptor and C++ backends consume the same materialization table; neither
+re-parses source syntax or independently decides which templates exist.
+
+Candidate binding and generic availability remain orthogonal. C++ emission
+represents a retained fixed-list size used only by a type as
+`hgraph::SIZE<"name">`. A retained binding read by the body is a reification
+request and fails closed until hgraph exposes an intentional wiring-time or
+runtime value contract. A concrete `const` substitution used by the body is
+folded normally. The backend must not recover retained values by inspecting a
+live input schema on every evaluation.
 
 ## Function classification
 
@@ -1103,8 +1115,10 @@ descriptor or registry drift becomes an error.
 A source-defined operator lowers to a deterministic alias of the corresponding
 `hgraph::Operator` contract. Each non-generic `impl fn` lowers to one explicitly
 registered graph or node candidate according to its classified body. A generic
-`impl fn` emits no open C++ template candidate: each Hgraph IR materialization
-emits a separate concrete, readable graph or node struct and registration. An
+`impl fn` emits no unrestricted C++ template candidate: each Hgraph IR
+materialization emits a separate readable graph or node struct and
+registration. Concrete slots appear as concrete C++ schemas; retained
+signature slots appear as hgraph resolver markers. An
 ordinary `fn` lowers as an exact callable and is not placed in a registry.
 Only an ordinary `export fn` is emitted into the module's public exact-function
 surface.
@@ -1132,10 +1146,11 @@ constraints. Only records reachable from those surfaces are retained; private
 body types do not leak into the package interface.
 
 Generic implementation origins are private compiler input and do not appear as
-unresolved candidates in the provider inventory. Each explicit materialization
-does appear, under the same stable identity used by generated registration,
-with a concrete signature and no remaining generic parameters. This keeps
-descriptor discovery identical to the candidate set installed by the module.
+unrestricted candidates in the provider inventory. Each explicit
+materialization does appear, under the same stable identity used by generated
+registration. Its descriptor signature substitutes concrete slots and retains
+only the residual generics explicitly marked with `_`. This keeps descriptor
+discovery identical to the candidate pattern installed by the module.
 
 Record IDs are assigned by a fixed traversal of declarations ordered by stable
 identity and are meaningful only inside that descriptor. A symbol type carries
@@ -1554,10 +1569,11 @@ expression is read from the syntax tree.
   `TSWAny<T>` while a concrete tick or duration window becomes `TSW<T, N, M>`
   or `TSWDuration<T, period_us, minimum_us>`. A generic operator implementation
   is not emitted as a C++ template or type-erased catch-all. Each
-  `instantiate` record substitutes its type and `const` arguments before
-  emission and produces a concrete implementation struct. The selected call's
-  concrete window schema is retained when a graph implementation receives
-  `TSWAny`.
+  `instantiate` record substitutes its concrete type and `const` arguments
+  before emission and preserves `_` slots as supported hgraph resolver
+  markers. A retained fixed-list size becomes `SIZE<"name">`; a retained named
+  rolling size is not supported by hgraph. The selected call's concrete window
+  schema is retained when a graph implementation receives `TSWAny`.
 - **Runtime-node structs.** A runtime function in the supported scalar subset
   is an empty static node struct in the generated header. Its `eval` signature
   carries typed `In`, `Scalar`, `RecordableState`, and `Out` selectors. The

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -146,10 +146,12 @@ resolved substitutions; it never stores an `OperatorImpl *`, provider lease,
 port, or wiring object. A call whose wiring-time value is not yet known (for
 example a `const` function parameter) and a higher-order call awaiting callable
 erasure retain their complete HGL result type and nominal identity but are
-marked `deferred`. Likewise, a sole source `impl fn` may be named directly,
-while two or more candidates remain deferred for hgraph ranking rather than
-being ranked by a compiler-private matcher. The current slice also checks that
-a sole source candidate is applicable before naming it.
+marked `deferred`. Likewise, a sole concrete source `impl fn` may be named
+directly. A generic implementation is concrete only for a substitution retained
+by an `instantiate` declaration; its unresolved template is never selected.
+Two or more candidates remain deferred for hgraph ranking rather than being
+ranked by a compiler-private matcher. The current slice also checks that a sole
+source candidate is applicable before naming it.
 
 Callable constraints now use the same substitution object as signature
 matching. Positive conjunctive equalities may bind an output-only type or
@@ -371,8 +373,10 @@ roles, defaults, result relationship, and source range. Every
 carries the `impl` modifier to the unique local or selectively imported
 operator of its name, reports an error when no such operator exists, and
 reports a conflict for a plain `fn` whose name is an in-scope operator. A bound
-implementation is a provider candidate and rejects an `export` modifier; only
-an unbound exact function may be exported directly.
+non-generic implementation is a provider candidate and rejects an `export`
+modifier; a generic bound implementation is a template whose explicit
+materializations are candidates. Only an unbound exact function may be
+exported directly.
 
 The resolved module stores that selected binding on the implementation
 declaration itself. Lowering copies it to `FunctionDecl::operator_contract` as
@@ -380,6 +384,15 @@ a stable HIR symbol. Imported symbols keep the defining-module identity
 (`hgraph.std.valid`) separate from the current native registry key (`valid`),
 so neither type checking nor later descriptor generation reconstructs a
 contract from the implementation's short name.
+
+An `InstantiateDecl` retains the selected local operator symbol and its ordered
+type/value arguments. Typed HIR checks each request against every generic
+implementation template of that operator, evaluates implementation and mapped
+contract requirements, rejects duplicates, and records explicit
+`Materialization` records containing the implementation symbol and complete
+substitution. Hgraph IR translates those records to stable callable and binding
+IDs. The descriptor and C++ backends consume the same materialization table;
+neither re-parses source syntax or independently decides which templates exist.
 
 ## Function classification
 
@@ -1088,9 +1101,11 @@ algorithm. Generated C++ dispatches through the public contract alias again so
 descriptor or registry drift becomes an error.
 
 A source-defined operator lowers to a deterministic alias of the corresponding
-`hgraph::Operator` contract. Each `impl fn` lowers to an explicitly registered
-graph or node candidate according to its classified body. An ordinary `fn`
-lowers as an exact callable and is not placed in a registry.
+`hgraph::Operator` contract. Each non-generic `impl fn` lowers to one explicitly
+registered graph or node candidate according to its classified body. A generic
+`impl fn` emits no open C++ template candidate: each Hgraph IR materialization
+emits a separate concrete, readable graph or node struct and registration. An
+ordinary `fn` lowers as an exact callable and is not placed in a registry.
 Only an ordinary `export fn` is emitted into the module's public exact-function
 surface.
 
@@ -1115,6 +1130,12 @@ implementation candidates reference structured signatures and three
 descriptor-local arenas for canonical types, compile-time expressions, and
 constraints. Only records reachable from those surfaces are retained; private
 body types do not leak into the package interface.
+
+Generic implementation origins are private compiler input and do not appear as
+unresolved candidates in the provider inventory. Each explicit materialization
+does appear, under the same stable identity used by generated registration,
+with a concrete signature and no remaining generic parameters. This keeps
+descriptor discovery identical to the candidate set installed by the module.
 
 Record IDs are assigned by a fixed traversal of declarations ordered by stable
 identity and are meaningful only inside that descriptor. A symbol type carries
@@ -1450,7 +1471,8 @@ device. The TOML run configuration is provisional and not in the first pass.
 
 Status: implemented for the composition and runtime forms exercised by every
 checked-in example as of 2026-09-06. This includes nominal and generic structs,
-generic operator implementations, fixed and duration windows, sparse struct
+explicitly materialized generic operator implementations, fixed and duration
+windows, sparse struct
 deltas, concise `map` functions, scalar and collection runtime inputs, borrowed
 collection traversal, fixed-list and independent dynamic graph traversal,
 explicit reference schemas, guarded fixed-list reference routing, `out`,
@@ -1530,8 +1552,12 @@ expression is read from the syntax tree.
   `ScalarVar` patterns at operator boundaries and ordinary C++ template
   parameters for structural declarations. A generic rolling parameter becomes
   `TSWAny<T>` while a concrete tick or duration window becomes `TSW<T, N, M>`
-  or `TSWDuration<T, period_us, minimum_us>`. The selected call's concrete
-  window schema is retained when a graph implementation receives `TSWAny`.
+  or `TSWDuration<T, period_us, minimum_us>`. A generic operator implementation
+  is not emitted as a C++ template or type-erased catch-all. Each
+  `instantiate` record substitutes its type and `const` arguments before
+  emission and produces a concrete implementation struct. The selected call's
+  concrete window schema is retained when a graph implementation receives
+  `TSWAny`.
 - **Runtime-node structs.** A runtime function in the supported scalar subset
   is an empty static node struct in the generated header. Its `eval` signature
   carries typed `In`, `Scalar`, `RecordableState`, and `Out` selectors. The
@@ -1583,7 +1609,8 @@ expression is read from the syntax tree.
   roles are rechecked at the IR and emission boundaries.
 - **Registration.** `hgraph::OperatorProviderHandle register_operators()`
   registers each export and
-  each `impl fn` with
+  each concrete non-generic `impl fn`, plus every concrete generic
+  materialization, with
   `hgraph::register_graph_overload<operators::x, x>()` for a composition or
   `hgraph::register_overload<operators::x, x>()` for a runtime node. Private
   runtime helpers get readable aliases in a translation-unit-local

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -85,11 +85,11 @@ when no unit follows it, so `1e5` is a float literal and `1e5m` an invalid
 duration run. `temporal_literal` and `duration_literal` are defined under
 "Temporal scalar types".
 
-The hard reserved words are exactly these 41, the keyword table of
+The hard reserved words are exactly these 42, the keyword table of
 `src/syntax/token.cpp`:
 
 ```text
-module use as export abstract impl operator fn struct const requires is let var state inject return if else
+module use as export abstract impl instantiate operator fn struct const requires is let var state inject return if else
 start when stop for test assert eval
 true false null
 bool i64 f64 str date time datetime duration
@@ -153,7 +153,8 @@ use_decl        = "use", module_path,
                   ( "::", import_set | "as", identifier );
 import_set      = "{", identifier, { ",", identifier }, [ "," ], "}";
 
-declaration     = struct_decl | operator_decl | function_decl | test_decl;
+declaration     = struct_decl | operator_decl | instantiate_decl
+                | function_decl | test_decl;
 struct_decl     = [ "export" ], [ "abstract" ], "struct", identifier,
                   [ generic_parameters ],
                   [ ":", struct_parent, { ",", struct_parent } ],
@@ -166,6 +167,10 @@ inherited_default
                 = identifier, "=", const_expression;
 operator_decl   = "operator", identifier, [ generic_parameters ],
                   function_signature, [ requires_clause ];
+instantiate_decl
+                = "instantiate", instantiation,
+                  { ",", instantiation }, [ "," ];
+instantiation   = identifier, generic_arguments;
 function_decl   = [ "export" | "impl" ], "fn", identifier,
                   [ generic_parameters ], function_signature,
                   [ requires_clause ], function_body;
@@ -226,6 +231,8 @@ it is not a general local-variable qualifier. `export` applies to a named
 ordinary exact `fn` or a `struct`; other declarations reject it. `impl` marks
 a named `fn` as an implementation of an operator in scope; the two function
 modifiers are mutually exclusive. Operators are public without a modifier.
+`instantiate` is a module-level request for concrete generic operator
+implementations; it is not a function call or a visibility modifier.
 
 A struct has a module-qualified nominal identity. Its fields are public,
 immutable, and ordered metadata, with newline separators and no semicolons.
@@ -846,9 +853,40 @@ effective dispatch constraint is the conjunction of the mapped operator and
 candidate constraints. The body still passes through ordinary function
 classification and may lower to either graph composition or one runtime node.
 Several `impl fn` declarations may share a name; each is a separate candidate
-of the same operator. An `impl fn` contributes a public candidate to the
-operator and cannot also be marked `export`; it is not an independently named
-exact function.
+of the same operator. A non-generic `impl fn` contributes a public candidate
+directly. A generic `impl fn` contributes only concrete candidates requested by
+an `instantiate` declaration and cannot also be marked `export`; neither the
+template nor its materializations are independently named exact functions.
+
+```hgl
+operator choose<T>(value: T) -> T
+
+impl fn choose<T>(value: T) -> T
+requires T in {i64, f64}
+=> value
+
+instantiate choose<i64>, choose<f64>
+```
+
+An instantiation argument list binds the generic parameters of each local
+generic implementation template in declaration order. A type parameter
+requires a type argument; a `const` parameter requires a compile-time value
+assignable to its declared value type. The checker evaluates the substituted
+implementation and operator constraints before retaining a materialization.
+One request applies to every matching template of that operator. No match and
+duplicate `(implementation, arguments)` pairs are type diagnostics.
+
+The declaration may appear before or after the corresponding `impl fn`; typed
+HIR processes all instantiation requests before checking bodies so source order
+does not change the candidate set. A generic implementation with no request is
+legal but contributes no concrete source candidate. An uninstantiated template
+is never emitted or placed in a module descriptor.
+
+The current implementation accepts only a locally declared operator contract.
+Although ordinary `impl fn` binding also admits a selectively imported
+operator, materializing that case requires descriptor-backed external contract
+metadata and currently produces a module diagnostic. This is a staged compiler
+boundary, not a different long-term visibility rule.
 
 A module alias creates only a namespace:
 

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -170,7 +170,10 @@ operator_decl   = "operator", identifier, [ generic_parameters ],
 instantiate_decl
                 = "instantiate", instantiation,
                   { ",", instantiation }, [ "," ];
-instantiation   = identifier, generic_arguments;
+instantiation   = identifier, "<", materialization_argument,
+                  { ",", materialization_argument }, [ "," ], ">";
+materialization_argument
+                = type | const_expression | "_";
 function_decl   = [ "export" | "impl" ], "fn", identifier,
                   [ generic_parameters ], function_signature,
                   [ requires_clause ], function_body;
@@ -231,8 +234,10 @@ it is not a general local-variable qualifier. `export` applies to a named
 ordinary exact `fn` or a `struct`; other declarations reject it. `impl` marks
 a named `fn` as an implementation of an operator in scope; the two function
 modifiers are mutually exclusive. Operators are public without a modifier.
-`instantiate` is a module-level request for concrete generic operator
-implementations; it is not a function call or a visibility modifier.
+`instantiate` is a module-level request for generic operator implementation
+candidates; it is not a function call or a visibility modifier. In this
+declaration only, `_` retains the generic parameter in that position instead
+of binding it to a concrete type or value.
 
 A struct has a module-qualified nominal identity. Its fields are public,
 immutable, and ordered metadata, with newline separators and no semicolons.
@@ -854,8 +859,8 @@ candidate constraints. The body still passes through ordinary function
 classification and may lower to either graph composition or one runtime node.
 Several `impl fn` declarations may share a name; each is a separate candidate
 of the same operator. A non-generic `impl fn` contributes a public candidate
-directly. A generic `impl fn` contributes only concrete candidates requested by
-an `instantiate` declaration and cannot also be marked `export`; neither the
+directly. A generic `impl fn` contributes only candidates requested by an
+`instantiate` declaration and cannot also be marked `export`; neither the
 template nor its materializations are independently named exact functions.
 
 ```hgl
@@ -871,10 +876,55 @@ instantiate choose<i64>, choose<f64>
 An instantiation argument list binds the generic parameters of each local
 generic implementation template in declaration order. A type parameter
 requires a type argument; a `const` parameter requires a compile-time value
-assignable to its declared value type. The checker evaluates the substituted
-implementation and operator constraints before retaining a materialization.
+assignable to its declared value type. `_` accepts either kind and explicitly
+retains that parameter as a resolver variable. The checker evaluates the
+substituted implementation and operator constraints before retaining a
+materialization. Constraints must currently be decidable from the concrete
+arguments without binding a retained parameter; residual constraints over
+retained parameters are not yet emitted.
 One request applies to every matching template of that operator. No match and
 duplicate `(implementation, arguments)` pairs are type diagnostics.
+
+Concrete binding and implementation availability are separate axes. A generic
+may be:
+
+- **concrete-required** because the body needs a concrete C++ value type,
+  storage layout, or operation;
+- a **retained marker** used only in the candidate signature and resolver type
+  relationships; or
+- **retained and reified**, meaning the resolved wiring-time type or value must
+  be made available for the implementation body to inspect.
+
+The compiler infers the use from the typed body; `instantiate` does not add a
+second annotation for it. Marker-only fixed-list sizes lower directly to
+`hgraph::SIZE<"name">` and have no runtime field. Reading a retained generic as
+a value requires an explicit reification mechanism and currently fails with a
+targeted `emit-cpp` diagnostic. Binding that same generic concretely remains
+valid. This prevents an implementation detail such as per-tick schema
+inspection from being introduced as an accidental language rule.
+
+For example, a list reduction may require a concrete element type for its
+accumulator while remaining indifferent to fixed list size:
+
+```hgl
+impl fn sum_<T, const size: i64>(values: list<T, size>) -> T
+requires T in {i64, f64}
+{
+    when {
+        var total: T = 0
+        for value in values(values) {
+            total += value
+        }
+        return total
+    }
+}
+
+instantiate sum_<i64, _>, sum_<f64, _>
+```
+
+Here `T` is concrete-required, while `size` is a retained marker selected from
+the input schema by hgraph's resolver. If the body referenced `size` as a
+value, it would instead require reification.
 
 The declaration may appear before or after the corresponding `impl fn`; typed
 HIR processes all instantiation requests before checking bodies so source order

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -401,13 +401,18 @@ Use a deterministic fixture and the real hgraph standard registry to cover:
   independently through qualified calls;
 - aliased modules not creating implementation bindings;
 - ordinary functions remaining exact without `impl`;
-- operators and `impl fn` candidates being public without export modifiers;
+- operators and concrete `impl fn` candidates being public without export
+  modifiers, with generic templates contributing only requested
+  materializations;
 - unexported exact functions remaining module-internal and `export fn` exact
   functions appearing in selective and qualified lookup;
 - exported exact functions not forming overload sets;
 - compatible concrete and generic implementation signatures, including type,
   rolling-size, and list-size variables, with `unbounded` binding a list-size
   generic;
+- explicit type and `const` materialization arguments, constraint rejection,
+  duplicate rejection, concrete descriptor signatures, and matching generated
+  registration;
 - constrained variables, derived type substitutions, structural requirements,
   and required-operator capabilities;
 - exact, generic, defaulted, named, lifted, ambiguous, and no-match calls;

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -410,9 +410,9 @@ Use a deterministic fixture and the real hgraph standard registry to cover:
 - compatible concrete and generic implementation signatures, including type,
   rolling-size, and list-size variables, with `unbounded` binding a list-size
   generic;
-- explicit type and `const` materialization arguments, constraint rejection,
-  duplicate rejection, concrete descriptor signatures, and matching generated
-  registration;
+- explicit type, `const`, and retained `_` materialization arguments,
+  constraint rejection, duplicate rejection, residual descriptor generics,
+  retained fixed-list size markers, and matching generated registration;
 - constrained variables, derived type substitutions, structural requirements,
   and required-operator capabilities;
 - exact, generic, defaulted, named, lifted, ambiguous, and no-match calls;

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -58,8 +58,9 @@ because their signatures differ.
 
 Operators use a different rule. Declaring an `operator` makes its contract
 public automatically. A concrete compatible `impl fn` participates directly;
-a generic `impl fn` contributes only the concrete candidates requested by an
-`instantiate` declaration. Candidates are reached through the operator and are
+a generic `impl fn` contributes only the candidates requested by an
+`instantiate` declaration, with `_` retaining selected resolver slots.
+Candidates are reached through the operator and are
 not independently exported exact functions. Consequently `export` is invalid
 on an `impl fn`: the binding already supplies its public meaning.
 
@@ -267,8 +268,8 @@ node-only constructs make that candidate a runtime implementation.
 ### Explicit implementation materialization
 
 A generic `impl fn` is a source template, not an open-ended candidate placed in
-the runtime registry. The module requests each concrete implementation it needs
-with `instantiate`:
+the runtime registry. The module requests each implementation candidate it
+needs with `instantiate`:
 
 ```hgl
 operator absolute<T>(value: T) -> T
@@ -293,15 +294,52 @@ impl fn summarize<T, const size: i64>(values: rolling<T, size>) -> T =>
 instantiate summarize<f64, 20>
 ```
 
-Each request is checked against the implementation signature, its `requires`
-clause, and the operator contract. A request that matches no generic template,
-or repeats the same concrete implementation, is a type error. When several
+Use `_` when a generic should remain selectable by overload resolution instead
+of being fixed by this declaration. A reduction often needs a concrete element
+type but does not care about the fixed size of its input list:
+
+```hgl
+operator sum_<T, const size: i64>(values: list<T, size>) -> T
+
+impl fn sum_<T, const size: i64>(values: list<T, size>) -> T
+requires T in {i64, f64}
+{
+    when {
+        var total: T = 0
+        for value in values(values) {
+            total += value
+        }
+        return total
+    }
+}
+
+instantiate sum_<i64, _>, sum_<f64, _>
+```
+
+The two candidates have concrete accumulator types but still match any fixed
+list size. The retained `size` is a type marker: it participates in matching
+the input schema but is not stored or passed to the node at evaluation time.
+
+This differs from a generic that the body reads. Such a value must be
+**reified**—made available as read-only wiring-time or runtime metadata. The
+distinction is inferred from how the generic is used, not written on the
+parameter. The current compiler supports retained fixed-list-size markers and
+concrete values; reading a retained generic in an implementation is a visible
+`emit-cpp` limitation while the reification contract is designed.
+
+Each concrete argument binds the corresponding implementation generic in
+declaration order; `_` retains it. Each request is checked against the
+implementation signature, its `requires` clause, and the operator contract. A
+request that matches no generic template, or repeats the same candidate
+pattern, is a type error. Requirements over retained slots must currently be
+decidable from the concrete bindings without constraining a retained slot.
+When several
 generic templates of the same operator accept the argument list, each matching
 template is materialized; hgraph still applies its ordinary overload ranking
 when the operator is called.
 
 `instantiate` affects candidate generation, not source visibility. The generic
-template and its concrete materializations remain hidden behind the public
+template and its requested candidates remain hidden behind the public
 operator contract. A generic implementation with no materialization is valid
 source but contributes no generated candidate.
 

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -57,10 +57,11 @@ family. Two exported ordinary functions therefore cannot share a name merely
 because their signatures differ.
 
 Operators use a different rule. Declaring an `operator` makes its contract
-public automatically, and every compatible `impl fn` of that name participates
-as an implementation candidate. The candidate is reached through the operator
-and is not an independently exported exact function. Consequently `export` is
-invalid on an `impl fn`: the binding already supplies its public meaning.
+public automatically. A concrete compatible `impl fn` participates directly;
+a generic `impl fn` contributes only the concrete candidates requested by an
+`instantiate` declaration. Candidates are reached through the operator and are
+not independently exported exact functions. Consequently `export` is invalid
+on an `impl fn`: the binding already supplies its public meaning.
 
 ## Temporal and constant parameters
 
@@ -262,6 +263,52 @@ An implementation may be concrete or generic, but it must specialize the
 operator contract rather than change its public argument roles. Its body is
 classified normally: an ordinary body becomes graph composition, while
 node-only constructs make that candidate a runtime implementation.
+
+### Explicit implementation materialization
+
+A generic `impl fn` is a source template, not an open-ended candidate placed in
+the runtime registry. The module requests each concrete implementation it needs
+with `instantiate`:
+
+```hgl
+operator absolute<T>(value: T) -> T
+
+impl fn absolute<T>(value: T) -> T
+requires T in {i64, f64}
+=> if value < 0 { -value } else { value }
+
+instantiate absolute<i64>, absolute<f64>
+```
+
+The arguments after `absolute` bind the generic parameters declared by the
+`impl fn`, in order. They may include type arguments and wiring-time constant
+arguments:
+
+```hgl
+operator summarize<T, const size: i64>(values: rolling<T, size>) -> T
+
+impl fn summarize<T, const size: i64>(values: rolling<T, size>) -> T =>
+    mean(values)
+
+instantiate summarize<f64, 20>
+```
+
+Each request is checked against the implementation signature, its `requires`
+clause, and the operator contract. A request that matches no generic template,
+or repeats the same concrete implementation, is a type error. When several
+generic templates of the same operator accept the argument list, each matching
+template is materialized; hgraph still applies its ordinary overload ranking
+when the operator is called.
+
+`instantiate` affects candidate generation, not source visibility. The generic
+template and its concrete materializations remain hidden behind the public
+operator contract. A generic implementation with no materialization is valid
+source but contributes no generated candidate.
+
+> **Current compiler boundary:** explicit materialization is implemented for an
+> operator declared in the same module. A generic `impl fn` may bind to a
+> selectively imported operator, but materializing and emitting that imported
+> contract awaits descriptor-backed imported operator metadata.
 
 Operator identity is nominal and includes its defining module. Two modules may
 therefore declare unrelated operators with the same short name. Name and import

--- a/language/docs/user-guide/language-tour.md
+++ b/language/docs/user-guide/language-tour.md
@@ -78,8 +78,9 @@ is an error rather than an unrelated private function.
 
 A generic `impl fn combine<T>(...)` is a hidden template instead. Write
 `instantiate combine<i64>, combine<f64>` at module level to publish those
-concrete candidates; calls still use ordinary `combine(...)` syntax and hgraph
-selects among the registered implementations.
+candidates. An `_` argument may retain a generic resolver slot rather than
+fixing it. Calls still use ordinary `combine(...)` syntax and hgraph selects
+among the registered implementations.
 
 An implementation module selects an externally defined operator with a
 selective import such as `use my.contracts::{combine}`. Exactly one operator

--- a/language/docs/user-guide/language-tour.md
+++ b/language/docs/user-guide/language-tour.md
@@ -76,6 +76,11 @@ it is not an independently importable exact function and does not use
 `export`. The `impl` modifier is mandatory, so a misspelt implementation name
 is an error rather than an unrelated private function.
 
+A generic `impl fn combine<T>(...)` is a hidden template instead. Write
+`instantiate combine<i64>, combine<f64>` at module level to publish those
+concrete candidates; calls still use ordinary `combine(...)` syntax and hgraph
+selects among the registered implementations.
+
 An implementation module selects an externally defined operator with a
 selective import such as `use my.contracts::{combine}`. Exactly one operator
 definition may occupy that unqualified binding. A module alias instead keeps

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -103,8 +103,9 @@ operator. Equal-ranked implementations within one selected operator remain an
 ambiguity error.
 
 Every non-generic `impl fn` contributes an implementation candidate. A generic
-`impl fn` contributes the concrete candidates requested by `instantiate`, not
-its unresolved source template. Neither form uses `export` or is separately
+`impl fn` contributes only the candidates requested by `instantiate`; `_` may
+retain selected resolver slots, but the unrestricted source template is not a
+candidate. Neither form uses `export` or is separately
 importable by its implementation module's name. `export fn` is reserved for
 exposing an ordinary exact function.
 
@@ -133,10 +134,11 @@ module or registration order as a tie-break.
 
 Each imported declaration and each provider in the target closure is checked
 against a language module descriptor. A descriptor contains public exact
-functions, nominal operator identities, concrete implementation candidates
+functions, nominal operator identities, requested implementation candidates
 with provider provenance, versions, required public headers, CMake package and
 target names, and lifecycle and registration entry points. Explicit generic
-materializations have concrete descriptor signatures; the hidden generic
+materializations substitute concrete slots and expose only explicitly retained
+residual generics in their descriptor signatures; the hidden unrestricted
 templates do not enter the provider inventory. A descriptor does not grant
 access to arbitrary symbols in a library.
 

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -102,9 +102,11 @@ operator definitions; it does not break a tie between implementations of one
 operator. Equal-ranked implementations within one selected operator remain an
 ambiguity error.
 
-Every `impl fn` contributes an implementation candidate. It does not use
-`export` and is not separately importable by its implementation module's
-name. `export fn` is reserved for exposing an ordinary exact function.
+Every non-generic `impl fn` contributes an implementation candidate. A generic
+`impl fn` contributes the concrete candidates requested by `instantiate`, not
+its unresolved source template. Neither form uses `export` or is separately
+importable by its implementation module's name. `export fn` is reserved for
+exposing an ordinary exact function.
 
 ## Implementation discovery
 
@@ -131,10 +133,12 @@ module or registration order as a tie-break.
 
 Each imported declaration and each provider in the target closure is checked
 against a language module descriptor. A descriptor contains public exact
-functions, nominal operator identities, implementation candidates with provider
-provenance, versions, required public headers, CMake package and target names,
-and lifecycle and registration entry points. It does not grant access to
-arbitrary symbols in a library.
+functions, nominal operator identities, concrete implementation candidates
+with provider provenance, versions, required public headers, CMake package and
+target names, and lifecycle and registration entry points. Explicit generic
+materializations have concrete descriptor signatures; the hidden generic
+templates do not enter the provider inventory. A descriptor does not grant
+access to arbitrary symbols in a library.
 
 ## Compiled module lifecycle
 

--- a/language/examples/operators-and-generics.hgl
+++ b/language/examples/operators-and-generics.hgl
@@ -16,6 +16,8 @@ impl fn summarize<
 >(window: rolling<f64, max_size, min_size>) -> f64 =>
     mean(window)
 
+instantiate summarize<20, 20>
+
 export fn summarize_full_window(window: rolling<f64, 20>) -> f64 =>
     summarize(window)
 

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -506,6 +506,10 @@ namespace hgl::codegen
                                                                         const PlannedTypeBindings *bindings);
             [[nodiscard]] std::string                 value_type(const HType &type, SourceRange range);
             [[nodiscard]] std::string                 schema(const HType &type, SourceRange range);
+            [[nodiscard]] std::string                 materialization_cpp_name(const gir::Materialization &item, std::size_t index);
+            void                                      begin_materialization(const gir::Materialization &item, std::size_t index);
+            void                                      end_materialization();
+            [[nodiscard]] std::string_view            active_callable_identity(const gir::Callable &item) const noexcept;
 
             // -- expressions
             [[nodiscard]] Value eval_planned_expr(gir::ValueId id, Frame &frame);
@@ -620,13 +624,18 @@ namespace hgl::codegen
             std::vector<gir::CallableId> callable_declarations_{};
             bool                         uses_analytics_{false};
             /// Locals declared in the current function, for unique C++ names.
-            std::unordered_map<std::string, int> local_counts_{};
-            std::unordered_set<std::string>      local_names_{};
-            Writer                               generated_helpers_{};
-            std::size_t                          anonymous_function_index_{0};
-            Writer                              *current_body_{nullptr};
-            std::size_t                          conditional_index_{0};
-            std::size_t                          traversal_index_{0};
+            std::unordered_map<std::string, int>                local_counts_{};
+            std::unordered_set<std::string>                     local_names_{};
+            Writer                                              generated_helpers_{};
+            std::size_t                                         anonymous_function_index_{0};
+            Writer                                             *current_body_{nullptr};
+            std::size_t                                         conditional_index_{0};
+            std::size_t                                         traversal_index_{0};
+            PlannedTypeBindings                                 materialized_types_{};
+            std::unordered_map<std::uint32_t, gir::ConstExprId> materialized_values_{};
+            std::string                                         materialized_cpp_name_{};
+            std::string                                         materialized_identity_{};
+            gir::CallableId                                     materialized_callable_{};
         };
 
         std::string_view Emitter::local_identity(std::string_view identity) noexcept {
@@ -643,6 +652,7 @@ namespace hgl::codegen
         }
 
         std::string Emitter::callable_cpp_name(gir::CallableId decl) {
+            if (materialized_callable_ == decl && !materialized_cpp_name_.empty()) { return materialized_cpp_name_; }
             const gir::Callable &item = callable(decl);
             std::string          name = cpp_name(callable_name(decl));
             if (item.visibility != gir::CallableVisibility::Implementation) { return name; }
@@ -653,6 +663,87 @@ namespace hgl::codegen
                 backend(item.range, "hgraph IR implementation '" + item.identity + "' has no canonical numeric identity");
             }
             return name + "_impl_" + item.identity.substr(marker + 1U);
+        }
+
+        std::string Emitter::materialization_cpp_name(const gir::Materialization &item, std::size_t index) {
+            const gir::CallableId saved = materialized_callable_;
+            materialized_callable_      = {};
+            std::string result          = callable_cpp_name(item.implementation);
+            materialized_callable_      = saved;
+            for (const gir::Substitution &substitution : item.substitutions) {
+                result += "__";
+                if (substitution.type.valid()) {
+                    const gir::Type &type = graph_type(substitution.type, item.range);
+                    if (type.kind == hir::TypeKind::Scalar) {
+                        result += hir::scalar_type_name(type.scalar);
+                    } else if (!type.nominal_identity.empty()) {
+                        result += cpp_name(local_identity(type.nominal_identity));
+                    } else {
+                        result += "type";
+                    }
+                } else if (substitution.constant) {
+                    std::visit(
+                        [&](const auto &value) {
+                            using T = std::decay_t<decltype(value)>;
+                            if constexpr (std::is_same_v<T, std::int64_t>) {
+                                const std::string spelling = std::to_string(value);
+                                result += value < 0 ? "neg_" + spelling.substr(1) : spelling;
+                            } else if constexpr (std::is_same_v<T, bool>) {
+                                result += value ? "true" : "false";
+                            } else {
+                                result += "value";
+                            }
+                        },
+                        *substitution.constant);
+                } else {
+                    result += "value";
+                }
+            }
+            result += "__m" + std::to_string(index);
+            return result;
+        }
+
+        void Emitter::begin_materialization(const gir::Materialization &item, std::size_t index) {
+            if (!item.implementation.valid() || item.implementation.value >= graph_.callables.size()) {
+                backend(item.range, "hgraph IR materialization names an invalid implementation");
+            }
+            const gir::Callable &implementation = callable(item.implementation, item.range);
+            if (implementation.visibility != gir::CallableVisibility::Implementation || implementation.generics.empty()) {
+                backend(item.range, "hgraph IR materialization target is not a generic operator implementation");
+            }
+            materialized_types_.clear();
+            materialized_values_.clear();
+            for (const gir::Substitution &substitution : item.substitutions) {
+                if (!substitution.parameter.valid()) {
+                    backend(item.range, "hgraph IR materialization has an invalid generic binding");
+                }
+                if (substitution.type.valid()) {
+                    materialized_types_.emplace(substitution.parameter.value, planned_type(substitution.type, item.range));
+                } else if (substitution.value.valid()) {
+                    materialized_values_.emplace(substitution.parameter.value, substitution.value);
+                } else {
+                    backend(item.range, "hgraph IR materialization leaves a generic argument unresolved");
+                }
+            }
+            if (materialized_types_.size() + materialized_values_.size() != implementation.generics.size()) {
+                backend(item.range, "hgraph IR materialization does not bind every implementation generic");
+            }
+            materialized_cpp_name_ = materialization_cpp_name(item, index);
+            if (item.identity.empty()) { backend(item.range, "hgraph IR materialization has no candidate identity"); }
+            materialized_identity_ = item.identity;
+            materialized_callable_ = item.implementation;
+        }
+
+        void Emitter::end_materialization() {
+            materialized_types_.clear();
+            materialized_values_.clear();
+            materialized_cpp_name_.clear();
+            materialized_identity_.clear();
+            materialized_callable_ = {};
+        }
+
+        std::string_view Emitter::active_callable_identity(const gir::Callable &item) const noexcept {
+            return materialized_identity_.empty() ? std::string_view{item.identity} : std::string_view{materialized_identity_};
         }
 
         const gir::Binding &Emitter::planned_binding(gir::BindingId id, SourceRange fallback) {
@@ -786,6 +877,10 @@ namespace hgl::codegen
 
         std::optional<std::int64_t> Emitter::planned_integer(gir::ConstExprId id, SourceRange fallback) {
             const gir::ConstExpr &expression = graph_constant(id, fallback);
+            if (expression.kind == gir::ConstExprKind::Parameter && expression.parameter_binding.valid()) {
+                const auto found = materialized_values_.find(expression.parameter_binding.value);
+                if (found != materialized_values_.end()) { return planned_integer(found->second, fallback); }
+            }
             if (expression.kind != gir::ConstExprKind::Literal || !expression.literal) { return std::nullopt; }
             if (const auto *value = std::get_if<std::int64_t>(&*expression.literal)) { return *value; }
             return std::nullopt;
@@ -831,7 +926,12 @@ namespace hgl::codegen
                         return fold_binary(expression.binary, planned_constant(expression.lhs, range),
                                            planned_constant(expression.rhs, range), range);
                     }
-                case gir::ConstExprKind::Parameter: unsupported(range, "a generic parameter in a generated constant expression");
+                case gir::ConstExprKind::Parameter:
+                    if (expression.parameter_binding.valid()) {
+                        const auto found = materialized_values_.find(expression.parameter_binding.value);
+                        if (found != materialized_values_.end()) { return planned_constant(found->second, range); }
+                    }
+                    unsupported(range, "an unmaterialized generic parameter in a generated constant expression");
                 case gir::ConstExprKind::Index: unsupported(range, "an indexed generated constant expression");
                 case gir::ConstExprKind::Field: unsupported(range, "a field-read generated constant expression");
                 case gir::ConstExprKind::Sequence: unsupported(range, "a generated list or map constant");
@@ -886,6 +986,10 @@ namespace hgl::codegen
                                 if (const auto found = bindings->find(type.binding.value); found != bindings->end()) {
                                     return found->second;
                                 }
+                            }
+                            if (const auto found = materialized_types_.find(type.binding.value);
+                                found != materialized_types_.end()) {
+                                return found->second;
                             }
                             if (type.binding.value >= graph_.bindings.size()) {
                                 backend(range, "hgraph IR type refers to an invalid generic binding");
@@ -974,21 +1078,22 @@ namespace hgl::codegen
                         result.kind = HType::Kind::Rolling;
                         result.children.push_back(planned_type(type.children.front(), range, bindings));
                         if (!type.size.valid()) { return result; }
-                        const gir::ConstExpr &maximum = graph_constant(type.size, range);
-                        if (maximum.kind != gir::ConstExprKind::Literal || !maximum.literal) {
-                            // A symbolic size is a type relationship, not a C++
-                            // non-type template parameter on the operator marker.
-                            return result;
-                        }
-                        if (const auto *size = std::get_if<std::int64_t>(&*maximum.literal)) {
-                            if (*size <= 0) { backend(range, "typed HIR admitted a non-positive rolling size"); }
-                            result.size                               = std::to_string(*size);
+                        const gir::ConstExpr &maximum     = graph_constant(type.size, range);
+                        const auto            maximum_i64 = planned_integer(type.size, range);
+                        if (maximum_i64) {
+                            if (*maximum_i64 <= 0) { backend(range, "typed HIR admitted a non-positive rolling size"); }
+                            result.size                               = std::to_string(*maximum_i64);
                             const std::optional<std::int64_t> minimum = planned_integer(type.min_size, range);
                             if (!minimum) { unsupported(range, "a rolling minimum given by a const generic"); }
-                            if (*minimum <= 0 || *minimum > *size) {
+                            if (*minimum <= 0 || *minimum > *maximum_i64) {
                                 backend(range, "typed HIR admitted an invalid rolling minimum size");
                             }
                             result.min_size = std::to_string(*minimum);
+                            return result;
+                        }
+                        if (maximum.kind != gir::ConstExprKind::Literal || !maximum.literal) {
+                            // A symbolic size is a type relationship, not a C++
+                            // non-type template parameter on the operator marker.
                             return result;
                         }
                         if (const auto *size = std::get_if<syntax::TemporalValue>(&*maximum.literal);
@@ -3010,8 +3115,7 @@ namespace hgl::codegen
                         branch != nullptr && tail.phase == hir::Phase::Wiring) {
                         gir::ConditionalContinuationPlan continuation = gir::plan_temporal_continuation(
                             graph_, id, block.statements.size(), callable(frame.fn).result, block.tail);
-                        value = lower_planned_conditional(block.tail, *branch, tail.range, frame, true,
-                                                          std::move(continuation));
+                        value = lower_planned_conditional(block.tail, *branch, tail.range, frame, true, std::move(continuation));
                     } else {
                         value = eval_planned_expr(block.tail, frame);
                     }
@@ -3922,15 +4026,15 @@ namespace hgl::codegen
             frame.runtime = true;
             out.line("// " + where(planned.range));
             out.open("struct " + callable_cpp_name(decl));
-            out.line("[[maybe_unused]] static constexpr auto name = " + quote(planned.identity) + ";");
+            out.line("[[maybe_unused]] static constexpr auto name = " + quote(active_callable_identity(planned)) + ";");
             emit_defaults(planned, out);
             if (!info.states.empty()) {
                 std::vector<std::string> fields;
                 for (const RuntimeState &state : info.states) {
                     fields.push_back("hgraph::Field<" + quote(state.name) + ", " + schema(state.type, state.range) + ">");
                 }
-                out.line("using recordable_state = hgraph::TSB<" + quote(planned.identity + ".state") + ", " + join(fields, ", ") +
-                         ">;");
+                out.line("using recordable_state = hgraph::TSB<" +
+                         quote(std::string{active_callable_identity(planned)} + ".state") + ", " + join(fields, ", ") + ">;");
             }
 
             if (!info.states.empty() || !info.start_blocks.empty()) {
@@ -4114,7 +4218,7 @@ namespace hgl::codegen
                 out.line(result_type(decl) + " " + name + "::compose(" + signature(decl, true) + ")");
             } else {
                 out.open("struct " + name);
-                out.line("[[maybe_unused]] static constexpr auto name = " + quote(callable(decl).identity) + ";");
+                out.line("[[maybe_unused]] static constexpr auto name = " + quote(active_callable_identity(planned)) + ";");
                 // Defaults of const parameters travel with the graph so the
                 // registry can apply them when the function is called by name.
                 emit_defaults(callable(decl), out);
@@ -4347,10 +4451,12 @@ namespace hgl::codegen
             std::vector<gir::CallableId>       impls;
             std::map<std::string, std::string> cpp_functions;
             for (const gir::CallableId id : callable_declarations_) {
-                check_supported(id);
                 const gir::Callable &fn = callable(id);
-                const std::string    source_name{callable_name(id)};
-                const std::string    generated_name = callable_cpp_name(id);
+                const bool           generic_implementation =
+                    fn.visibility == gir::CallableVisibility::Implementation && !fn.generics.empty();
+                if (!generic_implementation) { check_supported(id); }
+                const std::string source_name{callable_name(id)};
+                const std::string generated_name = callable_cpp_name(id);
                 if (const auto [found, inserted] = cpp_functions.emplace(generated_name, source_name);
                     !inserted && found->second != source_name) {
                     backend(fn.range,
@@ -4391,7 +4497,16 @@ namespace hgl::codegen
             // their containing functions emit, then placed before every use.
             Writer private_functions;
             for (const gir::CallableId id : internal) { emit_function(id, private_functions, Form::InlineStruct); }
-            for (const gir::CallableId id : impls) { emit_function(id, private_functions, Form::InlineStruct); }
+            for (const gir::CallableId id : impls) {
+                if (callable(id).generics.empty()) { emit_function(id, private_functions, Form::InlineStruct); }
+            }
+            for (std::size_t index = 0; index < graph_.materializations.size(); ++index) {
+                const gir::Materialization &materialization = graph_.materializations[index];
+                begin_materialization(materialization, index);
+                check_supported(materialization.implementation);
+                emit_function(materialization.implementation, private_functions, Form::InlineStruct);
+                end_materialization();
+            }
             Writer public_functions;
             for (const gir::CallableId id : exports) {
                 if (callable(id).kind == gir::CallableKind::Composition) { emit_function(id, public_functions, Form::OutOfLine); }
@@ -4446,6 +4561,7 @@ namespace hgl::codegen
             }
             for (const gir::CallableId id : impls) {
                 const gir::Callable &implementation = callable(id);
+                if (!implementation.generics.empty()) { continue; }
                 const auto contract = std::find_if(graph_.operators.begin(), graph_.operators.end(), [&](const auto &candidate) {
                     return candidate.identity == implementation.operator_identity;
                 });
@@ -4457,6 +4573,21 @@ namespace hgl::codegen
                                                      : "hgraph::register_graph_overload";
                 body.line(registration + "<operators::" + cpp_name(local_identity(contract->identity)) + ", " +
                           callable_cpp_name(id) + ">();");
+            }
+            for (std::size_t index = 0; index < graph_.materializations.size(); ++index) {
+                const gir::Materialization &materialization = graph_.materializations[index];
+                const gir::Callable        &implementation  = callable(materialization.implementation, materialization.range);
+                const auto contract = std::find_if(graph_.operators.begin(), graph_.operators.end(), [&](const auto &candidate) {
+                    return candidate.identity == implementation.operator_identity;
+                });
+                if (contract == graph_.operators.end() || contract->imported) {
+                    unsupported(implementation.range, "an instantiated impl fn of an imported operator");
+                }
+                const std::string registration = implementation.kind == gir::CallableKind::RuntimeNode
+                                                     ? "hgraph::register_overload"
+                                                     : "hgraph::register_graph_overload";
+                body.line(registration + "<operators::" + cpp_name(local_identity(contract->identity)) + ", " +
+                          materialization_cpp_name(materialization, index) + ">();");
             }
             body.close(");");
             body.open("auto rollback = hgraph::make_scope_exit<true>([&]");

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -633,6 +633,7 @@ namespace hgl::codegen
             std::size_t                                         traversal_index_{0};
             PlannedTypeBindings                                 materialized_types_{};
             std::unordered_map<std::uint32_t, gir::ConstExprId> materialized_values_{};
+            std::unordered_set<std::uint32_t>                   retained_generics_{};
             std::string                                         materialized_cpp_name_{};
             std::string                                         materialized_identity_{};
             gir::CallableId                                     materialized_callable_{};
@@ -672,7 +673,9 @@ namespace hgl::codegen
             materialized_callable_      = saved;
             for (const gir::Substitution &substitution : item.substitutions) {
                 result += "__";
-                if (substitution.type.valid()) {
+                if (substitution.retained) {
+                    result += "any_" + cpp_name(planned_binding(substitution.parameter, item.range).name);
+                } else if (substitution.type.valid()) {
                     const gir::Type &type = graph_type(substitution.type, item.range);
                     if (type.kind == hir::TypeKind::Scalar) {
                         result += hir::scalar_type_name(type.scalar);
@@ -713,11 +716,17 @@ namespace hgl::codegen
             }
             materialized_types_.clear();
             materialized_values_.clear();
+            retained_generics_.clear();
             for (const gir::Substitution &substitution : item.substitutions) {
                 if (!substitution.parameter.valid()) {
                     backend(item.range, "hgraph IR materialization has an invalid generic binding");
                 }
-                if (substitution.type.valid()) {
+                if (substitution.retained) {
+                    if (substitution.type.valid() || substitution.value.valid() || substitution.constant) {
+                        backend(item.range, "hgraph IR retained generic also has a concrete binding");
+                    }
+                    retained_generics_.insert(substitution.parameter.value);
+                } else if (substitution.type.valid()) {
                     materialized_types_.emplace(substitution.parameter.value, planned_type(substitution.type, item.range));
                 } else if (substitution.value.valid()) {
                     materialized_values_.emplace(substitution.parameter.value, substitution.value);
@@ -725,8 +734,9 @@ namespace hgl::codegen
                     backend(item.range, "hgraph IR materialization leaves a generic argument unresolved");
                 }
             }
-            if (materialized_types_.size() + materialized_values_.size() != implementation.generics.size()) {
-                backend(item.range, "hgraph IR materialization does not bind every implementation generic");
+            if (materialized_types_.size() + materialized_values_.size() + retained_generics_.size() !=
+                implementation.generics.size()) {
+                backend(item.range, "hgraph IR materialization does not classify every implementation generic");
             }
             materialized_cpp_name_ = materialization_cpp_name(item, index);
             if (item.identity.empty()) { backend(item.range, "hgraph IR materialization has no candidate identity"); }
@@ -737,6 +747,7 @@ namespace hgl::codegen
         void Emitter::end_materialization() {
             materialized_types_.clear();
             materialized_values_.clear();
+            retained_generics_.clear();
             materialized_cpp_name_.clear();
             materialized_identity_.clear();
             materialized_callable_ = {};
@@ -930,6 +941,9 @@ namespace hgl::codegen
                     if (expression.parameter_binding.valid()) {
                         const auto found = materialized_values_.find(expression.parameter_binding.value);
                         if (found != materialized_values_.end()) { return planned_constant(found->second, range); }
+                        if (retained_generics_.contains(expression.parameter_binding.value)) {
+                            unsupported(range, "a retained generic used as a value; generic reification");
+                        }
                     }
                     unsupported(range, "an unmaterialized generic parameter in a generated constant expression");
                 case gir::ConstExprKind::Index: unsupported(range, "an indexed generated constant expression");
@@ -1045,12 +1059,23 @@ namespace hgl::codegen
                         result.kind = HType::Kind::List;
                         result.children.push_back(planned_type(type.children.front(), range, bindings));
                         if (type.size.valid()) {
-                            // The checker owns the size rules (type_check.cpp,
-                            // check_type_shape); a symbolic size is a backend limit.
                             const std::optional<std::int64_t> size = planned_integer(type.size, range);
-                            if (!size) { unsupported(range, "a list size given by a const generic"); }
-                            if (*size <= 0) { backend(range, "typed HIR admitted a non-positive list size"); }
-                            result.size = std::to_string(*size);
+                            if (size) {
+                                if (*size <= 0) { backend(range, "typed HIR admitted a non-positive list size"); }
+                                result.size = std::to_string(*size);
+                            } else {
+                                const gir::ConstExpr &expression = graph_constant(type.size, range);
+                                if (expression.kind != gir::ConstExprKind::Parameter || !expression.parameter_binding.valid() ||
+                                    (materialized_callable_.valid() &&
+                                     !retained_generics_.contains(expression.parameter_binding.value))) {
+                                    unsupported(range, "a list size given by an unmaterialized const generic");
+                                }
+                                const gir::Binding &binding = planned_binding(expression.parameter_binding, range);
+                                if (binding.kind != gir::BindingKind::ConstParameter) {
+                                    backend(range, "a retained list size does not name a const generic");
+                                }
+                                result.size = "hgraph::SIZE<" + quote(binding.name) + ">";
+                            }
                         }
                         return result;
                     }
@@ -1770,6 +1795,15 @@ namespace hgl::codegen
                         }
                         const auto found = frame.planned_bindings.find(reference.binding.value);
                         if (found == frame.planned_bindings.end()) {
+                            if (binding.kind == gir::BindingKind::ConstParameter) {
+                                if (const auto materialized = materialized_values_.find(reference.binding.value);
+                                    materialized != materialized_values_.end()) {
+                                    return planned_constant(materialized->second, range);
+                                }
+                                if (retained_generics_.contains(reference.binding.value)) {
+                                    unsupported(range, "a retained generic used as a value; generic reification");
+                                }
+                            }
                             backend(range, "'" + binding.name + "' is not bound in this function");
                         }
                         Value result = found->second;
@@ -2950,6 +2984,9 @@ namespace hgl::codegen
             }
 
             if (iterator.type.kind == HType::Kind::List && !iterator.type.size.empty()) {
+                if (iterator.type.size.starts_with("hgraph::SIZE<")) {
+                    unsupported(iterable_expression.range, "graph traversal over a list whose size remains a resolver generic");
+                }
                 const std::int64_t count = std::stoll(iterator.type.size);
                 for (std::int64_t index = 0; index < count; ++index) {
                     Frame iteration = frame;
@@ -4088,7 +4125,7 @@ namespace hgl::codegen
 
         std::string Emitter::signature(gir::CallableId decl, bool with_names) {
             const gir::Callable     &fn = callable(decl);
-            std::vector<std::string> params{with_names ? "hgraph::Wiring &w" : "hgraph::Wiring &"};
+            std::vector<std::string> params{with_names ? "[[maybe_unused]] hgraph::Wiring &w" : "hgraph::Wiring &"};
             for (const gir::Parameter &param : fn.parameters) {
                 const HType       type  = planned_type(param.type, fn.range);
                 const SourceRange range = graph_type(param.type, fn.range).range;

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -494,6 +494,7 @@ namespace hgl::codegen
                                                                              SourceRange fallback);
             [[nodiscard]] const gir::Type           &graph_type(gir::TypeId id, SourceRange fallback);
             [[nodiscard]] const gir::ConstExpr      &graph_constant(gir::ConstExprId id, SourceRange fallback);
+            [[nodiscard]] gir::ConstExprId           materialized_constant(gir::ConstExprId id, SourceRange fallback);
             [[nodiscard]] std::optional<std::int64_t> planned_integer(gir::ConstExprId id, SourceRange fallback);
             [[nodiscard]] bool                        has_planned_result(gir::TypeId id, SourceRange fallback);
             [[nodiscard]] Value                       planned_constant(gir::ConstExprId id, SourceRange fallback = {});
@@ -886,12 +887,20 @@ namespace hgl::codegen
             return graph_.types[id.value].kind != ir::hir::TypeKind::Void;
         }
 
-        std::optional<std::int64_t> Emitter::planned_integer(gir::ConstExprId id, SourceRange fallback) {
-            const gir::ConstExpr &expression = graph_constant(id, fallback);
-            if (expression.kind == gir::ConstExprKind::Parameter && expression.parameter_binding.valid()) {
+        gir::ConstExprId Emitter::materialized_constant(gir::ConstExprId id, SourceRange fallback) {
+            std::unordered_set<std::uint32_t> seen;
+            while (true) {
+                const gir::ConstExpr &expression = graph_constant(id, fallback);
+                if (expression.kind != gir::ConstExprKind::Parameter || !expression.parameter_binding.valid()) { return id; }
                 const auto found = materialized_values_.find(expression.parameter_binding.value);
-                if (found != materialized_values_.end()) { return planned_integer(found->second, fallback); }
+                if (found == materialized_values_.end()) { return id; }
+                if (!seen.insert(id.value).second) { backend(fallback, "cyclic materialized constant substitution"); }
+                id = found->second;
             }
+        }
+
+        std::optional<std::int64_t> Emitter::planned_integer(gir::ConstExprId id, SourceRange fallback) {
+            const gir::ConstExpr &expression = graph_constant(materialized_constant(id, fallback), fallback);
             if (expression.kind != gir::ConstExprKind::Literal || !expression.literal) { return std::nullopt; }
             if (const auto *value = std::get_if<std::int64_t>(&*expression.literal)) { return *value; }
             return std::nullopt;
@@ -1103,8 +1112,9 @@ namespace hgl::codegen
                         result.kind = HType::Kind::Rolling;
                         result.children.push_back(planned_type(type.children.front(), range, bindings));
                         if (!type.size.valid()) { return result; }
-                        const gir::ConstExpr &maximum     = graph_constant(type.size, range);
-                        const auto            maximum_i64 = planned_integer(type.size, range);
+                        const gir::ConstExprId maximum_id  = materialized_constant(type.size, range);
+                        const gir::ConstExpr  &maximum     = graph_constant(maximum_id, range);
+                        const auto             maximum_i64 = planned_integer(maximum_id, range);
                         if (maximum_i64) {
                             if (*maximum_i64 <= 0) { backend(range, "typed HIR admitted a non-positive rolling size"); }
                             result.size                               = std::to_string(*maximum_i64);
@@ -1123,7 +1133,7 @@ namespace hgl::codegen
                         }
                         if (const auto *size = std::get_if<syntax::TemporalValue>(&*maximum.literal);
                             size != nullptr && size->kind == syntax::TemporalKind::Duration) {
-                            const gir::ConstExpr &minimum = graph_constant(type.min_size, range);
+                            const gir::ConstExpr &minimum = graph_constant(materialized_constant(type.min_size, range), range);
                             const auto           *minimum_value =
                                 minimum.literal ? std::get_if<syntax::TemporalValue>(&*minimum.literal) : nullptr;
                             if (minimum.kind != gir::ConstExprKind::Literal) {

--- a/language/src/descriptor/module_descriptor.cpp
+++ b/language/src/descriptor/module_descriptor.cpp
@@ -112,6 +112,32 @@ namespace hgl::descriptor
                 return snapshot;
             }
 
+            [[nodiscard]] Signature materialized_signature(const hgraph_ir::Callable        &callable,
+                                                           const hgraph_ir::Materialization &materialization) {
+                MaterializedBindings bindings;
+                for (const hgraph_ir::Substitution &substitution : materialization.substitutions) {
+                    if (!substitution.parameter.valid()) { continue; }
+                    if (substitution.type.valid()) {
+                        bindings.types.emplace(substitution.parameter.value, substitution.type);
+                    } else if (substitution.value.valid()) {
+                        bindings.values.emplace(substitution.parameter.value, substitution.value);
+                    }
+                }
+
+                Signature snapshot;
+                for (const hgraph_ir::Parameter &parameter : callable.parameters) {
+                    snapshot.parameters.push_back(Parameter{
+                        .name             = parameter.name,
+                        .binding_identity = binding_identity(parameter.binding, parameter.name),
+                        .is_const         = parameter.is_const,
+                        .type             = type(parameter.type, &bindings),
+                        .default_value    = constant(parameter.default_value, &bindings),
+                    });
+                }
+                snapshot.result = type(callable.result, &bindings);
+                return snapshot;
+            }
+
             [[nodiscard]] StructField field(const hgraph_ir::StructField &source) {
                 return StructField{
                     .name            = source.name,
@@ -125,22 +151,47 @@ namespace hgl::descriptor
             [[nodiscard]] SchemaId type_reference(hgraph_ir::TypeId source) { return type(source); }
 
           private:
+            struct MaterializedBindings
+            {
+                std::unordered_map<std::uint32_t, hgraph_ir::TypeId>      types{};
+                std::unordered_map<std::uint32_t, hgraph_ir::ConstExprId> values{};
+                mutable std::unordered_map<std::uint32_t, SchemaId>       type_records{};
+                mutable std::unordered_map<std::uint32_t, SchemaId>       constant_records{};
+            };
+
             [[nodiscard]] std::string binding_identity(hgraph_ir::BindingId id, std::string_view fallback) const {
                 if (!id.valid()) { return std::string{fallback}; }
                 const hgraph_ir::Binding &binding = source_.bindings.at(id.value);
                 return binding.owner_identity.empty() ? binding.name : binding.owner_identity + "::" + binding.name;
             }
 
-            [[nodiscard]] SchemaId type(hgraph_ir::TypeId source_id) {
+            [[nodiscard]] SchemaId type(hgraph_ir::TypeId source_id, const MaterializedBindings *bindings = nullptr) {
                 if (!source_id.valid()) { return no_schema_id; }
-                if (const auto found = types_.find(source_id.value); found != types_.end()) { return found->second; }
+                const hgraph_ir::Type &source = source_.types.at(source_id.value);
+                if (bindings != nullptr && source.binding.valid()) {
+                    if (const auto found = bindings->types.find(source.binding.value); found != bindings->types.end()) {
+                        const SchemaId result = type(found->second, bindings);
+                        bindings->type_records.emplace(source_id.value, result);
+                        return result;
+                    }
+                }
+                if (bindings != nullptr) {
+                    if (const auto found = bindings->type_records.find(source_id.value); found != bindings->type_records.end()) {
+                        return found->second;
+                    }
+                } else {
+                    if (const auto found = types_.find(source_id.value); found != types_.end()) { return found->second; }
+                }
 
                 const SchemaId id{static_cast<SchemaId>(result_.types.size())};
-                types_.emplace(source_id.value, id);
+                if (bindings != nullptr) {
+                    bindings->type_records.emplace(source_id.value, id);
+                } else {
+                    types_.emplace(source_id.value, id);
+                }
                 result_.types.emplace_back();
 
-                const hgraph_ir::Type &source = source_.types.at(source_id.value);
-                TypeRecord             record;
+                TypeRecord record;
                 record.category         = type_category(source.kind);
                 record.scalar_name      = source.kind == ir::hir::TypeKind::Scalar
                                               ? std::string{ir::hir::scalar_type_name(source.scalar)}
@@ -148,30 +199,49 @@ namespace hgl::descriptor
                 record.nominal_identity = source.nominal_identity;
                 if (source.binding.valid()) { record.binding_identity = binding_identity(source.binding, source.nominal_identity); }
                 record.unbounded = source.unbounded;
-                for (hgraph_ir::TypeId child : source.children) { record.children.push_back(type(child)); }
+                for (hgraph_ir::TypeId child : source.children) { record.children.push_back(type(child, bindings)); }
                 for (const hgraph_ir::TypeArgument &argument : source.arguments) {
                     if (argument.type) {
-                        record.arguments.push_back(TypeArgument{TypeArgumentCategory::Type, type(*argument.type)});
+                        record.arguments.push_back(TypeArgument{TypeArgumentCategory::Type, type(*argument.type, bindings)});
                     } else if (argument.value) {
-                        record.arguments.push_back(TypeArgument{TypeArgumentCategory::Constant, constant(*argument.value)});
+                        record.arguments.push_back(
+                            TypeArgument{TypeArgumentCategory::Constant, constant(*argument.value, bindings)});
                     }
                 }
-                record.size       = constant(source.size);
-                record.min_size   = constant(source.min_size);
+                record.size       = constant(source.size, bindings);
+                record.min_size   = constant(source.min_size, bindings);
                 result_.types[id] = std::move(record);
                 return id;
             }
 
-            [[nodiscard]] SchemaId constant(hgraph_ir::ConstExprId source_id) {
+            [[nodiscard]] SchemaId constant(hgraph_ir::ConstExprId source_id, const MaterializedBindings *bindings = nullptr) {
                 if (!source_id.valid()) { return no_schema_id; }
-                if (const auto found = constants_.find(source_id.value); found != constants_.end()) { return found->second; }
+                const hgraph_ir::ConstExpr &source = source_.const_exprs.at(source_id.value);
+                if (bindings != nullptr && source.parameter_binding.valid()) {
+                    if (const auto found = bindings->values.find(source.parameter_binding.value); found != bindings->values.end()) {
+                        const SchemaId result = constant(found->second, bindings);
+                        bindings->constant_records.emplace(source_id.value, result);
+                        return result;
+                    }
+                }
+                if (bindings != nullptr) {
+                    if (const auto found = bindings->constant_records.find(source_id.value);
+                        found != bindings->constant_records.end()) {
+                        return found->second;
+                    }
+                } else {
+                    if (const auto found = constants_.find(source_id.value); found != constants_.end()) { return found->second; }
+                }
 
                 const SchemaId id{static_cast<SchemaId>(result_.constant_expressions.size())};
-                constants_.emplace(source_id.value, id);
+                if (bindings != nullptr) {
+                    bindings->constant_records.emplace(source_id.value, id);
+                } else {
+                    constants_.emplace(source_id.value, id);
+                }
                 result_.constant_expressions.emplace_back();
 
-                const hgraph_ir::ConstExpr &source = source_.const_exprs.at(source_id.value);
-                ConstantExpressionRecord    record;
+                ConstantExpressionRecord record;
                 record.category           = constant_category(source.kind);
                 record.literal            = source.literal;
                 record.parameter_identity = binding_identity(source.parameter_binding, source.parameter);
@@ -180,16 +250,16 @@ namespace hgl::descriptor
                 } else if (source.kind == hgraph_ir::ConstExprKind::Binary) {
                     record.operator_spelling = ir::hir::binary_op_spelling(source.binary);
                 }
-                record.lhs    = constant(source.lhs);
-                record.rhs    = constant(source.rhs);
+                record.lhs    = constant(source.lhs, bindings);
+                record.rhs    = constant(source.rhs, bindings);
                 record.member = source.member;
                 for (const hgraph_ir::ConstElement &element : source.elements) {
-                    record.elements.push_back(ConstantElement{constant(element.key), constant(element.value)});
+                    record.elements.push_back(ConstantElement{constant(element.key, bindings), constant(element.value, bindings)});
                 }
-                for (hgraph_ir::ConstExprId item : source.items) { record.items.push_back(constant(item)); }
-                record.constructed_type = type(source.constructed_type);
+                for (hgraph_ir::ConstExprId item : source.items) { record.items.push_back(constant(item, bindings)); }
+                record.constructed_type = type(source.constructed_type, bindings);
                 for (const hgraph_ir::ConstArgument &argument : source.arguments) {
-                    record.arguments.push_back(ConstantArgument{argument.name, constant(argument.value)});
+                    record.arguments.push_back(ConstantArgument{argument.name, constant(argument.value, bindings)});
                 }
                 record.delta                     = source.delta;
                 result_.constant_expressions[id] = std::move(record);
@@ -335,12 +405,23 @@ namespace hgl::descriptor
         }
         std::ranges::sort(implementations, {}, &hgraph_ir::Callable::identity);
         for (const hgraph_ir::Callable *callable : implementations) {
+            if (!callable->generics.empty()) { continue; }
             result.implementations.push_back(Implementation{
                 .identity               = callable->identity,
                 .operator_identity      = callable->operator_identity,
                 .operator_registry_name = registry_name(callable->operator_registry_name, callable->operator_identity),
                 .execution              = execution_kind(callable->kind),
                 .signature = schema.signature(callable->generics, callable->parameters, callable->result, callable->requirements),
+            });
+        }
+        for (const hgraph_ir::Materialization &materialization : module.materializations) {
+            const hgraph_ir::Callable &callable = module.callables.at(materialization.implementation.value);
+            result.implementations.push_back(Implementation{
+                .identity               = materialization.identity,
+                .operator_identity      = callable.operator_identity,
+                .operator_registry_name = registry_name(callable.operator_registry_name, callable.operator_identity),
+                .execution              = execution_kind(callable.kind),
+                .signature              = schema.materialized_signature(callable, materialization),
             });
         }
 

--- a/language/src/descriptor/module_descriptor.cpp
+++ b/language/src/descriptor/module_descriptor.cpp
@@ -125,6 +125,17 @@ namespace hgl::descriptor
                 }
 
                 Signature snapshot;
+                for (const hgraph_ir::GenericParameter &generic : callable.generics) {
+                    const auto substitution =
+                        std::ranges::find(materialization.substitutions, generic.binding, &hgraph_ir::Substitution::parameter);
+                    if (substitution == materialization.substitutions.end() || !substitution->retained) { continue; }
+                    snapshot.generics.push_back(GenericParameter{
+                        .name             = generic.name,
+                        .binding_identity = binding_identity(generic.binding, generic.name),
+                        .is_const         = generic.is_const,
+                        .type             = type(generic.type, &bindings),
+                    });
+                }
                 for (const hgraph_ir::Parameter &parameter : callable.parameters) {
                     snapshot.parameters.push_back(Parameter{
                         .name             = parameter.name,

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -578,7 +578,8 @@ namespace hgl::driver
             const auto       last  = input.find_first_of(" \t(<{", first);
             std::string_view word  = input.substr(first == std::string_view::npos ? 0 : first,
                                                   last == std::string_view::npos ? std::string_view::npos : last - first);
-            return word == "fn" || word == "export" || word == "impl" || word == "operator" || word == "use" || word == "test";
+            return word == "fn" || word == "export" || word == "impl" || word == "operator" || word == "instantiate" ||
+                   word == "use" || word == "test";
         }
 
         bool is_binding(std::string_view input) {
@@ -669,10 +670,10 @@ namespace hgl::driver
             /// keywords, the kernel modules, and every name the session has
             /// declared or bound.
             std::vector<std::string> completions() const {
-                std::vector<std::string> words{":help",    ":list", ":quit",  "fn",      "export",     "impl",
-                                               "operator", "use",   "test",   "let",     "var",        "assert",
-                                               "eval",     "const", "atomic", "rolling", "hgraph.std", "hgraph.analytics"};
-                const auto               declared = [&](const std::string &text) {
+                std::vector<std::string> words{
+                    ":help", ":list",  ":quit", "fn",    "export", "impl",    "operator",   "instantiate",     "use", "test", "let",
+                    "var",   "assert", "eval",  "const", "atomic", "rolling", "hgraph.std", "hgraph.analytics"};
+                const auto declared = [&](const std::string &text) {
                     // The declared name follows the first keyword(s): `fn name`,
                     // `export fn name`, `impl fn name`, `operator name`,
                     // `test name`, `let name`, `var name`, `use a.b::{x, y}`.

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -313,6 +313,9 @@ namespace hgl::hgraph_ir
         TypeId                           type{};
         ConstExprId                      value{};
         std::optional<ir::hir::Constant> constant{};
+        /// The source generic remains a resolver variable in the generated
+        /// candidate. Its uses may be signature-only or require reification.
+        bool retained{false};
     };
 
     /// Resolved semantic operation attached to a value. Canonical language
@@ -522,9 +525,11 @@ namespace hgl::hgraph_ir
         syntax::SourceRange           range{};
     };
 
-    /// One concrete resolver candidate requested from a generic source
-    /// `impl fn`. The implementation remains hidden; only this substituted
-    /// callable is registered by the generated module lifecycle.
+    /// One resolver candidate requested from a generic source `impl fn`.
+    /// Concrete substitutions specialize the candidate; retained
+    /// substitutions preserve selected generic slots for resolver matching.
+    /// The implementation remains hidden and only this candidate is
+    /// registered by the generated module lifecycle.
     struct Materialization
     {
         std::string               identity{};

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -522,6 +522,17 @@ namespace hgl::hgraph_ir
         syntax::SourceRange           range{};
     };
 
+    /// One concrete resolver candidate requested from a generic source
+    /// `impl fn`. The implementation remains hidden; only this substituted
+    /// callable is registered by the generated module lifecycle.
+    struct Materialization
+    {
+        std::string               identity{};
+        CallableId                implementation{};
+        std::vector<Substitution> substitutions{};
+        syntax::SourceRange       range{};
+    };
+
     struct TestPlan
     {
         std::string         identity{};
@@ -562,6 +573,7 @@ namespace hgl::hgraph_ir
         std::vector<OperatorContract> operators{};
         std::vector<NativeFunction>   native_functions{};
         std::vector<Callable>         callables{};
+        std::vector<Materialization>  materializations{};
         std::vector<Binding>          bindings{};
         std::vector<Value>            values{};
         std::vector<Statement>        statements{};

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -709,6 +709,7 @@ namespace hgl::hgraph_ir
                         .type     = lower_type(substitution.type),
                         .value    = lower_const_expr(substitution.value, range, "an operation substitution"),
                         .constant = substitution.constant,
+                        .retained = substitution.retained,
                     });
                 }
                 return target;
@@ -934,6 +935,7 @@ namespace hgl::hgraph_ir
                     .type               = lower_type(source.type),
                     .value              = lower_const_expr(source.value, range, "an implementation materialization"),
                     .constant           = source.constant,
+                    .retained           = source.retained,
                 };
             }
 

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -37,6 +37,7 @@ namespace hgl::hgraph_ir
                 lower_operators();
                 lower_native_functions();
                 lower_callables();
+                lower_materializations();
                 lower_tests();
                 collect_provider_requirements();
                 lower_source_order();
@@ -926,6 +927,38 @@ namespace hgl::hgraph_ir
                 }
             }
 
+            [[nodiscard]] Substitution lower_substitution(const hir::Substitution &source, syntax::SourceRange range) {
+                return Substitution{
+                    .parameter          = binding(source.parameter),
+                    .parameter_identity = source.parameter.valid() ? binding_identity(source.parameter) : source.name,
+                    .type               = lower_type(source.type),
+                    .value              = lower_const_expr(source.value, range, "an implementation materialization"),
+                    .constant           = source.constant,
+                };
+            }
+
+            void lower_materializations() {
+                for (const hir::Declaration &declaration : source_.declarations) {
+                    const auto *instantiate = std::get_if<hir::InstantiateDecl>(&declaration.node);
+                    if (instantiate == nullptr) { continue; }
+                    for (const hir::Instantiation &request : instantiate->entries) {
+                        for (const hir::Materialization &source : request.materializations) {
+                            Materialization target;
+                            target.implementation = callable(source.implementation);
+                            if (target.implementation.valid()) {
+                                target.identity = result_.callables[target.implementation.value].identity +
+                                                  "@instantiate:" + std::to_string(result_.materializations.size());
+                            }
+                            target.range = source.range;
+                            for (const hir::Substitution &substitution : source.substitutions) {
+                                target.substitutions.push_back(lower_substitution(substitution, source.range));
+                            }
+                            result_.materializations.push_back(std::move(target));
+                        }
+                    }
+                }
+            }
+
             void lower_tests() {
                 for (const hir::Declaration &declaration : source_.declarations) {
                     const auto *source = std::get_if<hir::TestDecl>(&declaration.node);
@@ -947,7 +980,8 @@ namespace hgl::hgraph_ir
 
                     const hir::Declaration &declaration = source_.declaration(source_id);
                     if (std::holds_alternative<hir::ModuleDecl>(declaration.node) ||
-                        std::holds_alternative<hir::UseDecl>(declaration.node)) {
+                        std::holds_alternative<hir::UseDecl>(declaration.node) ||
+                        std::holds_alternative<hir::InstantiateDecl>(declaration.node)) {
                         continue;
                     }
                     diagnostics_.report(syntax::Category::Type, declaration.range, "typed HIR declaration has no hgraph IR handle");

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -275,7 +275,9 @@ namespace hgl::hgraph_ir
                     } else {
                         out << substitution.parameter_identity;
                     }
-                    if (substitution.type.valid()) {
+                    if (substitution.retained) {
+                        out << ":_";
+                    } else if (substitution.type.valid()) {
                         out << ":";
                         print_type_id(out, substitution.type);
                     }
@@ -668,7 +670,9 @@ namespace hgl::hgraph_ir
                 if (index != 0) { out << ", "; }
                 const Substitution &substitution = materialization.substitutions[index];
                 print_binding_id(out, substitution.parameter);
-                if (substitution.type.valid()) {
+                if (substitution.retained) {
+                    out << ":_";
+                } else if (substitution.type.valid()) {
                     out << ':';
                     print_type_id(out, substitution.type);
                 }

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -658,6 +658,33 @@ namespace hgl::hgraph_ir
             out << '\n';
         }
 
+        out << "materializations\n";
+        for (const Materialization &materialization : module.materializations) {
+            out << "  ";
+            print_callable_id(out, materialization.implementation);
+            out << " identity=" << materialization.identity;
+            out << " substitutions=[";
+            for (std::size_t index = 0; index < materialization.substitutions.size(); ++index) {
+                if (index != 0) { out << ", "; }
+                const Substitution &substitution = materialization.substitutions[index];
+                print_binding_id(out, substitution.parameter);
+                if (substitution.type.valid()) {
+                    out << ':';
+                    print_type_id(out, substitution.type);
+                }
+                if (substitution.value.valid()) {
+                    out << '=';
+                    print_const_expr_id(out, substitution.value);
+                } else if (substitution.constant) {
+                    out << '=';
+                    print_constant(out, *substitution.constant);
+                }
+            }
+            out << ']';
+            print_range(out, materialization.range);
+            out << '\n';
+        }
+
         out << "bindings\n";
         for (std::size_t index = 0; index < module.bindings.size(); ++index) {
             static constexpr std::string_view names[]{

--- a/language/src/ir/hir.h
+++ b/language/src/ir/hir.h
@@ -128,6 +128,9 @@ namespace hgl::ir::hir
         TypeId              type{};
         ExprId              value{};
         syntax::SourceRange range{};
+        /// Retain the corresponding implementation generic rather than
+        /// binding it. Used only by explicit materialization requests.
+        bool retained{false};
     };
 
     struct Type
@@ -211,6 +214,8 @@ namespace hgl::ir::hir
         TypeId                  type{};
         ExprId                  value{};
         std::optional<Constant> constant{};
+        /// The parameter remains a resolver variable in this candidate.
+        bool retained{false};
     };
 
     enum class OperationKind : std::uint8_t {

--- a/language/src/ir/hir.h
+++ b/language/src/ir/hir.h
@@ -567,6 +567,21 @@ namespace hgl::ir::hir
         Signature                     signature{};
         ConstraintId                  requirements{};
     };
+    struct Materialization
+    {
+        SymbolId                  implementation{};
+        std::vector<Substitution> substitutions{};
+        syntax::SourceRange       range{};
+    };
+    struct Instantiation
+    {
+        SymbolId                     operator_contract{};
+        std::vector<TypeArgument>    arguments{};
+        std::vector<Materialization> materializations{};
+        syntax::SourceRange          range{};
+    };
+    struct InstantiateDecl
+    { std::vector<Instantiation> entries{}; };
     struct FunctionDecl
     {
         Visibility   visibility{Visibility::Internal};
@@ -583,7 +598,7 @@ namespace hgl::ir::hir
     };
     struct TestDecl
     { BlockId block{}; };
-    using DeclarationNode = std::variant<ModuleDecl, UseDecl, StructDecl, OperatorDecl, FunctionDecl, TestDecl>;
+    using DeclarationNode = std::variant<ModuleDecl, UseDecl, StructDecl, OperatorDecl, InstantiateDecl, FunctionDecl, TestDecl>;
     struct Declaration
     {
         DeclarationId       id{};

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -578,6 +578,28 @@ namespace hgl::ir
                                 print_generics(node.generics);
                                 print_signature(node.signature);
                                 out_ << " requires=" << ref('c', node.requirements);
+                            } else if constexpr (std::is_same_v<T, hir::InstantiateDecl>) {
+                                out_ << "instantiate entries=[";
+                                for (std::size_t entry_index = 0; entry_index < node.entries.size(); ++entry_index) {
+                                    if (entry_index != 0) { out_ << ", "; }
+                                    const hir::Instantiation &entry = node.entries[entry_index];
+                                    out_ << ref('s', entry.operator_contract) << '<';
+                                    for (std::size_t argument = 0; argument < entry.arguments.size(); ++argument) {
+                                        if (argument != 0) { out_ << ", "; }
+                                        if (entry.arguments[argument].kind == hir::TypeArgumentKind::Type) {
+                                            out_ << ref('t', entry.arguments[argument].type);
+                                        } else {
+                                            out_ << ref('e', entry.arguments[argument].value);
+                                        }
+                                    }
+                                    out_ << "> materializations=[";
+                                    for (std::size_t item = 0; item < entry.materializations.size(); ++item) {
+                                        if (item != 0) { out_ << ", "; }
+                                        out_ << ref('s', entry.materializations[item].implementation);
+                                    }
+                                    out_ << ']';
+                                }
+                                out_ << ']';
                             } else if constexpr (std::is_same_v<T, hir::FunctionDecl>) {
                                 static constexpr std::string_view visibility[]{"internal", "export", "impl"};
                                 out_ << visibility[static_cast<std::size_t>(node.visibility)] << ' '

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -586,7 +586,9 @@ namespace hgl::ir
                                     out_ << ref('s', entry.operator_contract) << '<';
                                     for (std::size_t argument = 0; argument < entry.arguments.size(); ++argument) {
                                         if (argument != 0) { out_ << ", "; }
-                                        if (entry.arguments[argument].kind == hir::TypeArgumentKind::Type) {
+                                        if (entry.arguments[argument].retained) {
+                                            out_ << '_';
+                                        } else if (entry.arguments[argument].kind == hir::TypeArgumentKind::Type) {
                                             out_ << ref('t', entry.arguments[argument].type);
                                         } else {
                                             out_ << ref('e', entry.arguments[argument].value);

--- a/language/src/ir/lower.cpp
+++ b/language/src/ir/lower.cpp
@@ -382,6 +382,13 @@ namespace hgl::ir
                             mark_generics(node.generics, declaration);
                             mark_signature(node.signature, declaration);
                             mark_constraint(node.requirements, declaration);
+                        } else if constexpr (std::is_same_v<T, ast::InstantiateDecl>) {
+                            for (const ast::Instantiation &entry : node.entries) {
+                                for (const ast::GenericArgument &argument : entry.arguments) {
+                                    mark_type(argument.type, declaration);
+                                    mark_expr(argument.value, declaration);
+                                }
+                            }
                         } else if constexpr (std::is_same_v<T, ast::FunctionDecl>) {
                             mark_generics(node.generics, declaration);
                             mark_signature(node.signature, declaration);
@@ -1075,6 +1082,33 @@ namespace hgl::ir
                             target.node =
                                 hir::OperatorDecl{lower_generics(index, node.generics), lower_signature(index, node.signature),
                                                   id<hir::ConstraintId>(node.requirements)};
+                        } else if constexpr (std::is_same_v<T, ast::InstantiateDecl>) {
+                            hir::InstantiateDecl                   instantiate;
+                            const std::vector<semantics::Binding> &bindings = resolved_.instantiation_binding(index);
+                            for (std::size_t entry_index = 0; entry_index < node.entries.size(); ++entry_index) {
+                                const ast::Instantiation &source_entry = node.entries[entry_index];
+                                hir::Instantiation        entry;
+                                entry.range = source_entry.range;
+                                if (entry_index < bindings.size() &&
+                                    bindings[entry_index].kind != semantics::BindingKind::Unbound) {
+                                    entry.operator_contract =
+                                        symbol_for(bindings[entry_index], source_entry.name.range, source_entry.name.text);
+                                }
+                                for (const ast::GenericArgument &argument : source_entry.arguments) {
+                                    hir::TypeArgument lowered;
+                                    lowered.range = argument.range;
+                                    if (argument.type != ast::no_node) {
+                                        lowered.kind = hir::TypeArgumentKind::Type;
+                                        lowered.type = id<hir::TypeId>(argument.type);
+                                    } else {
+                                        lowered.kind  = hir::TypeArgumentKind::Value;
+                                        lowered.value = id<hir::ExprId>(argument.value);
+                                    }
+                                    entry.arguments.push_back(std::move(lowered));
+                                }
+                                instantiate.entries.push_back(std::move(entry));
+                            }
+                            target.node = std::move(instantiate);
                         } else if constexpr (std::is_same_v<T, ast::FunctionDecl>) {
                             hir::FunctionDecl function;
                             function.visibility = lower_visibility(node.visibility);

--- a/language/src/ir/lower.cpp
+++ b/language/src/ir/lower.cpp
@@ -1096,8 +1096,11 @@ namespace hgl::ir
                                 }
                                 for (const ast::GenericArgument &argument : source_entry.arguments) {
                                     hir::TypeArgument lowered;
-                                    lowered.range = argument.range;
-                                    if (argument.type != ast::no_node) {
+                                    lowered.range    = argument.range;
+                                    lowered.retained = argument.retained;
+                                    if (argument.retained) {
+                                        lowered.kind = hir::TypeArgumentKind::Type;
+                                    } else if (argument.type != ast::no_node) {
                                         lowered.kind = hir::TypeArgumentKind::Type;
                                         lowered.type = id<hir::TypeId>(argument.type);
                                     } else {

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -224,6 +224,7 @@ namespace hgl::ir
                 for (std::size_t index = 0; index < implementation.generics.size(); ++index) {
                     const GenericParameter &generic  = implementation.generics[index];
                     const TypeArgument     &argument = request.arguments[index];
+                    if (argument.retained) { continue; }
                     if (generic.is_const) {
                         if (argument.kind != TypeArgumentKind::Value || !argument.value.valid()) { return false; }
                         Expr &value = check_expr(argument.value, generic.type);
@@ -264,11 +265,34 @@ namespace hgl::ir
                 for (std::size_t index = 0; index < lhs.substitutions.size(); ++index) {
                     const Substitution &a = lhs.substitutions[index];
                     const Substitution &b = rhs.substitutions[index];
-                    if (a.parameter != b.parameter || a.type.valid() != b.type.valid() || a.value.valid() != b.value.valid()) {
+                    if (a.parameter != b.parameter || a.retained != b.retained || a.type.valid() != b.type.valid() ||
+                        a.value.valid() != b.value.valid()) {
                         return false;
                     }
                     if (a.type.valid() && !same(a.type, b.type)) { return false; }
                     if (a.value.valid() && !canonical_types_.same_value(a.value, b.value)) { return false; }
+                }
+                return true;
+            }
+
+            /// A partially materialized candidate is a pattern: every
+            /// concrete binding must agree with the call substitution, while
+            /// a retained slot accepts the value inferred by the resolver.
+            [[nodiscard]] bool materialization_accepts(const Materialization &candidate, const Materialization &requested) {
+                if (candidate.implementation != requested.implementation ||
+                    candidate.substitutions.size() != requested.substitutions.size()) {
+                    return false;
+                }
+                for (std::size_t index = 0; index < candidate.substitutions.size(); ++index) {
+                    const Substitution &published = candidate.substitutions[index];
+                    const Substitution &actual    = requested.substitutions[index];
+                    if (published.parameter != actual.parameter) { return false; }
+                    if (published.retained) { continue; }
+                    if (published.type.valid() != actual.type.valid() || published.value.valid() != actual.value.valid()) {
+                        return false;
+                    }
+                    if (published.type.valid() && !same(published.type, actual.type)) { return false; }
+                    if (published.value.valid() && !canonical_types_.same_value(published.value, actual.value)) { return false; }
                 }
                 return true;
             }
@@ -294,6 +318,15 @@ namespace hgl::ir
                                                   "operator implementation instantiation", false)) {
                         continue;
                     }
+                    bool retained_was_bound = false;
+                    for (std::size_t index = 0; index < implementation->generics.size(); ++index) {
+                        if (!request.arguments[index].retained) { continue; }
+                        const GenericParameter &generic = implementation->generics[index];
+                        retained_was_bound =
+                            generic.is_const ? bindings.has_value(generic.symbol) : bindings.has_type(generic.symbol);
+                        if (retained_was_bound) { break; }
+                    }
+                    if (retained_was_bound) { continue; }
                     if (!contract_accepts_materialization(*contract, *implementation, bindings, request.range)) { continue; }
                     matched = true;
 
@@ -301,7 +334,9 @@ namespace hgl::ir
                     materialization.implementation = declaration.symbol;
                     materialization.substitutions  = bindings.materialize(implementation->generics);
                     materialization.range          = request.range;
-                    for (Substitution &substitution : materialization.substitutions) {
+                    for (std::size_t index = 0; index < materialization.substitutions.size(); ++index) {
+                        Substitution &substitution = materialization.substitutions[index];
+                        substitution.retained      = request.arguments[index].retained;
                         if (substitution.value.valid()) { substitution.constant = module_.expr(substitution.value).constant; }
                     }
                     const bool duplicate = std::ranges::any_of(materializations_, [&](const Materialization &existing) {
@@ -1534,7 +1569,7 @@ namespace hgl::ir
                     const Materialization requested{.implementation = candidates.front(),
                                                     .substitutions  = std::move(substitutions)};
                     if (!std::ranges::any_of(materializations_, [&](const Materialization &materialization) {
-                            return same_materialization(materialization, requested);
+                            return materialization_accepts(materialization, requested);
                         })) {
                         return {};
                     }

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -104,6 +104,7 @@ namespace hgl::ir
                 check_type_expressions();
                 canonical_types_.initialize();
                 void_type_ = canonical_types_.void_type();
+                check_instantiations();
                 for (DeclarationId declaration : module_.source_order) { check_declaration(declaration); }
                 ir::check_definite_assignment(module_, diagnostics_);
                 validate_completion();
@@ -214,6 +215,115 @@ namespace hgl::ir
                 }
                 if (!conforms) {
                     type_error(declaration.range, "implementation signature does not conform to its operator contract");
+                }
+            }
+
+            [[nodiscard]] bool bind_instantiation_arguments(const Instantiation &request, const FunctionDecl &implementation,
+                                                            detail::GenericSubstitution &substitution) {
+                if (implementation.generics.size() != request.arguments.size()) { return false; }
+                for (std::size_t index = 0; index < implementation.generics.size(); ++index) {
+                    const GenericParameter &generic  = implementation.generics[index];
+                    const TypeArgument     &argument = request.arguments[index];
+                    if (generic.is_const) {
+                        if (argument.kind != TypeArgumentKind::Value || !argument.value.valid()) { return false; }
+                        Expr &value = check_expr(argument.value, generic.type);
+                        if (value.phase != Phase::Constant) { return false; }
+                        if (!canonical_types_.assignable(generic.type, value.type)) { return false; }
+                        if (!substitution.bind_value(generic.symbol, argument.value)) { return false; }
+                    } else {
+                        if (argument.kind != TypeArgumentKind::Type || !argument.type.valid()) { return false; }
+                        const TypeId concrete = canonical(argument.type);
+                        if (!concrete.valid() || !substitution.bind_type(generic.symbol, concrete)) { return false; }
+                    }
+                }
+                return true;
+            }
+
+            [[nodiscard]] bool contract_accepts_materialization(const OperatorDecl &contract, const FunctionDecl &implementation,
+                                                                detail::GenericSubstitution &implementation_bindings,
+                                                                syntax::SourceRange          range) {
+                detail::GenericSubstitution contract_bindings{module_, canonical_types_};
+                if (contract.signature.parameters.size() != implementation.signature.parameters.size()) { return false; }
+                for (std::size_t index = 0; index < contract.signature.parameters.size(); ++index) {
+                    if (!contract_bindings.unify(contract.signature.parameters[index].type,
+                                                 implementation_bindings.apply(implementation.signature.parameters[index].type))) {
+                        return false;
+                    }
+                }
+                if (!contract_bindings.unify(contract.signature.result,
+                                             implementation_bindings.apply(implementation.signature.result))) {
+                    return false;
+                }
+                return constraint_solver_.solve(contract.requirements, contract_bindings, range, "operator instantiation", false);
+            }
+
+            [[nodiscard]] bool same_materialization(const Materialization &lhs, const Materialization &rhs) {
+                if (lhs.implementation != rhs.implementation || lhs.substitutions.size() != rhs.substitutions.size()) {
+                    return false;
+                }
+                for (std::size_t index = 0; index < lhs.substitutions.size(); ++index) {
+                    const Substitution &a = lhs.substitutions[index];
+                    const Substitution &b = rhs.substitutions[index];
+                    if (a.parameter != b.parameter || a.type.valid() != b.type.valid() || a.value.valid() != b.value.valid()) {
+                        return false;
+                    }
+                    if (a.type.valid() && !same(a.type, b.type)) { return false; }
+                    if (a.value.valid() && !canonical_types_.same_value(a.value, b.value)) { return false; }
+                }
+                return true;
+            }
+
+            void check_instantiation(Instantiation &request) {
+                if (!request.operator_contract.valid()) { return; }
+                const OperatorDecl *contract = operator_decl(request.operator_contract);
+                if (contract == nullptr) {
+                    type_error(request.range, "instantiate names no local operator contract");
+                    return;
+                }
+
+                bool matched = false;
+                for (Declaration &declaration : module_.declarations) {
+                    auto *implementation = std::get_if<FunctionDecl>(&declaration.node);
+                    if (implementation == nullptr || implementation->visibility != Visibility::Implementation ||
+                        implementation->operator_contract != request.operator_contract || implementation->generics.empty()) {
+                        continue;
+                    }
+                    detail::GenericSubstitution bindings{module_, canonical_types_};
+                    if (!bind_instantiation_arguments(request, *implementation, bindings)) { continue; }
+                    if (!constraint_solver_.solve(implementation->requirements, bindings, request.range,
+                                                  "operator implementation instantiation", false)) {
+                        continue;
+                    }
+                    if (!contract_accepts_materialization(*contract, *implementation, bindings, request.range)) { continue; }
+                    matched = true;
+
+                    Materialization materialization;
+                    materialization.implementation = declaration.symbol;
+                    materialization.substitutions  = bindings.materialize(implementation->generics);
+                    materialization.range          = request.range;
+                    for (Substitution &substitution : materialization.substitutions) {
+                        if (substitution.value.valid()) { substitution.constant = module_.expr(substitution.value).constant; }
+                    }
+                    const bool duplicate = std::ranges::any_of(materializations_, [&](const Materialization &existing) {
+                        return same_materialization(existing, materialization);
+                    });
+                    if (duplicate) {
+                        type_error(request.range, "operator implementation is instantiated more than once with the same arguments");
+                        continue;
+                    }
+                    materializations_.push_back(materialization);
+                    request.materializations.push_back(std::move(materialization));
+                }
+                if (!matched) { type_error(request.range, "instantiate matches no local generic operator implementation"); }
+            }
+
+            void check_instantiations() {
+                for (DeclarationId declaration_id : module_.source_order) {
+                    if (!declaration_id.valid()) { continue; }
+                    auto *declaration = std::get_if<InstantiateDecl>(&module_.declarations[declaration_id.value].node);
+                    if (declaration == nullptr) { continue; }
+                    validate_owned_type_applications(declaration_id);
+                    for (Instantiation &request : declaration->entries) { check_instantiation(request); }
                 }
             }
 
@@ -347,6 +457,9 @@ namespace hgl::ir
                             active_requirements_ = node.requirements;
                             validate_owned_type_applications(id);
                             check_signature_defaults(node.signature);
+                        } else if constexpr (std::is_same_v<T, InstantiateDecl>) {
+                            // Materializations are checked as one module-level set
+                            // before bodies so source order cannot affect availability.
                         } else if constexpr (std::is_same_v<T, FunctionDecl>) {
                             active_native_phase_ =
                                 node.kind == FunctionKind::Runtime ? NativePhase::Evaluation : NativePhase::Wiring;
@@ -1362,7 +1475,7 @@ namespace hgl::ir
             }
 
             [[nodiscard]] bool local_candidate_matches(const FunctionDecl &candidate, const std::vector<ExprId> &arguments,
-                                                       TypeId expected) {
+                                                       TypeId expected, std::vector<Substitution> *substitutions = nullptr) {
                 if (candidate.signature.parameters.size() != arguments.size()) { return false; }
                 detail::GenericSubstitution bindings{module_, canonical_types_};
                 for (std::size_t index = 0; index < arguments.size(); ++index) {
@@ -1389,6 +1502,12 @@ namespace hgl::ir
                         return false;
                     }
                 }
+                if (substitutions != nullptr) {
+                    *substitutions = bindings.materialize(candidate.generics);
+                    for (Substitution &substitution : *substitutions) {
+                        if (substitution.value.valid()) { substitution.constant = module_.expr(substitution.value).constant; }
+                    }
+                }
                 return true;
             }
 
@@ -1408,8 +1527,19 @@ namespace hgl::ir
                 const Symbol &symbol = module_.symbol(candidates.front());
                 const auto   *candidate =
                     symbol.owner.valid() ? std::get_if<FunctionDecl>(&module_.declaration(symbol.owner).node) : nullptr;
-                return candidate != nullptr && local_candidate_matches(*candidate, arguments, expected) ? candidates.front()
-                                                                                                        : SymbolId{};
+                if (candidate == nullptr) { return {}; }
+                std::vector<Substitution> substitutions;
+                if (!local_candidate_matches(*candidate, arguments, expected, &substitutions)) { return {}; }
+                if (!candidate->generics.empty()) {
+                    const Materialization requested{.implementation = candidates.front(),
+                                                    .substitutions  = std::move(substitutions)};
+                    if (!std::ranges::any_of(materializations_, [&](const Materialization &materialization) {
+                            return same_materialization(materialization, requested);
+                        })) {
+                        return {};
+                    }
+                }
+                return candidates.front();
             }
 
             void check_local_operator_call(Expr &expression, const Call &call, SymbolId target, const OperatorDecl &op,
@@ -2281,6 +2411,7 @@ namespace hgl::ir
             ConstraintId                               active_requirements_{};
             ConstraintId                               inherited_requirements_{};
             std::optional<detail::GenericSubstitution> inherited_substitution_{};
+            std::vector<Materialization>               materializations_{};
             Expr                                       missing_expression_{};
         };
     }  // namespace

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -46,6 +46,7 @@ namespace hgl::semantics
                 result_.type_bindings.resize(module.types.size());
                 result_.constraint_bindings.resize(module.constraints.size());
                 result_.implementation_bindings.resize(module.decls.size());
+                result_.instantiation_bindings.resize(module.decls.size());
                 result_.kinds.resize(module.decls.size(), FunctionKind::Composition);
                 result_.struct_info.resize(module.decls.size());
             }
@@ -60,6 +61,8 @@ namespace hgl::semantics
                         resolve_function(id, *fn);
                     } else if (const auto *op = std::get_if<ast::OperatorDecl>(&decl.node)) {
                         resolve_operator(id, *op);
+                    } else if (const auto *instantiate = std::get_if<ast::InstantiateDecl>(&decl.node)) {
+                        resolve_instantiation(id, *instantiate);
                     } else if (const auto *test = std::get_if<ast::TestDecl>(&decl.node)) {
                         resolve_test(id, *test);
                     }
@@ -284,6 +287,37 @@ namespace hgl::semantics
                 declare_generics(id, op.generics, context);
                 resolve_signature(id, op.signature, context);
                 resolve_constraint(op.requirements, context);
+                pop_scope();
+            }
+
+            void resolve_instantiation(ast::DeclId id, const ast::InstantiateDecl &declaration) {
+                Context context;
+                context.fn = id;
+                push_scope();
+                auto &bindings = result_.instantiation_bindings[id];
+                bindings.reserve(declaration.entries.size());
+                for (const ast::Instantiation &entry : declaration.entries) {
+                    Binding                      binding;
+                    const std::optional<Binding> found = lookup(entry.name.text);
+                    if (found && found->kind == BindingKind::Operator) {
+                        report(Category::Module, entry.name.range,
+                               "'instantiate " + std::string{entry.name.text} +
+                                   "<...>' of an imported operator requires external contract metadata");
+                    } else if (!found || found->kind != BindingKind::LocalOperator) {
+                        report(Category::Module, entry.name.range,
+                               "'instantiate " + std::string{entry.name.text} + "<...>' names no operator declared in this module");
+                    } else {
+                        binding = *found;
+                    }
+                    bindings.push_back(std::move(binding));
+                    for (const ast::GenericArgument &argument : entry.arguments) {
+                        if (argument.type != ast::no_node) {
+                            resolve_type(argument.type, context);
+                        } else if (argument.value != ast::no_node) {
+                            resolve_expr(argument.value, context);
+                        }
+                    }
+                }
                 pop_scope();
             }
 

--- a/language/src/semantics/resolve.h
+++ b/language/src/semantics/resolve.h
@@ -91,6 +91,7 @@ namespace hgl::semantics
         std::vector<Binding>          type_bindings;            ///< indexed by TypeId
         std::vector<Binding>          constraint_bindings;      ///< indexed by ConstraintId
         std::vector<Binding>          implementation_bindings;  ///< selected operator, indexed by DeclId
+        std::vector<std::vector<Binding>> instantiation_bindings;   ///< local operator per instantiate entry, indexed by DeclId
         std::vector<FunctionKind>     kinds;                    ///< indexed by DeclId
         std::vector<ImportedOperator> imports;
         std::vector<ImportedFunction> imported_functions;
@@ -105,6 +106,9 @@ namespace hgl::semantics
         [[nodiscard]] const Binding &type_binding(ast::TypeId id) const noexcept { return type_bindings[id]; }
         [[nodiscard]] const Binding &constraint_binding(ast::ConstraintId id) const noexcept { return constraint_bindings[id]; }
         [[nodiscard]] const Binding &implementation_binding(ast::DeclId id) const noexcept { return implementation_bindings[id]; }
+        [[nodiscard]] const std::vector<Binding> &instantiation_binding(ast::DeclId id) const noexcept {
+            return instantiation_bindings[id];
+        }
         [[nodiscard]] FunctionKind   kind(ast::DeclId id) const noexcept { return kinds[id]; }
         [[nodiscard]] const StructInfo &structure(ast::DeclId id) const noexcept { return struct_info[id]; }
     };

--- a/language/src/syntax/ast.h
+++ b/language/src/syntax/ast.h
@@ -464,6 +464,16 @@ namespace hgl::syntax::ast
         ConstraintId                  requirements{no_node};
     };
 
+    struct Instantiation
+    {
+        SourceRange                  range{};
+        Name                         name{};
+        std::vector<GenericArgument> arguments{};
+    };
+
+    struct InstantiateDecl
+    { std::vector<Instantiation> entries{}; };
+
     enum class FunctionVisibility : std::uint8_t
     {
         Internal,
@@ -514,7 +524,7 @@ namespace hgl::syntax::ast
         BlockId block{no_node};
     };
 
-    using DeclNode = std::variant<ModuleDecl, UseDecl, StructDecl, OperatorDecl, FunctionDecl, TestDecl>;
+    using DeclNode = std::variant<ModuleDecl, UseDecl, StructDecl, OperatorDecl, InstantiateDecl, FunctionDecl, TestDecl>;
 
     struct Decl
     {

--- a/language/src/syntax/ast.h
+++ b/language/src/syntax/ast.h
@@ -80,6 +80,9 @@ namespace hgl::syntax::ast
         TypeId      type{no_node};
         ExprId      value{no_node};
         Name        name{};
+        /// `instantiate op<_, ...>` retains the generic parameter at this
+        /// position instead of binding it to a concrete type or value.
+        bool retained{false};
     };
 
     struct Type

--- a/language/src/syntax/ast_printer.cpp
+++ b/language/src/syntax/ast_printer.cpp
@@ -142,6 +142,18 @@ namespace hgl::syntax
                 if (d.requirements != ast::no_node) { constraint(depth + 1, d.requirements, "requires"); }
             }
 
+            void decl_node(int depth, SourceRange range, const ast::InstantiateDecl &d) {
+                line(depth, "InstantiateDecl", range, "");
+                for (const ast::Instantiation &entry : d.entries) {
+                    line(depth + 1, "Instantiation", entry.range, std::string{entry.name.text});
+                    for (const ast::GenericArgument &argument : entry.arguments) {
+                        line(depth + 2, "GenericArgument", argument.range, "");
+                        if (argument.type != ast::no_node) { type(depth + 3, argument.type); }
+                        if (argument.value != ast::no_node) { expr(depth + 3, argument.value); }
+                    }
+                }
+            }
+
             void decl_node(int depth, SourceRange range, const ast::FunctionDecl &d)
             {
                 std::string details;

--- a/language/src/syntax/ast_printer.cpp
+++ b/language/src/syntax/ast_printer.cpp
@@ -147,7 +147,7 @@ namespace hgl::syntax
                 for (const ast::Instantiation &entry : d.entries) {
                     line(depth + 1, "Instantiation", entry.range, std::string{entry.name.text});
                     for (const ast::GenericArgument &argument : entry.arguments) {
-                        line(depth + 2, "GenericArgument", argument.range, "");
+                        line(depth + 2, "GenericArgument", argument.range, argument.retained ? "retained" : "");
                         if (argument.type != ast::no_node) { type(depth + 3, argument.type); }
                         if (argument.value != ast::no_node) { expr(depth + 3, argument.value); }
                     }

--- a/language/src/syntax/ast_projection.cpp
+++ b/language/src/syntax/ast_projection.cpp
@@ -308,7 +308,8 @@ namespace hgl::syntax
                 return module_.add(std::move(type));
             }
 
-            [[nodiscard]] std::vector<ast::GenericArgument> project_generic_arguments(SyntaxNodeId id) {
+            [[nodiscard]] std::vector<ast::GenericArgument> project_generic_arguments(SyntaxNodeId id,
+                                                                                      bool         type_value_position = true) {
                 std::vector<ast::GenericArgument> result;
                 for (const SyntaxNodeId child : child_nodes(id, SyntaxKind::GenericArgument)) {
                     ast::GenericArgument argument;
@@ -326,7 +327,7 @@ namespace hgl::syntax
                         } else if (node(value).kind == SyntaxKind::Name) {
                             argument.name = direct_names(value, "a generic argument").front();
                         } else {
-                            argument.type = project_type(value, true);
+                            argument.type = project_type(value, type_value_position);
                         }
                     } else {
                         const std::vector<SyntaxTokenId> tokens = child_tokens(child);
@@ -336,7 +337,7 @@ namespace hgl::syntax
                                 type.kind           = ast::TypeKind::Scalar;
                                 type.range          = node(child).range;
                                 type.scalar         = *scalar;
-                                type.value_position = true;
+                                type.value_position = type_value_position;
                                 argument.type       = module_.add(std::move(type));
                                 result.push_back(std::move(argument));
                                 continue;
@@ -991,6 +992,7 @@ namespace hgl::syntax
                     case SyntaxKind::UseDecl: return project_use_decl(declaration);
                     case SyntaxKind::FunctionDecl: return project_function_decl(declaration);
                     case SyntaxKind::OperatorDecl: return project_operator_decl(declaration);
+                    case SyntaxKind::InstantiateDecl: return project_instantiate_decl(declaration);
                     case SyntaxKind::StructDecl: return project_struct_decl(declaration);
                     case SyntaxKind::TestDecl: return project_test_decl(declaration);
                     default: malformed("invalid declaration production");
@@ -1051,6 +1053,29 @@ namespace hgl::syntax
                 if (find_child(id, SyntaxKind::Expression) || find_child(id, SyntaxKind::Block)) {
                     diagnostics_.report(Category::Parse, node(id).range,
                                         "an operator declaration has no body; implement it with 'impl fn'");
+                }
+                return ast::Decl{node(id).range, std::move(result)};
+            }
+
+            [[nodiscard]] ast::Decl project_instantiate_decl(SyntaxNodeId id) {
+                ast::InstantiateDecl result;
+                for (const SyntaxNodeId child : child_nodes(id, SyntaxKind::Instantiation)) {
+                    ast::Instantiation entry;
+                    entry.range                        = node(child).range;
+                    const std::vector<ast::Name> names = direct_names(child, "an operator name");
+                    require(names.size() == 1, "instantiation has an invalid operator name");
+                    entry.name      = names.front();
+                    entry.arguments = project_generic_arguments(only_child(child, SyntaxKind::GenericArguments), false);
+                    for (ast::GenericArgument &argument : entry.arguments) {
+                        if (argument.name.empty()) { continue; }
+                        ast::Type type;
+                        type.kind     = ast::TypeKind::Named;
+                        type.range    = argument.name.range;
+                        type.name     = argument.name;
+                        argument.type = module_.add(std::move(type));
+                        argument.name = {};
+                    }
+                    result.entries.push_back(std::move(entry));
                 }
                 return ast::Decl{node(id).range, std::move(result)};
             }

--- a/language/src/syntax/ast_projection.cpp
+++ b/language/src/syntax/ast_projection.cpp
@@ -308,8 +308,8 @@ namespace hgl::syntax
                 return module_.add(std::move(type));
             }
 
-            [[nodiscard]] std::vector<ast::GenericArgument> project_generic_arguments(SyntaxNodeId id,
-                                                                                      bool         type_value_position = true) {
+            [[nodiscard]] std::vector<ast::GenericArgument>
+            project_generic_arguments(SyntaxNodeId id, bool type_value_position = true, bool allow_retained = false) {
                 std::vector<ast::GenericArgument> result;
                 for (const SyntaxNodeId child : child_nodes(id, SyntaxKind::GenericArgument)) {
                     ast::GenericArgument argument;
@@ -319,7 +319,10 @@ namespace hgl::syntax
                         const SyntaxNodeId value = semantic_child(child);
                         if (node(value).kind == SyntaxKind::SizeExpression) {
                             const std::vector<SyntaxTokenId> tokens = descendant_tokens(value);
-                            if (tokens.size() == 1 && source_token(tokens.front()).kind == TokenKind::Identifier) {
+                            if (allow_retained && tokens.size() == 1 &&
+                                source_token(tokens.front()).kind == TokenKind::Placeholder) {
+                                argument.retained = true;
+                            } else if (tokens.size() == 1 && source_token(tokens.front()).kind == TokenKind::Identifier) {
                                 argument.name = name(tokens.front());
                             } else {
                                 argument.value = project_expression(value);
@@ -1065,7 +1068,7 @@ namespace hgl::syntax
                     const std::vector<ast::Name> names = direct_names(child, "an operator name");
                     require(names.size() == 1, "instantiation has an invalid operator name");
                     entry.name      = names.front();
-                    entry.arguments = project_generic_arguments(only_child(child, SyntaxKind::GenericArguments), false);
+                    entry.arguments = project_generic_arguments(only_child(child, SyntaxKind::GenericArguments), false, true);
                     for (ast::GenericArgument &argument : entry.arguments) {
                         if (argument.name.empty()) { continue; }
                         ast::Type type;

--- a/language/src/syntax/syntax_tree.cpp
+++ b/language/src/syntax/syntax_tree.cpp
@@ -82,6 +82,8 @@ namespace hgl::syntax
             KindName{SyntaxKind::OptionalRequiresClause, "optional_requires_clause"},
             KindName{SyntaxKind::FunctionDecl, "function_decl"},
             KindName{SyntaxKind::OperatorDecl, "operator_decl"},
+            KindName{SyntaxKind::Instantiation, "instantiation"},
+            KindName{SyntaxKind::InstantiateDecl, "instantiate_decl"},
             KindName{SyntaxKind::StructMember, "struct_member"},
             KindName{SyntaxKind::StructBodyItem, "struct_body_item"},
             KindName{SyntaxKind::StructDecl, "struct_decl"},

--- a/language/src/syntax/syntax_tree.h
+++ b/language/src/syntax/syntax_tree.h
@@ -90,6 +90,8 @@ namespace hgl::syntax
         OptionalRequiresClause,
         FunctionDecl,
         OperatorDecl,
+        Instantiation,
+        InstantiateDecl,
         StructMember,
         StructBodyItem,
         StructDecl,

--- a/language/src/syntax/token.cpp
+++ b/language/src/syntax/token.cpp
@@ -7,13 +7,14 @@ namespace hgl::syntax
 {
     namespace
     {
-        constexpr std::array<std::pair<std::string_view, TokenKind>, 42> keywords{{
+        constexpr std::array<std::pair<std::string_view, TokenKind>, 43> keywords{{
             {"module", TokenKind::KwModule},
             {"use", TokenKind::KwUse},
             {"as", TokenKind::KwAs},
             {"export", TokenKind::KwExport},
             {"abstract", TokenKind::KwAbstract},
             {"impl", TokenKind::KwImpl},
+            {"instantiate", TokenKind::KwInstantiate},
             {"operator", TokenKind::KwOperator},
             {"fn", TokenKind::KwFn},
             {"struct", TokenKind::KwStruct},

--- a/language/src/syntax/token.h
+++ b/language/src/syntax/token.h
@@ -14,8 +14,7 @@ namespace hgl::syntax
     /// Token kinds. Keywords are the hard reserved words of the developer
     /// guide ("Lexical rules"); contextual type keywords (`atomic`, `tuple`,
     /// `list`, `set`, `map`, `rolling`, `unbounded`) lex as identifiers.
-    enum class TokenKind : std::uint8_t
-    {
+    enum class TokenKind : std::uint8_t {
         EndOfFile,
         Newline,  ///< one token per run of line terminators (comments included)
 
@@ -33,6 +32,7 @@ namespace hgl::syntax
         KwExport,
         KwAbstract,
         KwImpl,
+        KwInstantiate,
         KwOperator,
         KwFn,
         KwStruct,

--- a/language/src/syntax/token_grammar.cpp
+++ b/language/src/syntax/token_grammar.cpp
@@ -50,14 +50,14 @@ namespace hgl::syntax
                                                 contextual<ContextToken::Delta> / contextual<ContextToken::AppliedConstructor>;
         inline constexpr auto reserved_name =
             token_choice<TokenKind::KwModule, TokenKind::KwUse, TokenKind::KwAs, TokenKind::KwExport, TokenKind::KwAbstract,
-                         TokenKind::KwImpl, TokenKind::KwOperator, TokenKind::KwFn, TokenKind::KwStruct, TokenKind::KwConst,
-                         TokenKind::KwRequires, TokenKind::KwIs, TokenKind::KwLet, TokenKind::KwVar, TokenKind::KwState,
-                         TokenKind::KwInject, TokenKind::KwReturn, TokenKind::KwIf, TokenKind::KwElse, TokenKind::KwStart,
-                         TokenKind::KwWhen, TokenKind::KwStop, TokenKind::KwFor, TokenKind::KwTest, TokenKind::KwAssert,
-                         TokenKind::KwEval, TokenKind::KwTrue, TokenKind::KwFalse, TokenKind::KwNull, TokenKind::KwBool,
-                         TokenKind::KwI64, TokenKind::KwF64, TokenKind::KwStr, TokenKind::KwDate, TokenKind::KwTime,
-                         TokenKind::KwDateTime, TokenKind::KwDuration, TokenKind::KwCivilDateTime, TokenKind::KwZonedDateTime,
-                         TokenKind::KwZonedTime, TokenKind::KwTimeZone>;
+                         TokenKind::KwImpl, TokenKind::KwInstantiate, TokenKind::KwOperator, TokenKind::KwFn, TokenKind::KwStruct,
+                         TokenKind::KwConst, TokenKind::KwRequires, TokenKind::KwIs, TokenKind::KwLet, TokenKind::KwVar,
+                         TokenKind::KwState, TokenKind::KwInject, TokenKind::KwReturn, TokenKind::KwIf, TokenKind::KwElse,
+                         TokenKind::KwStart, TokenKind::KwWhen, TokenKind::KwStop, TokenKind::KwFor, TokenKind::KwTest,
+                         TokenKind::KwAssert, TokenKind::KwEval, TokenKind::KwTrue, TokenKind::KwFalse, TokenKind::KwNull,
+                         TokenKind::KwBool, TokenKind::KwI64, TokenKind::KwF64, TokenKind::KwStr, TokenKind::KwDate,
+                         TokenKind::KwTime, TokenKind::KwDateTime, TokenKind::KwDuration, TokenKind::KwCivilDateTime,
+                         TokenKind::KwZonedDateTime, TokenKind::KwZonedTime, TokenKind::KwTimeZone>;
 
         inline constexpr auto ordinary_name = identifier / contextual_name;
         inline constexpr auto raw_name      = ordinary_name / reserved_name;
@@ -606,6 +606,16 @@ namespace hgl::syntax
                     dsl::if_(dsl::p<generic_parameters>) + dsl::p<signature> + dsl::p<optional_requires_clause> + dsl::if_(body);
         };
 
+        struct instantiation
+        { static constexpr auto rule = dsl::p<name> + dsl::p<generic_arguments>; };
+
+        struct instantiate_decl
+        {
+            static constexpr auto rule = token<TokenKind::KwInstantiate> >>
+                                         dsl::list(dsl::peek(ordinary_name + token<TokenKind::Less>) >> dsl::p<instantiation>,
+                                                   dsl::trailing_sep(dsl::p<comma_separator>));
+        };
+
         struct struct_member
         {
             static constexpr auto rule =
@@ -654,13 +664,14 @@ namespace hgl::syntax
 
         struct declaration
         {
-            static constexpr auto rule =
-                dsl::p<use_decl> | dsl::p<function_decl> | dsl::p<operator_decl> | dsl::p<struct_decl> | dsl::p<test_decl>;
+            static constexpr auto rule = dsl::p<use_decl> | dsl::p<function_decl> | dsl::p<operator_decl> |
+                                         dsl::p<instantiate_decl> | dsl::p<struct_decl> | dsl::p<test_decl>;
         };
 
-        inline constexpr auto declaration_start =
-            token<TokenKind::KwUse> / token<TokenKind::KwFn> / token<TokenKind::KwOperator> / token<TokenKind::KwStruct> /
-            token<TokenKind::KwTest> / token<TokenKind::KwExport> / token<TokenKind::KwImpl> / token<TokenKind::KwAbstract>;
+        inline constexpr auto declaration_start = token<TokenKind::KwUse> / token<TokenKind::KwFn> / token<TokenKind::KwOperator> /
+                                                  token<TokenKind::KwInstantiate> / token<TokenKind::KwStruct> /
+                                                  token<TokenKind::KwTest> / token<TokenKind::KwExport> / token<TokenKind::KwImpl> /
+                                                  token<TokenKind::KwAbstract>;
 
         struct declaration_line
         {

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -295,6 +295,7 @@ add_test(NAME hgraph_language_codegen COMMAND hgl_codegen_tests)
 # beside `hgl test` and the native-only runtime-node behavior.
 hgl_add_module(hgl_codegen_fixture STATIC HGL
     codegen/parity.hgl
+    codegen/partial-materialization.hgl
     codegen/runtime.hgl
     ../examples/conditional-early-return.hgl
     ../examples/conditional-forwarding.hgl
@@ -330,6 +331,7 @@ set(_hgl_generated_test_sources
     codegen/generated_tests.cpp
     codegen/generated_runtime_tests.cpp
     codegen/generated_native_tests.cpp
+    codegen/generated_partial_materialization_tests.cpp
     codegen/generated_iteration_tests.cpp
     codegen/generated_reference_tests.cpp
     codegen/generated_structural_tests.cpp

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -1107,6 +1107,42 @@ impl fn choose(value: i64) -> i64 => value
     }
 }
 
+TEST_CASE("emit-cpp emits and registers only requested generic operator materializations",
+          "[codegen][hgraph-ir][operators][generics]") {
+    Unit unit{R"(
+module materialized_overloads
+
+operator choose<T>(value: T) -> T
+impl fn choose<T>(value: T) -> T
+requires T in {i64, f64}
+=> value
+
+instantiate choose<i64>, choose<f64>
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+    REQUIRE(unit.graph.callables.size() == 1);
+    REQUIRE(unit.graph.materializations.size() == 2);
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    const std::string &identity = unit.graph.callables.front().identity;
+    const std::size_t  marker   = identity.find_last_of('#');
+    REQUIRE(marker != std::string::npos);
+    const std::string base = "choose_impl_" + identity.substr(marker + 1U);
+
+    CHECK_FALSE(contains(emitted->source, "struct " + base + " {"));
+    CHECK(contains(emitted->source, "struct " + base + "__i64__m0"));
+    CHECK(contains(emitted->source, "struct " + base + "__f64__m1"));
+    CHECK(contains(emitted->source, "register_graph_overload<operators::choose, " + base + "__i64__m0>()"));
+    CHECK(contains(emitted->source, "register_graph_overload<operators::choose, " + base + "__f64__m1>()"));
+    CHECK_FALSE(contains(emitted->header, base));
+    for (const hgl::hgraph_ir::Materialization &materialization : unit.graph.materializations) {
+        CHECK(contains(emitted->source, materialization.identity));
+        CHECK(contains(emitted->descriptor, materialization.identity));
+    }
+}
+
 TEST_CASE("emit-cpp uses the hgraph IR identity for local operator calls", "[codegen][hgraph-ir][operators]") {
     Unit unit{R"(
 module renamed_ops

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -1196,6 +1196,25 @@ instantiate extent<_>
                    "a retained generic used as a value; generic reification is not supported by emit-cpp yet"));
 }
 
+TEST_CASE("emit-cpp resolves a concrete duration generic before selecting a rolling shape",
+          "[codegen][hgraph-ir][operators][generics][rolling]") {
+    Unit unit{R"(
+module materialized_duration_window
+
+operator latest<const size: duration>(value: rolling<f64, size>) -> f64
+impl fn latest<const size: duration>(value: rolling<f64, size>) -> f64 => 1.0
+
+instantiate latest<5m>
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "hgraph::TSWDuration<hgraph::Float, 300000000, 300000000>"));
+    CHECK_FALSE(contains(emitted->source, "hgraph::TSWAny<hgraph::Float>"));
+}
+
 TEST_CASE("emit-cpp uses the hgraph IR identity for local operator calls", "[codegen][hgraph-ir][operators]") {
     Unit unit{R"(
 module renamed_ops

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -193,7 +193,7 @@ TEST_CASE("emit-cpp names the pair after the module and exports its functions", 
     CHECK(contains(emitted->source, "#include \"parity.h\""));
     CHECK(contains(emitted->source, "namespace\n"));
     CHECK(contains(emitted->source, "struct scale\n"));
-    CHECK(contains(emitted->source, "hgraph::Port<hgraph::TS<hgraph::Float>> plus::compose(hgraph::Wiring &w, "
+    CHECK(contains(emitted->source, "hgraph::Port<hgraph::TS<hgraph::Float>> plus::compose([[maybe_unused]] hgraph::Wiring &w, "
                                     "hgraph::Port<hgraph::TS<hgraph::Float>> a, hgraph::Port<hgraph::TS<hgraph::Float>> b)"));
     CHECK(contains(emitted->source, "hgraph::wire<hgraph::stdlib::add_>(w, a, b).as<hgraph::TS<hgraph::Float>>()"));
     CHECK(contains(emitted->source, "hgraph::wire<hgraph::stdlib::gt_>(w, x, threshold.value()).as<hgraph::TS<hgraph::Bool>>()"));
@@ -1143,6 +1143,59 @@ instantiate choose<i64>, choose<f64>
     }
 }
 
+TEST_CASE("emit-cpp retains a size generic in a partially materialized list candidate",
+          "[codegen][hgraph-ir][operators][generics]") {
+    Unit unit{R"(
+module partially_materialized_overloads
+
+operator preserve<T, const size: i64>(value: list<T, size>) -> list<T, size>
+impl fn preserve<T, const size: i64>(value: list<T, size>) -> list<T, size> => value
+
+instantiate preserve<i64, _>
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.graph.materializations.size() == 1);
+
+    const auto emitted = unit.emit();
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "struct preserve_impl_2__i64__any_size__m0"));
+    CHECK(contains(emitted->source, "hgraph::TSL<hgraph::TS<hgraph::Int>, hgraph::SIZE<\"size\">>"));
+    CHECK(contains(emitted->source, "register_graph_overload<operators::preserve, preserve_impl_2__i64__any_size__m0>()"));
+    CHECK(contains(emitted->descriptor, "\"name\": \"size\""));
+    CHECK(contains(emitted->descriptor, "\"kind\": \"const\""));
+}
+
+TEST_CASE("emit-cpp diagnoses value use of a retained generic separately from a signature marker",
+          "[codegen][hgraph-ir][operators][generics]") {
+    Unit concrete{R"(
+module concrete_reification
+
+operator extent<const size: i64>(value: list<i64, size>) -> i64
+impl fn extent<const size: i64>(value: list<i64, size>) -> i64 => size
+
+instantiate extent<3>
+)"};
+    REQUIRE_FALSE(concrete.diagnostics.has_errors());
+    const auto concrete_emitted = concrete.emit();
+    INFO(concrete.diagnostics.render(concrete.file));
+    REQUIRE(concrete_emitted);
+    CHECK(contains(concrete_emitted->source, "hgraph::Int{3}"));
+
+    Unit unit{R"(
+module reified_materialization
+
+operator extent<const size: i64>(value: list<i64, size>) -> i64
+impl fn extent<const size: i64>(value: list<i64, size>) -> i64 => size
+
+instantiate extent<_>
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    CHECK_FALSE(unit.emit());
+    CHECK(contains(unit.diagnostics.render(unit.file),
+                   "a retained generic used as a value; generic reification is not supported by emit-cpp yet"));
+}
+
 TEST_CASE("emit-cpp uses the hgraph IR identity for local operator calls", "[codegen][hgraph-ir][operators]") {
     Unit unit{R"(
 module renamed_ops
@@ -2003,7 +2056,7 @@ export fn w(delete: f64, const int: i64 = 1) -> f64 => delete * int
     REQUIRE(emitted);
     CHECK(emitted->namespace_name == "t::new_");
     CHECK(contains(emitted->header, "using w_ = hgraph::Operator<\"t.new.w\""));
-    CHECK(contains(emitted->source, "hgraph::Port<hgraph::TS<hgraph::Float>> w_::compose(hgraph::Wiring &w, "
+    CHECK(contains(emitted->source, "hgraph::Port<hgraph::TS<hgraph::Float>> w_::compose([[maybe_unused]] hgraph::Wiring &w, "
                                     "hgraph::Port<hgraph::TS<hgraph::Float>> delete_, hgraph::Scalar<\"int\", hgraph::Int> int_)"));
 }
 

--- a/language/tests/codegen/generated_partial_materialization_tests.cpp
+++ b/language/tests/codegen/generated_partial_materialization_tests.cpp
@@ -1,0 +1,38 @@
+#include <partial-materialization.h>
+
+#include "wiring/backend.h"
+
+#include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/types/graph_wiring.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace hgraph;
+namespace partial = checks::partial_materialization;
+
+namespace
+{
+    template <std::size_t Size> GraphBuilder compose_preserved_list() {
+        static_assert(Size == 2 || Size == 3);
+        hgl::wiring::ensure_session();
+        partial::register_operators();
+        Wiring w;
+        auto   first  = wire<stdlib::const_, TS<Int>>(w, Int{1});
+        auto   second = wire<stdlib::const_, TS<Int>>(w, Int{2});
+        if constexpr (Size == 2) {
+            Port<TSL<TS<Int>, 2>> values{stdlib::to_tsl<TSL<TS<Int>, 2>>(w, first, second).erased()};
+            static_cast<void>(wire<partial::operators::preserve>(w, values));
+        } else {
+            auto                  third = wire<stdlib::const_, TS<Int>>(w, Int{3});
+            Port<TSL<TS<Int>, 3>> values{stdlib::to_tsl<TSL<TS<Int>, 3>>(w, first, second, third).erased()};
+            static_cast<void>(wire<partial::operators::preserve>(w, values));
+        }
+        return std::move(w).finish();
+    }
+}  // namespace
+
+TEST_CASE("a retained size materialization resolves for different fixed list sizes",
+          "[codegen][generated][generic][materialization]") {
+    CHECK_NOTHROW(compose_preserved_list<2>());
+    CHECK_NOTHROW(compose_preserved_list<3>());
+}

--- a/language/tests/codegen/partial-materialization.hgl
+++ b/language/tests/codegen/partial-materialization.hgl
@@ -1,0 +1,12 @@
+// A retained generic is part of the candidate pattern without becoming a
+// runtime value. The element type is concrete; fixed list size remains
+// selectable by hgraph's resolver.
+
+module checks.partial_materialization
+
+operator preserve<T, const size: i64>(value: list<T, size>) -> list<T, size>
+
+impl fn preserve<T, const size: i64>(value: list<T, size>) -> list<T, size> =>
+    value
+
+instantiate preserve<i64, _>

--- a/language/tests/descriptor/module_descriptor_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_tests.cpp
@@ -198,6 +198,56 @@ TEST_CASE("module descriptors advertise concrete implementation materializations
     CHECK(result.types[result.implementations[1].signature.result].scalar_name == "f64");
 }
 
+TEST_CASE("module descriptors retain residual materialization generics", "[descriptor][generics]") {
+    gir::Module module;
+    module.path     = "checks.partial";
+    module.bindings = {
+        gir::Binding{.name = "T", .kind = gir::BindingKind::TypeParameter, .owner_identity = "checks.partial.keep#1"},
+        gir::Binding{.name = "N", .kind = gir::BindingKind::ConstParameter, .owner_identity = "checks.partial.keep#1"},
+        gir::Binding{.name = "value", .kind = gir::BindingKind::SignalParameter, .owner_identity = "checks.partial.keep#1"},
+    };
+    module.const_exprs = {
+        gir::ConstExpr{.kind = gir::ConstExprKind::Parameter, .parameter = "N", .parameter_binding = gir::BindingId{1}},
+    };
+    module.types = {
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Scalar, .scalar = hgl::ir::hir::ScalarType::I64},
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Symbol, .nominal_identity = "T", .binding = gir::BindingId{0}},
+        gir::Type{.kind = hgl::ir::hir::TypeKind::List, .children = {gir::TypeId{1}}, .size = gir::ConstExprId{0}},
+    };
+    module.callables = {
+        gir::Callable{
+            .identity               = "checks.partial.keep#1",
+            .operator_identity      = "checks.partial.keep",
+            .operator_registry_name = "checks.partial.keep",
+            .visibility             = gir::CallableVisibility::Implementation,
+            .kind                   = gir::CallableKind::Composition,
+            .generics               = {gir::GenericParameter{"T", false, {}, gir::BindingId{0}},
+                                       gir::GenericParameter{"N", true, gir::TypeId{0}, gir::BindingId{1}}},
+            .parameters             = {gir::Parameter{"value", false, gir::TypeId{2}, {}, gir::BindingId{2}}},
+            .result                 = gir::TypeId{2},
+        },
+    };
+    module.materializations = {
+        gir::Materialization{
+            .identity       = "checks.partial.keep#1@instantiate:0",
+            .implementation = gir::CallableId{0},
+            .substitutions  = {gir::Substitution{.parameter = gir::BindingId{0}, .type = gir::TypeId{0}},
+                               gir::Substitution{.parameter = gir::BindingId{1}, .retained = true}},
+        },
+    };
+
+    const descriptor::ModuleDescriptor result = descriptor::describe_module(module, {});
+    REQUIRE(result.implementations.size() == 1);
+    const descriptor::Signature &signature = result.implementations.front().signature;
+    REQUIRE(signature.generics.size() == 1);
+    CHECK(signature.generics.front().name == "N");
+    CHECK(signature.generics.front().is_const);
+    REQUIRE(signature.parameters.size() == 1);
+    CHECK(signature.parameters.front().type == signature.result);
+    CHECK(result.types[signature.result].size != descriptor::no_schema_id);
+    CHECK(result.constant_expressions[result.types[signature.result].size].parameter_identity == "checks.partial.keep#1::N");
+}
+
 TEST_CASE("module descriptor JSON is canonical and reviewable", "[descriptor]") {
     descriptor::ModuleDescriptor module;
     module.module_identity   = "acme.\"prices\"";

--- a/language/tests/descriptor/module_descriptor_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_tests.cpp
@@ -148,6 +148,56 @@ TEST_CASE("module descriptors retain structured signatures layouts and constrain
     CHECK(json.find("\"category\": \"compatibility\"") != std::string::npos);
 }
 
+TEST_CASE("module descriptors advertise concrete implementation materializations", "[descriptor][generics]") {
+    gir::Module module;
+    module.path     = "checks.materialized";
+    module.bindings = {
+        gir::Binding{.name = "T", .kind = gir::BindingKind::TypeParameter, .owner_identity = "checks.materialized.choose#1"},
+        gir::Binding{.name = "value", .kind = gir::BindingKind::SignalParameter, .owner_identity = "checks.materialized.choose#1"},
+    };
+    module.types = {
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Scalar, .scalar = hgl::ir::hir::ScalarType::I64},
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Scalar, .scalar = hgl::ir::hir::ScalarType::F64},
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Symbol, .nominal_identity = "T", .binding = gir::BindingId{0}},
+    };
+    module.callables = {
+        gir::Callable{
+            .identity               = "checks.materialized.choose#1",
+            .operator_identity      = "checks.materialized.choose",
+            .operator_registry_name = "checks.materialized.choose",
+            .visibility             = gir::CallableVisibility::Implementation,
+            .kind                   = gir::CallableKind::Composition,
+            .generics               = {gir::GenericParameter{"T", false, {}, gir::BindingId{0}}},
+            .parameters             = {gir::Parameter{"value", false, gir::TypeId{2}, {}, gir::BindingId{1}}},
+            .result                 = gir::TypeId{2},
+        },
+    };
+    module.materializations = {
+        gir::Materialization{
+            .identity       = "checks.materialized.choose#1@instantiate:0",
+            .implementation = gir::CallableId{0},
+            .substitutions  = {gir::Substitution{.parameter = gir::BindingId{0}, .type = gir::TypeId{0}}},
+        },
+        gir::Materialization{
+            .identity       = "checks.materialized.choose#1@instantiate:1",
+            .implementation = gir::CallableId{0},
+            .substitutions  = {gir::Substitution{.parameter = gir::BindingId{0}, .type = gir::TypeId{1}}},
+        },
+    };
+
+    const descriptor::ModuleDescriptor result = descriptor::describe_module(module, {});
+    REQUIRE(result.implementations.size() == 2);
+    CHECK(result.implementations[0].identity == "checks.materialized.choose#1@instantiate:0");
+    CHECK(result.implementations[1].identity == "checks.materialized.choose#1@instantiate:1");
+    for (const descriptor::Implementation &implementation : result.implementations) {
+        CHECK(implementation.signature.generics.empty());
+        REQUIRE(implementation.signature.parameters.size() == 1);
+        CHECK(implementation.signature.parameters.front().type == implementation.signature.result);
+    }
+    CHECK(result.types[result.implementations[0].signature.result].scalar_name == "i64");
+    CHECK(result.types[result.implementations[1].signature.result].scalar_name == "f64");
+}
+
 TEST_CASE("module descriptor JSON is canonical and reviewable", "[descriptor]") {
     descriptor::ModuleDescriptor module;
     module.module_identity   = "acme.\"prices\"";

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -502,6 +502,29 @@ instantiate sized<i64, 3>, sized<f64, 5>
     CHECK(printed.find("=c") != std::string::npos);
 }
 
+TEST_CASE("hgraph IR distinguishes retained from concrete materialization slots", "[hgraph-ir][operators][generics]") {
+    Lowered lowered{R"(
+module checks.partial_materialization
+
+operator preserve<T, const N: i64>(value: list<T, N>) -> list<T, N>
+impl fn preserve<T, const N: i64>(value: list<T, N>) -> list<T, N> => value
+
+instantiate preserve<i64, _>
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+    REQUIRE(lowered.graph->materializations.size() == 1);
+    const hgl::hgraph_ir::Materialization &materialization = lowered.graph->materializations.front();
+    REQUIRE(materialization.substitutions.size() == 2);
+    CHECK(materialization.substitutions[0].type.valid());
+    CHECK_FALSE(materialization.substitutions[0].retained);
+    CHECK(materialization.substitutions[1].retained);
+    CHECK_FALSE(materialization.substitutions[1].type.valid());
+    CHECK_FALSE(materialization.substitutions[1].value.valid());
+    CHECK(hgl::hgraph_ir::print(*lowered.graph).find(":_") != std::string::npos);
+}
+
 TEST_CASE("hgraph IR prints constant-only operation substitutions", "[hgraph-ir][operators][printer]") {
     hgl::hgraph_ir::Module module;
     hgl::hgraph_ir::Value  value;

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -472,6 +472,36 @@ fn selected(value: f64) -> f64 => choose(value)
     CHECK(lowered.graph->provider_requirements.empty());
 }
 
+TEST_CASE("hgraph IR owns explicit generic implementation materializations", "[hgraph-ir][operators][generics]") {
+    Lowered lowered{R"(
+module checks.materializations
+
+operator sized<T, const N: i64>(value: list<T, N>) -> list<T, N>
+impl fn sized<T, const N: i64>(value: list<T, N>) -> list<T, N> => value
+
+instantiate sized<i64, 3>, sized<f64, 5>
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+    REQUIRE(lowered.graph->callables.size() == 1);
+    REQUIRE(lowered.graph->materializations.size() == 2);
+
+    for (std::size_t index = 0; index < lowered.graph->materializations.size(); ++index) {
+        const hgl::hgraph_ir::Materialization &materialization = lowered.graph->materializations[index];
+        CHECK(materialization.implementation.value == 0);
+        REQUIRE(materialization.substitutions.size() == 2);
+        CHECK(materialization.substitutions[0].type.valid());
+        REQUIRE(materialization.substitutions[1].constant);
+        CHECK(std::get<std::int64_t>(*materialization.substitutions[1].constant) == (index == 0 ? 3 : 5));
+    }
+
+    const std::string printed = hgl::hgraph_ir::print(*lowered.graph);
+    CHECK(printed.find("materializations") != std::string::npos);
+    CHECK(printed.find("@instantiate:0 substitutions=[") != std::string::npos);
+    CHECK(printed.find("=c") != std::string::npos);
+}
+
 TEST_CASE("hgraph IR prints constant-only operation substitutions", "[hgraph-ir][operators][printer]") {
     hgl::hgraph_ir::Module module;
     hgl::hgraph_ir::Value  value;

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -166,7 +166,10 @@ TEST_CASE("every guide example lowers to resolved HIR", "[ir][examples]") {
             }
         }
         for (ast::DeclId declaration = 0; declaration < lowered.ast.decls.size(); ++declaration) {
-            if (std::holds_alternative<ast::UseDecl>(lowered.ast.decl(declaration).node)) { continue; }
+            if (std::holds_alternative<ast::UseDecl>(lowered.ast.decl(declaration).node) ||
+                std::holds_alternative<ast::InstantiateDecl>(lowered.ast.decl(declaration).node)) {
+                continue;
+            }
             CHECK(lowered.hir.declaration(hir::DeclarationId{declaration}).symbol.valid());
         }
     }
@@ -989,6 +992,94 @@ fn apply_it(value: f64) -> f64 => choose(value)
         CHECK(expression.operation.deferred);
     }
     CHECK(found);
+}
+
+TEST_CASE("an unmaterialized generic implementation is not a concrete source candidate", "[ir][typed][generics][operators]") {
+    Lowered lowered{R"(
+module checks.unmaterialized_candidate
+
+operator choose<T>(value: T) -> T
+impl fn choose<T>(value: T) -> T => value
+fn apply_it(value: f64) -> f64 => choose(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    const auto call = std::ranges::find_if(lowered.hir.exprs, [&](const hir::Expr &expression) {
+        return expression.operation.kind == hir::OperationKind::NominalOperator && expression.operation.target.valid() &&
+               lowered.hir.symbol(expression.operation.target).name == "choose";
+    });
+    REQUIRE(call != lowered.hir.exprs.end());
+    CHECK_FALSE(call->operation.candidate.valid());
+    CHECK(call->operation.deferred);
+}
+
+TEST_CASE("typed HIR materializes constrained generic operator implementations", "[ir][typed][generics][operators]") {
+    Lowered lowered{R"(
+module checks.materializations
+
+operator choose<T>(value: T) -> T
+impl fn choose<T>(value: T) -> T
+requires T in {i64, f64}
+=> value
+
+instantiate choose<i64>, choose<f64>
+
+fn choose_i64(value: i64) -> i64 => choose(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    const auto declaration = std::ranges::find_if(lowered.hir.declarations, [](const hir::Declaration &candidate) {
+        return std::holds_alternative<hir::InstantiateDecl>(candidate.node);
+    });
+    REQUIRE(declaration != lowered.hir.declarations.end());
+    const auto &instantiate = std::get<hir::InstantiateDecl>(declaration->node);
+    REQUIRE(instantiate.entries.size() == 2);
+    for (const hir::Instantiation &entry : instantiate.entries) {
+        REQUIRE(entry.materializations.size() == 1);
+        REQUIRE(entry.materializations.front().substitutions.size() == 1);
+        CHECK(entry.materializations.front().substitutions.front().type.valid());
+    }
+
+    const auto call = std::ranges::find_if(lowered.hir.exprs, [&](const hir::Expr &expression) {
+        return expression.operation.kind == hir::OperationKind::NominalOperator && expression.operation.target.valid() &&
+               lowered.hir.symbol(expression.operation.target).name == "choose";
+    });
+    REQUIRE(call != lowered.hir.exprs.end());
+    CHECK(call->operation.candidate.valid());
+    CHECK_FALSE(call->operation.deferred);
+}
+
+TEST_CASE("typed HIR rejects invalid and duplicate operator materializations", "[ir][typed][generics][operators]") {
+    Lowered unsupported{R"(
+module checks.materialization_constraint
+
+operator choose<T>(value: T) -> T
+impl fn choose<T>(value: T) -> T
+requires T in {i64, f64}
+=> value
+
+instantiate choose<str>
+)"};
+    require_clean(unsupported);
+    CHECK_FALSE(complete(unsupported));
+    CHECK(unsupported.diagnostics.render(unsupported.file).find("instantiate matches no local generic operator implementation") !=
+          std::string::npos);
+
+    Lowered duplicate{R"(
+module checks.duplicate_materialization
+
+operator choose<T>(value: T) -> T
+impl fn choose<T>(value: T) -> T => value
+
+instantiate choose<i64>, choose<i64>
+)"};
+    require_clean(duplicate);
+    CHECK_FALSE(complete(duplicate));
+    const std::string diagnostics = duplicate.diagnostics.render(duplicate.file);
+    CHECK(diagnostics.find("operator implementation is instantiated more than once with the same arguments") != std::string::npos);
+    CHECK(diagnostics.find("matches no local generic operator implementation") == std::string::npos);
 }
 
 TEST_CASE("constraint logic admits resolved alternatives without inferring through them", "[ir][typed][constraints]") {

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -1051,6 +1051,44 @@ fn choose_i64(value: i64) -> i64 => choose(value)
     CHECK_FALSE(call->operation.deferred);
 }
 
+TEST_CASE("typed HIR retains selected implementation generics in a materialized candidate", "[ir][typed][generics][operators]") {
+    Lowered lowered{R"(
+module checks.partial_materialization
+
+operator preserve<T, const N: i64>(value: list<T, N>) -> list<T, N>
+impl fn preserve<T, const N: i64>(value: list<T, N>) -> list<T, N> => value
+
+instantiate preserve<i64, _>
+
+fn preserve_three(value: list<i64, 3>) -> list<i64, 3> => preserve(value)
+)"};
+    require_clean(lowered);
+    const bool completed = complete(lowered);
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(completed);
+
+    const auto declaration = std::ranges::find_if(lowered.hir.declarations, [](const hir::Declaration &candidate) {
+        return std::holds_alternative<hir::InstantiateDecl>(candidate.node);
+    });
+    REQUIRE(declaration != lowered.hir.declarations.end());
+    const auto &entry = std::get<hir::InstantiateDecl>(declaration->node).entries.front();
+    REQUIRE(entry.arguments.size() == 2);
+    CHECK_FALSE(entry.arguments[0].retained);
+    CHECK(entry.arguments[1].retained);
+    REQUIRE(entry.materializations.size() == 1);
+    REQUIRE(entry.materializations.front().substitutions.size() == 2);
+    CHECK(entry.materializations.front().substitutions[0].type.valid());
+    CHECK(entry.materializations.front().substitutions[1].retained);
+
+    const auto call = std::ranges::find_if(lowered.hir.exprs, [&](const hir::Expr &expression) {
+        return expression.operation.kind == hir::OperationKind::NominalOperator && expression.operation.target.valid() &&
+               lowered.hir.symbol(expression.operation.target).name == "preserve";
+    });
+    REQUIRE(call != lowered.hir.exprs.end());
+    CHECK(call->operation.candidate.valid());
+    CHECK_FALSE(call->operation.deferred);
+}
+
 TEST_CASE("typed HIR rejects invalid and duplicate operator materializations", "[ir][typed][generics][operators]") {
     Lowered unsupported{R"(
 module checks.materialization_constraint
@@ -1080,6 +1118,21 @@ instantiate choose<i64>, choose<i64>
     const std::string diagnostics = duplicate.diagnostics.render(duplicate.file);
     CHECK(diagnostics.find("operator implementation is instantiated more than once with the same arguments") != std::string::npos);
     CHECK(diagnostics.find("matches no local generic operator implementation") == std::string::npos);
+
+    Lowered constrained_retained{R"(
+module checks.constrained_retained_materialization
+
+operator sized<const N: i64>(value: list<i64, N>) -> list<i64, N>
+impl fn sized<const N: i64>(value: list<i64, N>) -> list<i64, N>
+requires N == 3
+=> value
+
+instantiate sized<_>
+)"};
+    require_clean(constrained_retained);
+    CHECK_FALSE(complete(constrained_retained));
+    CHECK(constrained_retained.diagnostics.render(constrained_retained.file)
+              .find("instantiate matches no local generic operator implementation") != std::string::npos);
 }
 
 TEST_CASE("constraint logic admits resolved alternatives without inferring through them", "[ir][typed][constraints]") {

--- a/language/tests/semantics/resolve_tests.cpp
+++ b/language/tests/semantics/resolve_tests.cpp
@@ -352,6 +352,34 @@ impl fn choose(value: f64) -> f64 => value
     CHECK(clash.has(Category::Name, "'fn valid' conflicts with operator hgraph.std::valid"));
 }
 
+TEST_CASE("instantiations bind only to a local operator contract", "[semantics][generics][operators]") {
+    const Resolved local = resolve_clean(R"(
+module t
+
+operator choose<T>(value: T) -> T
+impl fn choose<T>(value: T) -> T => value
+instantiate choose<i64>, choose<f64>
+)");
+    REQUIRE(local.result.instantiation_bindings.size() == local.module.decls.size());
+    const auto declaration = std::ranges::find_if(local.module.declarations, [&](ast::DeclId id) {
+        return std::holds_alternative<ast::InstantiateDecl>(local.module.decl(id).node);
+    });
+    REQUIRE(declaration != local.module.declarations.end());
+    const std::vector<Binding> &bindings = local.result.instantiation_binding(*declaration);
+    REQUIRE(bindings.size() == 2);
+    CHECK(bindings[0].kind == BindingKind::LocalOperator);
+    CHECK(bindings[0].operator_identity == "t.choose");
+    CHECK(bindings[1].operator_identity == "t.choose");
+
+    const Resolved imported{R"(
+module t
+
+use hgraph.std::{valid}
+instantiate valid<f64>
+)"};
+    CHECK(imported.has(Category::Module, "'instantiate valid<...>' of an imported operator requires external contract metadata"));
+}
+
 TEST_CASE("tests are declarations, not values", "[semantics]") {
     const Resolved resolved{R"(
 module t

--- a/language/tests/syntax/lexer_tests.cpp
+++ b/language/tests/syntax/lexer_tests.cpp
@@ -42,13 +42,14 @@ TEST_CASE("empty input yields end of file", "[lexer]")
 
 TEST_CASE("keywords, identifiers and the placeholder", "[lexer]")
 {
-    Lexed lexed{"fn export abstract struct requires is null _ _x in tuple"};
+    Lexed lexed{"fn export abstract struct impl instantiate requires is null _ _x in tuple"};
     REQUIRE(kinds(lexed) == std::vector<TokenKind>{TokenKind::KwFn, TokenKind::KwExport, TokenKind::KwAbstract, TokenKind::KwStruct,
-                                                   TokenKind::KwRequires, TokenKind::KwIs, TokenKind::KwNull,
-                                                   TokenKind::Placeholder, TokenKind::Identifier, TokenKind::Identifier,
-                                                   TokenKind::Identifier, TokenKind::EndOfFile});
-    REQUIRE(lexed.result.tokens[8].text == "_x");
-    REQUIRE(lexed.result.tokens[9].text == "in");
+                                                   TokenKind::KwImpl, TokenKind::KwInstantiate, TokenKind::KwRequires,
+                                                   TokenKind::KwIs, TokenKind::KwNull, TokenKind::Placeholder,
+                                                   TokenKind::Identifier, TokenKind::Identifier, TokenKind::Identifier,
+                                                   TokenKind::EndOfFile});
+    REQUIRE(lexed.result.tokens[10].text == "_x");
+    REQUIRE(lexed.result.tokens[11].text == "in");
 }
 
 TEST_CASE("type keywords are reserved", "[lexer]")

--- a/language/tests/syntax/parser_tests.cpp
+++ b/language/tests/syntax/parser_tests.cpp
@@ -275,6 +275,20 @@ TEST_CASE("operator declarations have signatures and no body", "[parser]") {
             std::vector<std::string>{"the left side of an operator requirement is a call"});
 }
 
+TEST_CASE("instantiate declarations request concrete operator implementations", "[parser][generics][operators]") {
+    REQUIRE(dump_clean("module t\ninstantiate choose<i64>, choose<f64, 3>\n") == "Module\n"
+                                                                                 "  ModuleDecl t\n"
+                                                                                 "  InstantiateDecl\n"
+                                                                                 "    Instantiation choose\n"
+                                                                                 "      GenericArgument\n"
+                                                                                 "        Type scalar i64\n"
+                                                                                 "    Instantiation choose\n"
+                                                                                 "      GenericArgument\n"
+                                                                                 "        Type scalar f64\n"
+                                                                                 "      GenericArgument\n"
+                                                                                 "        IntLiteral 3\n");
+}
+
 TEST_CASE("the declarative grammar preserves trailing parenthesized newlines", "[parser]") {
     CHECK(dump_clean("module t\nfn grouped() -> i64 => (\n  1\n)\n").find("IntLiteral 1") != std::string::npos);
 }

--- a/language/tests/syntax/parser_tests.cpp
+++ b/language/tests/syntax/parser_tests.cpp
@@ -276,7 +276,7 @@ TEST_CASE("operator declarations have signatures and no body", "[parser]") {
 }
 
 TEST_CASE("instantiate declarations request concrete operator implementations", "[parser][generics][operators]") {
-    REQUIRE(dump_clean("module t\ninstantiate choose<i64>, choose<f64, 3>\n") == "Module\n"
+    REQUIRE(dump_clean("module t\ninstantiate choose<i64>, choose<f64, _>\n") == "Module\n"
                                                                                  "  ModuleDecl t\n"
                                                                                  "  InstantiateDecl\n"
                                                                                  "    Instantiation choose\n"
@@ -285,8 +285,7 @@ TEST_CASE("instantiate declarations request concrete operator implementations", 
                                                                                  "    Instantiation choose\n"
                                                                                  "      GenericArgument\n"
                                                                                  "        Type scalar f64\n"
-                                                                                 "      GenericArgument\n"
-                                                                                 "        IntLiteral 3\n");
+                                                                                 "      GenericArgument retained\n");
 }
 
 TEST_CASE("the declarative grammar preserves trailing parenthesized newlines", "[parser]") {


### PR DESCRIPTION
## Summary

- add module-level `instantiate op<...>` syntax for publishing generic `impl fn` operator candidates
- allow `_` in an instantiation slot to retain that type or const generic for resolver selection instead of binding it concretely
- distinguish concrete-required generics, signature-only retained markers, and retained values that require deliberate reification
- lower retained fixed-list sizes to `hgraph::SIZE<"name">`, with compiled resolver coverage across multiple concrete list sizes
- carry materialization substitutions through typed HIR, hgraph IR, descriptors, and readable generated C++
- register and advertise only requested materializations while keeping generic implementation templates hidden
- diagnose unsupported retained-generic value access and residual constraints explicitly
- resolve concrete duration substitutions before selecting rolling-window C++ shapes

For example, `instantiate sum_<i64, _>, sum_<f64, _>` publishes two candidates whose element types are fixed but whose list size remains selectable by hgraph's resolver. Retention alone does not make the selected size available to the implementation body; that requires a future explicit reification mechanism.

This PR is intentionally independent of the runtime-spec and HGL standard-library prototype. That prototype is stacked separately and consumes this syntax.

## Validation

- all 55 HGL tests
- clean native CMake build
- all 1,735 native C++ tests
- ABI3 wheel built with Python 3.12 and installed into a fresh Python 3.14 environment
- Python compatibility suite: 3,284 passed, 10 skipped
