### PR TITLE
Stop re-binding a reference-sourced nested boundary every cycle (fixes #769-#779)

### DIFF
--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -950,6 +950,16 @@ this codebase, the current code wins:
   branch-selection operation. Ordinary per-cycle rebinding is a no-op;
   ``make_active`` remains subscription-only and does not fabricate a
   modification. We deliberately diverge from Python's ``value = None`` reset.
+  That no-op is only a no-op if the "already bound?" test compares what a bind
+  *would record*, not what the child link currently observes: a ``REF`` source
+  is transparent at an input boundary, so the link records and reports the
+  referenced output, which never equals the ``REF`` output the boundary
+  re-offers. ``TSInputView::bound_to_source`` applies the bind-time adaptation
+  before comparing, which is why the boundary helpers use it instead of
+  comparing ``bound_output()`` handles. Comparing the observation instead
+  re-bound every reference-sourced boundary each cycle, and a re-bind notifies
+  the consumer, so a branch reading such a boundary ticked whenever its owner
+  evaluated with nothing changed upstream (issues #769-#779).
 - **Stable payload storage is implemented.** Fixed nested graphs are part of
   the parent node's storage plan. ``map_`` mirrors ``__keys__`` slots into
   stable entry-plus-graph blocks; ``mesh_`` uses its own observed key-slot

--- a/include/hgraph/runtime/nested_bindings.h
+++ b/include/hgraph/runtime/nested_bindings.h
@@ -137,6 +137,14 @@ walk_forwarding_target_path(TSOutputView view,
  * outer boundary is bound to (re-resolved each cycle; a no-op when the
  * endpoint already references the same output, and unbinds while the
  * upstream is unbound).
+ *
+ * The "already bound?" test adapts the offered source exactly as a bind
+ * would before comparing: a ``REF`` source is transparent at an input
+ * boundary, so the link records the *referenced* output and comparing the
+ * raw handles never matched. That re-bound a reference-sourced boundary on
+ * every cycle, and every re-bind notifies the consumer, so a nested branch
+ * reading such a boundary ticked whenever its owner evaluated, with no
+ * change upstream (issues #769-#779).
  */
 inline void bind_input_to_source(TSInputView target,
                                  const TSOutputView &source) {
@@ -152,8 +160,7 @@ inline void bind_input_to_source(TSInputView target,
     return;
   }
 
-  auto current = target.bound_output();
-  if (!current.handle().same_as(source.handle())) {
+  if (!target.bound_to_source(source)) {
     target.bind_output(source);
   }
 }
@@ -172,8 +179,7 @@ inline void rebind_input_to_source_silent(TSInputView target,
     return;
   }
 
-  auto current = target.bound_output();
-  if (!current.handle().same_as(source.handle())) {
+  if (!target.bound_to_source(source)) {
     target.rebind_output_silent(source);
   }
 }

--- a/include/hgraph/types/time_series/ts_input/base_view.h
+++ b/include/hgraph/types/time_series/ts_input/base_view.h
@@ -164,6 +164,20 @@ namespace hgraph
         [[nodiscard]] TSOutputView bound_output() const;
 
         /**
+         * True when binding ``output`` here would record the target this link
+         * already holds, so the bind can be skipped.
+         *
+         * Comparing ``bound_output()`` to the offered output is not the same
+         * test: a ``REF`` source is transparent at an input boundary, so the
+         * link records (and reports) the *referenced* output, which never
+         * equals the ``REF`` output a caller re-offers. Callers that re-bind
+         * a boundary every cycle must use this, or they re-bind a
+         * reference-sourced input every time, and every re-bind notifies the
+         * consumer (issues #769-#779).
+         */
+        [[nodiscard]] bool bound_to_source(const TSOutputView &output) const;
+
+        /**
          * True when the output this input's link bound can retarget without
          * the link rebinding: a ``REF`` output, or an output itself reached
          * through a target link (a from-REF alternative, a chained adaptor's

--- a/include/hgraph/types/time_series/ts_input/target_link.h
+++ b/include/hgraph/types/time_series/ts_input/target_link.h
@@ -139,9 +139,14 @@ namespace hgraph::detail
          * the target this link already holds. The source is adapted exactly as
          * ``bind`` adapts it, so a transparent ``REF`` source compares against
          * the referenced output the link actually followed (RFC 0036).
+         *
+         * Not ``noexcept``: the adaptation is the one ``bind`` performs, so an
+         * unbindable source raises here instead of at the bind it replaces.
+         * The graph's ordinary error handling sees the same exception it saw
+         * when the caller went straight to ``bind``.
          */
         [[nodiscard]] bool bound_to(const TSValueTypeMetaData &schema,
-                                    const TSOutputView &output) const noexcept;
+                                    const TSOutputView &output) const;
         [[nodiscard]] bool structural_transition_active() const noexcept;
         [[nodiscard]] bool sampled_structural_transition() const noexcept;
         [[nodiscard]] DateTime structural_transition_time() const noexcept;

--- a/include/hgraph/types/time_series/ts_input/target_link.h
+++ b/include/hgraph/types/time_series/ts_input/target_link.h
@@ -134,6 +134,14 @@ namespace hgraph::detail
         [[nodiscard]] TSDataView target_view() const noexcept;
         [[nodiscard]] TSDataView previous_target_view() const noexcept;
         [[nodiscard]] const TSOutputHandle &target_output() const noexcept;
+        /**
+         * True when a bind of ``output`` into a slot of ``schema`` would record
+         * the target this link already holds. The source is adapted exactly as
+         * ``bind`` adapts it, so a transparent ``REF`` source compares against
+         * the referenced output the link actually followed (RFC 0036).
+         */
+        [[nodiscard]] bool bound_to(const TSValueTypeMetaData &schema,
+                                    const TSOutputView &output) const noexcept;
         [[nodiscard]] bool structural_transition_active() const noexcept;
         [[nodiscard]] bool sampled_structural_transition() const noexcept;
         [[nodiscard]] DateTime structural_transition_time() const noexcept;

--- a/python/tests/test_nested_reference_context_retick.py
+++ b/python/tests/test_nested_reference_context_retick.py
@@ -1,0 +1,91 @@
+"""A nested branch must not re-tick because its owner evaluated.
+
+A nested-graph boundary (``switch_``, ``map_``) re-binds its child inputs on
+every evaluation so an upstream reference that re-points is absorbed. The
+"is this already bound?" test compared the offered output against what the
+child link *observes*, but a ``REF`` source is transparent at an input
+boundary, so the link observes the referenced output and the comparison never
+matched. The boundary therefore re-bound a reference-sourced input every
+cycle, and every re-bind notifies the consumer, so a branch reading such an
+input emitted whenever the switch key ticked - even when the key was
+unchanged and nothing upstream had moved (issues #769-#779).
+
+Released hgraph 0.5 rebuilds a branch only when the key *value* changes, and
+notifies the branch's boundary only then, so these graphs must not tick.
+"""
+
+import hgraph as hg
+from hgraph.test import eval_node
+
+
+@hg.compute_node
+def _publish_ref(ts: hg.REF[hg.TIME_SERIES_TYPE]) -> hg.TSD[str, hg.REF[hg.TIME_SERIES_TYPE]]:
+    """Republish ``ts`` under one key, the shape a TSD item lookup has."""
+    return {"k": ts.value}
+
+
+def _via_reference(value):
+    """Route ``value`` through a REF-producing source, as the parity corpus does."""
+    return _publish_ref(value)[hg.const("k")]
+
+
+@hg.graph
+def _add_offset(value: hg.TS[int]) -> hg.TS[int]:
+    return value + hg.get_context("offset", hg.TS[int])
+
+
+@hg.graph
+def _subtract_offset(value: hg.TS[int]) -> hg.TS[int]:
+    return value - hg.get_context("offset", hg.TS[int])
+
+
+@hg.graph
+def _context_switch(selector: hg.TS[str], value: hg.TS[int], offset: hg.TS[int]) -> hg.TS[int]:
+    offset = _via_reference(offset)
+    with offset:
+        return hg.switch_(selector, {"add": _add_offset, "subtract": _subtract_offset}, value)
+
+
+def test_unchanged_switch_key_does_not_retick_a_reference_sourced_context():
+    # The selector re-ticks with the same key on cycles 2 and 3: the branch is
+    # not rebuilt and no input changed, so there is no output.
+    assert eval_node(
+        _context_switch,
+        ["add", "add", "add"],
+        [0, None, None],
+        [0, None, None],
+    ) == [0, None, None]
+
+
+def test_changed_switch_key_still_rebuilds_and_emits():
+    # A real key change rebinds the branch, which samples its inputs and emits.
+    assert eval_node(
+        _context_switch,
+        ["add", "subtract"],
+        [1, None],
+        [10, None],
+    ) == [11, -9]
+
+
+def test_reference_sourced_context_still_propagates_its_own_ticks():
+    # The guard must not silence a genuine change to the context.
+    assert eval_node(
+        _context_switch,
+        ["add", None, None],
+        [1, None, None],
+        [10, 20, None],
+    ) == [11, 21, None]
+
+
+def test_reference_sourced_switch_argument_does_not_retick():
+    # The same boundary rule for an ordinary switch argument rather than a
+    # context: an unchanged key must not resample it.
+    @hg.graph
+    def passthrough(value: hg.TS[int]) -> hg.TS[int]:
+        return value
+
+    @hg.graph
+    def graph(selector: hg.TS[str], value: hg.TS[int]) -> hg.TS[int]:
+        return hg.switch_(selector, {"a": passthrough, "b": passthrough}, _via_reference(value))
+
+    assert eval_node(graph, ["a", "a", "a"], [1, None, None]) == [1, None, None]

--- a/src/hgraph/types/time_series/ts_input/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_input/base_view.cpp
@@ -390,6 +390,19 @@ namespace hgraph
         return link->resolved_target_at_path(*schema, data_.target_path_node()).view(evaluation_time_);
     }
 
+    bool TSInputView::bound_to_source(const TSOutputView &output) const
+    {
+        if (!is_target_position()) { return false; }
+
+        const auto *schema = detail::target_link_schema(data_.raw_data);
+        const auto *link   = data_.link_storage();
+        if (schema == nullptr || link == nullptr) { return false; }
+        // Only the link root records a bind target; a projected position
+        // inside it is reached through that one target.
+        if (data_.target_path_node() != nullptr) { return false; }
+        return link->bound_to(*schema, output);
+    }
+
     bool TSInputView::bound_target_is_reference() const noexcept
     {
         if (!is_target_position()) { return false; }

--- a/src/hgraph/types/time_series/ts_input/target_link.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link.cpp
@@ -72,6 +72,34 @@ namespace hgraph::detail
 
         [[nodiscard]] bool is_closed_union_narrowing(
             const TSValueTypeMetaData &requested,
+            const TSValueTypeMetaData *source) noexcept;
+
+        /**
+         * The handle a bind of ``output`` into a slot of ``schema`` records.
+         *
+         * A REF source bound into a concrete slot is transparent, so the
+         * recorded handle is the *referenced* output, not the reference. Both
+         * ``bind_impl`` and the "is this link already bound to that source?"
+         * test go through here, so a caller re-offering the same source
+         * compares like with like (RFC 0036).
+         */
+        [[nodiscard]] TSOutputHandle bind_target_handle(const TSValueTypeMetaData &schema,
+                                                        const TSOutputView &output)
+        {
+            const bool closed_union_narrowing = is_closed_union_narrowing(schema, output.schema());
+            const bool signal_from_reference =
+                schema.kind == TSTypeKind::SIGNAL && output.schema() != nullptr &&
+                output.schema()->kind == TSTypeKind::REF;
+            // SIGNAL accepts every concrete time-series shape, but a REF source is
+            // transparent at an input boundary: observe the referenced output's
+            // ticks, not changes to the reference token itself.
+            return (schema.kind == TSTypeKind::SIGNAL && !signal_from_reference) || closed_union_narrowing
+                       ? output.handle()
+                       : output.binding_for(schema);
+        }
+
+        [[nodiscard]] bool is_closed_union_narrowing(
+            const TSValueTypeMetaData &requested,
             const TSValueTypeMetaData *source) noexcept
         {
             if (source == nullptr || requested.kind != TSTypeKind::TS || source->kind != TSTypeKind::TS ||
@@ -954,16 +982,7 @@ namespace hgraph::detail
         }
 
         const bool closed_union_narrowing = is_closed_union_narrowing(schema, output.schema());
-        const bool signal_from_reference =
-            schema.kind == TSTypeKind::SIGNAL && output.schema() != nullptr &&
-            output.schema()->kind == TSTypeKind::REF;
-        // SIGNAL accepts every concrete time-series shape, but a REF source is
-        // transparent at an input boundary: observe the referenced output's
-        // ticks, not changes to the reference token itself.
-        auto target = (schema.kind == TSTypeKind::SIGNAL && !signal_from_reference) ||
-                              closed_union_narrowing
-                          ? output.handle()
-                          : output.binding_for(schema);
+        auto       target                 = bind_target_handle(schema, output);
         if (schema.kind != TSTypeKind::SIGNAL && !closed_union_narrowing &&
             !time_series_schema_equivalent(target.schema(), &schema))
         {
@@ -1194,6 +1213,13 @@ namespace hgraph::detail
     const TSOutputHandle &TSInputTargetLinkStorage::target_output() const noexcept
     {
         return state_.target;
+    }
+
+    bool TSInputTargetLinkStorage::bound_to(const TSValueTypeMetaData &schema,
+                                            const TSOutputView &output) const noexcept
+    {
+        if (!bound() || !output.bound()) { return false; }
+        return state_.target.same_as(bind_target_handle(schema, output));
     }
 
     bool TSInputTargetLinkStorage::structural_transition_active() const noexcept

--- a/src/hgraph/types/time_series/ts_input/target_link.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link.cpp
@@ -1216,7 +1216,7 @@ namespace hgraph::detail
     }
 
     bool TSInputTargetLinkStorage::bound_to(const TSValueTypeMetaData &schema,
-                                            const TSOutputView &output) const noexcept
+                                            const TSOutputView &output) const
     {
         if (!bound() || !output.bound()) { return false; }
         return state_.target.same_as(bind_target_handle(schema, output));

--- a/tests/cpp/test_context_wiring.cpp
+++ b/tests/cpp/test_context_wiring.cpp
@@ -289,6 +289,35 @@ namespace
         }
     };
 
+    /** Publishes its input as a reference, the shape a TSD/map/if_ source has. */
+    struct ReferencePublisher
+    {
+        static constexpr auto name = "reference_publisher";
+
+        static void eval(In<"ts", TS<Int>> ts, Out<REF<TS<Int>>> out) { out.set(ts.reference()); }
+    };
+
+    /** ``SwitchContextGraph`` with the context published through a reference. */
+    struct SwitchReferenceContextGraph
+    {
+        static constexpr auto name = "switch_reference_context_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Str>> key,
+                                     Port<TS<Int>> value, Port<TS<Int>> price)
+        {
+            auto published = wire<ReferencePublisher>(w, price).as<REF<TS<Int>>>();
+            context::scope<"price"> ctx{w, published};
+            return wire<stdlib::switch_>(
+                       w, key,
+                       stdlib::switch_cases({
+                           {Value{Str{"add"}}, fn<AddCapturedContext>()},
+                           {Value{Str{"sub"}}, fn<SubtractCapturedContext>()},
+                       }),
+                       value)
+                .as<TS<Int>>();
+        }
+    };
+
     struct MapContextGraph
     {
         static constexpr auto name = "map_context_graph";
@@ -444,6 +473,33 @@ TEST_CASE("context wiring: switch branches import context and react to its ticks
                      values<Int>(1, 2, none, none, 3),
                      values<Int>(10, none, 20, none, none)),
                  values<Int>(11, 12, 22, -18, -17));
+}
+
+TEST_CASE("context wiring: a reference-sourced context does not re-tick on an unchanged key")
+{
+    // The key re-ticks with the SAME value on cycles 2 and 3, so the branch is
+    // not rebuilt and nothing upstream changed: the branch must not evaluate.
+    // Re-binding the branch boundary each cycle used to notify a
+    // reference-sourced context every time the switch evaluated, so the branch
+    // re-emitted on every key tick (issues #769-#779).
+    stdlib::register_standard_operators();
+    CHECK_OUTPUT(eval_node<SwitchReferenceContextGraph>(
+                     values<Str>(Str{"add"}, Str{"add"}, Str{"add"}, Str{"sub"}),
+                     values<Int>(1, none, none, none),
+                     values<Int>(10, none, none, none)),
+                 values<Int>(11, none, none, -9));
+}
+
+TEST_CASE("context wiring: a reference-sourced context still propagates its own ticks")
+{
+    // The guard must not silence a genuine change: the context ticks on cycle
+    // 2 and the branch re-evaluates with the new value.
+    stdlib::register_standard_operators();
+    CHECK_OUTPUT(eval_node<SwitchReferenceContextGraph>(
+                     values<Str>(Str{"add"}, none, Str{"add"}),
+                     values<Int>(1, none, none),
+                     values<Int>(10, 20, none)),
+                 values<Int>(11, 21, none));
 }
 
 TEST_CASE("context wiring: map children share context across key and value lifetimes")

--- a/tools/parity/corpus/context-switch-unchanged-key-no-retick.json
+++ b/tools/parity/corpus/context-switch-unchanged-key-no-retick.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "id": "context-switch-unchanged-key-no-retick",
+  "description": "A switch key that re-ticks with an unchanged value must not resample a reference-sourced context, so the branch does not re-emit.",
+  "template": "context_switch",
+  "inputs": {
+    "selector": [
+      "add",
+      "add",
+      "add",
+      "subtract"
+    ],
+    "value": [
+      1,
+      null,
+      null,
+      null
+    ],
+    "offset": [
+      10,
+      null,
+      null,
+      null
+    ]
+  },
+  "parameters": {
+    "reference_source": "tsd_getitem"
+  },
+  "features": [
+    "binding:peered",
+    "framework:context",
+    "lifecycle:branch-rebind",
+    "operator:getitem_",
+    "reference-source:tsd_getitem",
+    "reference:REF",
+    "shape:TS",
+    "shape:TSD",
+    "topology:context",
+    "topology:switch"
+  ],
+  "source_issue": "https://github.com/hhenson/hgraph/issues/769"
+}


### PR DESCRIPTION
Fixes the eleven open `[parity]` issues (#769-#779). All eleven minimize to one defect.

## Symptom

Every issue is the same shape: a context read inside a `switch_` branch, with the context sourced through a REF (`tsd_getitem`, `map_element` or `if_true`). When the selector re-ticks with an **unchanged** key, released hgraph 0.5 emits nothing and the C++ runtime emits a value:

```
reference: [0, None]      candidate: [0, 0]
```

The reference-source and selector operator vary across the eleven; neither matters.

## Cause

A nested-graph boundary re-binds its child inputs on every evaluation, so an upstream reference that re-points is absorbed (`bind_branch_inputs`, "re-bind boundaries each cycle"). That is only free if the "already bound?" test is accurate, and it was not.

A REF source is transparent at an input boundary: `bind_impl` records `output.binding_for(schema)`, i.e. the **referenced** output, and `bound_output()` reports what the link observes - also the referenced output. The boundary helper compared that against the **REF** output it re-offers, so the handles never matched:

```
[REBIND] out 1 schema 0 data 0xb65154680 vs 0xb652ad220     # same output, different endpoint
```

So the boundary re-bound every cycle, and `TSInputView::bind_output` notifies the consumer on a re-bind. The branch's context consumer was therefore scheduled whenever the switch evaluated. Instrumented, the context ticked once per key tick (`count` inside the branch went 1, 2, 3) where a non-REF context ticked once.

Released hgraph rebuilds a branch only when the key *value* changes, and notifies the branch boundary only then, so the extra tick was a genuine divergence rather than an accepted deviation.

## Fix

`TSInputTargetLinkStorage::bound_to` adapts the offered source exactly as a bind would before comparing; `TSInputView::bound_to_source` exposes it at the link root (a projected position keeps the old path). `bind_input_to_source` and `rebind_input_to_source_silent` use it instead of comparing `bound_output()` handles. `bind_impl` and the new comparison share one `bind_target_handle` helper so the adaptation cannot drift.

This restores an invariant the design record already stated: `nested_graphs.rst` says "Ordinary per-cycle rebinding is a no-op". The doc now also records what the comparison has to be for that to hold, since the transparent-REF case is the trap.

A genuine REF re-point still re-binds and notifies, because the referenced output then differs. `map_` was checked and behaves identically with REF and plain contexts, before and after.

## Verification

All eleven recipes now reproduce the released trace, replayed from the issue bodies:

```
#769 PASS [0, None]        #774 PASS [None, 0, None]     #778 PASS [None, 0, None]
#770 PASS [0, None]        #775 PASS [None, 0, None]     #779 PASS [None, -1, None]
#771 PASS [0, None]        #776 PASS [None, 0, None]
#772 PASS [0, None]        #777 PASS [0, None]
#773 PASS [None, 0, None]
```

Coverage added, per the issues' acceptance criteria:

- **Native C++ `eval_node`**: two cases in `test_context_wiring.cpp` - an unchanged key does not re-tick a reference-sourced context, and a genuine context tick still propagates. **Both fail without the fix** (verified by reverting the comparison and re-running).
- **Public Python wiring**: `python/tests/test_nested_reference_context_retick.py`, four cases including a real key change and a reference-sourced switch *argument*.
- **Parity corpus**: `context-switch-unchanged-key-no-retick.json`, so the harness keeps the case.

Local gate, all green:

| Check | Result |
|---|---|
| C++ suite | 1718 cases, 257446 assertions |
| Python `python/tests` + all five extension suites | 3654 passed, 10 skipped |
| Parity harness, REF sweep, transparency owners, switch TSD delta, ratchets | 923 passed |
| `sphinx -W` | build succeeded |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
