### PR TITLE
Support native collection-view overloads in HGL

### DIFF
--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -2,7 +2,8 @@
 
 Status: accepted boundary; descriptor validation, native declaration metadata,
 canonical fingerprints, the lifecycle ABI, explicit descriptor authoring, and
-exact canonical-scalar evaluation calls in AOT modules implemented;
+exact canonical-value and overloaded collection-input-view evaluation calls in
+AOT modules implemented;
 normalized-wrapper generation, opaque state, and external scripted dependency
 loading remain
 
@@ -44,11 +45,14 @@ For every exposed native declaration the descriptor records:
 - canonical HGL module and declaration identity;
 - declaration category: hgraph operator, exact native value function, native
   constructor, or lifecycle operation;
-- complete HGL parameter and result types;
+- complete HGL parameter and result types, including generic collection-view
+  patterns used only for overload selection;
 - permitted phases: wiring, start, evaluation, or stop;
 - observable effects, including mutation, I/O, blocking, and allocation where
   relevant;
 - value, owned, shared, or borrowed ownership and any dependent lifetime;
+- whether a parameter receives its current scalar value or its live typed input
+  view;
 - exception and thread-safety policy;
 - canonical C++ symbol or generated wrapper identity;
 - required public headers, CMake packages, imported targets, and runtime image;
@@ -67,8 +71,9 @@ associations, runtime images, and lifecycle ABI metadata. The reader enforces
 the initial non-blocking/noexcept evaluation envelope, explicit mutable state,
 borrow rules, and lifecycle consistency. The compiler can build an explicit
 module catalog from one or more descriptors, resolve a selective or aliased
-`use`, carry an exact canonical-scalar function through HIR and HGraph IR, and
-emit its reviewed `cpp_symbol` as a direct call. The AOT CMake helper obtains
+`use`, select an exact overload from canonical scalar or collection types,
+carry that candidate through HIR and HGraph IR, and emit its reviewed
+`cpp_symbol` as a direct call. The AOT CMake helper obtains
 descriptors from directly linked targets. Locked transitive dependency closure
 and external-package resolution for the scripted loader remain to be added. No
 new HGL declaration syntax is implied by this list.
@@ -86,12 +91,22 @@ An ordinary C++ scalar function is never lifted implicitly into one node per
 call. A package that wants temporal use supplies and registers the corresponding
 hgraph operator implementation explicitly.
 
-### Exact native value functions
+### Exact native value and view functions
 
-An exact native value function is callable only in phases allowed by its
-descriptor. The implemented first slice targets exact canonical-scalar
-computations inside an HGL runtime node. Construction or cleanup of private
-native state is the next stateful slice.
+An exact native function is callable only in phases allowed by its descriptor.
+A value parameter receives the current canonical scalar payload. A collection
+`input-view` parameter receives the corresponding live `TSL`, `TSS`, `TSD`, or
+rolling input view. This permits constant-time metadata operations such as
+`len(value)` and the existing collection iterators without materializing a
+collection or inspecting its schema on every tick. Construction or cleanup of
+private native state is the next stateful slice.
+
+Native declarations may share one canonical identity when their HGL signatures
+differ. The compiler treats them as one overload family, unifies generic
+collection patterns against the argument types, and records the unique selected
+candidate before HGraph IR lowering. No implicit conversions or native-overload
+ranking are involved: no match is an error, and overlapping matches are
+ambiguous. A package should therefore publish disjoint patterns.
 
 The generated C++ calls the declared symbol or its package-provided wrapper
 directly. The direct-wiring backend does not emulate it: a runtime-bearing
@@ -101,7 +116,7 @@ Calls from wiring-time constant evaluation, automatic temporal lifting, and
 general compile-time execution are outside the first interface. Although the
 phase metadata can describe wiring, start, evaluation, and stop, the compiler
 accepts a call only in a phase named by the descriptor and the implemented
-canonical-scalar slice is exercised in evaluation.
+canonical-value and collection-view slices are exercised in evaluation.
 
 ### Opaque native state
 
@@ -134,15 +149,20 @@ The compiler does not infer those operations from a C++ class definition.
 
 The first native-value implementation is intentionally narrow:
 
-- arguments and results are canonical scalar values or an opaque state value
-  declared by the same module;
+- value arguments and results are canonical scalar values or an opaque state
+  value declared by the same module;
+- collection arguments may use generic `list`, `set`, `map`, or `rolling`
+  patterns only when the parameter explicitly requests `input-view` access;
+- collection type and extent generics participate in compile-time selection but
+  are not automatically exposed as runtime values;
 - opaque state uses owned RAII storage and cannot cross a temporal port;
 - evaluation functions are non-blocking and `noexcept`;
 - mutation is restricted to an explicitly identified state argument;
 - raw pointers, references, pointer arithmetic, callbacks, variadic calls, and
   open C++ templates are not representable;
-- a C++ template is exposed only through an explicit specialization or wrapper
-  with one complete HGL signature;
+- an open C++ template is still exposed only through an explicit specialization
+  or wrapper; generic HGL input-view patterns erase to reviewed non-template C++
+  view types;
 - native declarations do not participate in implicit conversions;
 - descriptor and loaded-provider fingerprints must agree before wiring.
 
@@ -170,6 +190,26 @@ fn smooth(value: f64, const window: i64) -> f64 {
 }
 ```
 
+An overload family uses the same source syntax. Here `len` is a direct native
+view operation, while a public temporal `len_` operator can call it from its
+runtime implementation:
+
+```hgl
+use hgraph.native as native
+
+impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
+    when modified(value) && valid(value) {
+        return native::len(value)
+    }
+}
+```
+
+`T` and `size` select the list-view overload. The body does not need either
+value: the selected C++ overload reads `value.size()` from the live input view.
+This is the important distinction between a generic required to instantiate or
+select a callable, a marker retained only as part of a type, and runtime
+information explicitly available through a native view.
+
 This example introduces no new HGL syntax. The source spelling and inference
 rules for an imported opaque state type are not settled, so this record does not
 invent an example for them. The native implementation must stop at that design
@@ -180,10 +220,10 @@ question if existing nominal type syntax is insufficient.
 The installed `hgl::native_package` C++ API is the first producer. A small
 build-time executable owned by the native package fills an
 `hgl::native::Package` and calls `write_descriptor`. The authoring model can
-name only canonical scalars and nominal native types declared by that same
-package. It sorts set-like inventories and declarations, creates the shared
-descriptor schema records, seals the result, and runs the same validator used
-by `hgl check` before writing anything.
+name canonical scalars, nominal native types declared by that same package,
+and generic collection input-view patterns. It sorts set-like inventories and
+declarations, creates the shared descriptor schema records, seals the result,
+and runs the same validator used by `hgl check` before writing anything.
 
 For example, this describes a non-throwing scalar operation:
 
@@ -221,10 +261,41 @@ int main()
 ```
 
 The named `cpp_symbol` must already be an exact directly callable public C++
-symbol. If an overload, template, throwing function, or ownership-heavy API
-needs normalization, the package supplies a small reviewed wrapper and names
-that wrapper. Automatic wrapper emission is a remaining Stage F slice; the
-authoring API does not parse headers or accept arbitrary C++ declarations.
+symbol. Multiple descriptor declarations may name the same C++ overload family
+and HGL identity when their HGL signatures differ. If a template, throwing
+function, or ownership-heavy API needs normalization, the package supplies a
+small reviewed wrapper and names that wrapper. Automatic wrapper emission is a
+remaining Stage F slice; the authoring API does not parse headers or accept
+arbitrary C++ declarations.
+
+For example, an erased list-view overload is described as:
+
+```cpp
+const ValueType i64 = ValueType::canonical(ScalarType::I64);
+const ValueType t = ValueType::type_parameter("T");
+
+Declaration{
+    .identity = "hgraph.native::len",
+    .cpp_symbol = "hgraph::native::len",
+    .generics = {
+        GenericParameter{.name = "T"},
+        GenericParameter{.name = "N", .is_const = true, .type = i64},
+    },
+    .parameters = {
+        Parameter{
+            .name = "value",
+            .type = ValueType::list(t, "N"),
+            .access = ParameterAccess::InputView,
+        },
+    },
+    .result_type = i64,
+    .phases = {Phase::Evaluation},
+}
+```
+
+The named C++ overload accepts `const hgraph::TSLInputView &` (or the view by
+value) and returns `hgraph::Int`. Parallel declarations for `set<T>` and
+`map<K, V>` form the same HGL overload family.
 
 For AOT compilation, place the descriptor path on the native dependency
 target's `HGL_MODULE_DESCRIPTORS` property and link that target from the HGL

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -258,8 +258,9 @@ HGraph IR; unsupported language-depth items remain explicit roadmap work.
   scripted native module activation, replacement, and logical removal;
 - [x] provide an installed native-package authoring API which emits, seals, and
   validates descriptors;
-- [x] resolve exact canonical-scalar native evaluation functions from explicit
-  descriptors and emit direct readable calls in AOT modules;
+- [x] resolve exact canonical-value and overloaded generic collection-view
+  native evaluation functions from explicit descriptors and emit direct
+  readable calls in AOT modules;
 - generate normalized wrappers for C++ overloads, templates, exceptions, and
   ownership boundaries;
 - [x] add phase, effect, ownership, dependent-lifetime, exception,
@@ -339,7 +340,7 @@ today (#767, "Readiness").
 | Timed harness sequences (`[0s: v, ...]`) | provisional | Parsed and typed; "timed sequences are not supported by the first pass". |
 | `hgl run` | partial | `--entry`, `--mode`, `--start`, `--end`, `--set`; an entry is an `export fn` whose parameters are all `const`. |
 | `hgl run --config run.toml` (`[run]`, `[run.params]`) | provisional | Documented format; not read. |
-| Native interface | partial | JSON descriptor format v1, descriptor-only `hgl check`, `hgl::native_package`, lifecycle ABI v1 for scripted images, exact canonical-scalar calls emitted in AOT modules. Normalized wrappers, owned opaque state, scripted external dependencies, transitive closure, and the AOT lifecycle ABI remain; direct wiring rejects a native scalar call in a composition body. Format v1 labels every temporal parameter `"kind": "signal"`; renaming is an open v2 decision (#767 item 6). |
+| Native interface | partial | JSON descriptor format v1, descriptor-only `hgl check`, `hgl::native_package`, lifecycle ABI v1 for scripted images, and exact canonical-value plus overloaded generic collection-view calls emitted in AOT modules. Normalized wrappers, owned opaque state, scripted external dependencies, transitive closure, and the AOT lifecycle ABI remain; direct wiring rejects a native value call in a composition body. Format v1 labels every temporal parameter `"kind": "signal"`; renaming is an open v2 decision (#767 item 6). |
 | Tooling: `check` (`--dump-tokens`, `--dump-ast`, `--dump-hir`, `--dump-hgraph-ir`), `test`, `run`, `emit-cpp`, `repl`, `hgl_add_module()` with `PYTHON_MODULE`, native cache v3 | partial | Scripted loading and the cache are Unix-only; Windows, child orchestration, cache pruning, and dependency lock files are staged; there is no `hgl build`; the driver does not invoke `hgraph_ir::complete`. |
 
 The inventory comes next. Its first candidate set should prefer pure

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1187,15 +1187,17 @@ exact fingerprint before initialization.
 
 The installed `hgl::native_package` facade translates its deliberately narrow
 public C++ value model into this descriptor arena. It allocates canonical
-scalar and nominal schema records, normalizes inventories and declaration
-order, seals the descriptor, and invokes the ordinary descriptor validator.
+scalar, nominal, and generic collection-view schema records, normalizes
+inventories and declaration order, seals the descriptor, and invokes the
+ordinary descriptor validator.
 Compiler-internal HIR and HGraph-IR types remain hidden behind the shared
 library boundary. A data-only module catalog adapts validated descriptors into
 importable declarations. Resolution binds selective imports and module aliases
-to exact native-function symbols; type checking enforces exact
-canonical-scalar arguments, `const` roles, and permitted phases; and HGraph IR
-owns the selected C++ symbol and build inventory. The emitter renders that
-selection as a direct public-header call. Locked transitive dependency closure,
+to native overload families; type checking selects one exact scalar or
+collection-view signature and enforces `const` roles and permitted phases; and
+HGraph IR owns the selected C++ symbol and build inventory. The emitter renders
+value arguments as current payloads and `input-view` arguments as live typed
+selectors in a direct public-header call. Locked transitive dependency closure,
 normalized-wrapper generation, opaque state, and external-package resolution
 for scripted builds remain Stage F work. Validating one file does not yet prove
 that its declared provider requirements are present or mutually compatible.
@@ -1615,14 +1617,18 @@ expression is read from the syntax tree.
   `modified`, `added`, or `removed` views. A concise iterator predicate is
   inlined as a readable loop guard. Keyed `out[key] = value` uses the typed TSD
   output selector and accumulates child writes in the cycle's delta.
-- **Exact native scalar calls.** Explicit module descriptors form a data-only
-  import catalog. A selected native evaluation function retains its exact
-  signature, permitted phases, public headers, C++ symbol, dependency inventory,
+- **Exact native value and collection-view calls.** Explicit module descriptors
+  form a data-only import catalog. Declarations with one identity form an
+  overload family; generic `list`, `set`, `map`, and `rolling` patterns are
+  unified against checked argument types, and exactly one candidate must match.
+  The selected native evaluation function retains its signature, permitted
+  phases, parameter access, public headers, C++ symbol, dependency inventory,
   and descriptor fingerprint through HIR and HGraph IR. Its generated body is a
-  direct call such as `acme::stats::blend(value.value(), hgraph::Int{3})`; the
-  compiler neither derives an operator class nor implicitly lifts the scalar
-  function into a node. Argument order/names, exact scalar types, and `const`
-  roles are rechecked at the IR and emission boundaries.
+  direct call such as `acme::stats::blend(value.value(), hgraph::Int{3})` or
+  `hgraph::native::len(value)`. The latter passes the typed input selector, not
+  a materialized collection. The compiler neither derives an operator class nor
+  implicitly lifts the native function into a node. Argument order/names,
+  exact types, and `const` roles are rechecked at the IR and emission boundaries.
 - **Registration.** `hgraph::OperatorProviderHandle register_operators()`
   registers each export and
   each concrete non-generic `impl fn`, plus every concrete generic

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -349,22 +349,26 @@ metadata without loading native code.
 Descriptor validation does not yet locate or lock transitive provider
 requirements. For source compilation, each repeatable `--module-descriptor`
 option adds one explicitly named module to the import catalog. The compiler can
-currently lower an exact, canonical-scalar native function used during runtime
-evaluation; unsupported ownership, effects, nominal native types, or phases
-are diagnosed at the import or call boundary rather than silently approximated.
+currently lower exact canonical-value functions and overloaded collection-view
+functions used during runtime evaluation. For example, `len(value)` can select
+a native list, set, or map overload and read the live collection size.
+Unsupported ownership, effects, nominal native types, or phases are diagnosed
+at the import or call boundary rather than silently approximated.
 
 Native libraries create descriptors with the installed C++ target
 `hgl::native_package` and `<hgl/native_package.h>`. Its public model is narrower
-than the descriptor format: a signature can contain only canonical scalars or
-a nominal native type declared by that package. `descriptor_json(package)`
+than the descriptor format: a signature can contain canonical scalars, a
+nominal native type declared by that package, or a generic `list`, `set`, `map`,
+or `rolling` input-view pattern. `descriptor_json(package)`
 returns canonical sealed JSON; `write_descriptor(package, path)` additionally
 writes it for installation. Both reject the same unsafe phase, effect,
 ownership, borrow, and lifecycle combinations as `hgl check`.
 
-The package names either an exact public C++ function or its own reviewed
-normalizing wrapper in each declaration's `cpp_symbol`. The authoring API does
-not parse C++ headers and does not make arbitrary overloads or templates part
-of HGL. See [Native interface](../design/native-interface.md#producing-descriptors)
+The package names either an exact public C++ function family or its own reviewed
+normalizing wrapper in each declaration's `cpp_symbol`. Declarations sharing an
+HGL identity form an overload family and must have distinguishable exact type
+patterns. The authoring API does not parse C++ headers and does not make
+arbitrary templates part of HGL. See [Native interface](../design/native-interface.md#producing-descriptors)
 for the complete example and current wrapper boundary.
 
 A package is a CMake project. `hgl_add_module()`, installed with `hgl` in
@@ -416,11 +420,11 @@ nominal and generic structs, fixed and duration rolling windows, sparse struct
 deltas, concise functions passed to `map`, collection inputs and iteration,
 scalar recordable state, ordered `when` handlers, `inject out`, keyed TSD output
 writes, `inject logger`, lifecycle blocks over state and `const` configuration,
-and exact canonical-scalar calls imported from native descriptors during
-runtime evaluation. Native calls remain direct and readable in generated C++;
-the compiler does not synthesize an operator subclass or implicit node. The
-generated package tests compile every example and execute a native-call fixture
-as C++.
+and exact canonical-value or collection-view calls imported from native
+descriptors during runtime evaluation. Native calls remain direct and readable
+in generated C++; the compiler does not synthesize an operator subclass or
+implicit node. The generated package tests compile every example and execute a
+native-call fixture as C++.
 
 It still reports, by name, and writes nothing for generated runtime sources,
 calls to other HGL runtime functions, non-scalar state, native opaque state,

--- a/language/include/hgl/native_package.h
+++ b/language/include/hgl/native_package.h
@@ -41,21 +41,58 @@ namespace hgl::native
     enum class ValueTypeCategory : std::uint8_t {
         Scalar,
         Native,
+        TypeParameter,
+        List,
+        Set,
+        Map,
+        Rolling,
     };
 
-    /// One exact value type in a native signature. Native identities must be
-    /// declared by the same Package; temporal and container types are not
-    /// representable in this API.
+    /// One HGL value pattern in a native signature. Type parameters name a
+    /// generic declared by the same Declaration. Collection patterns describe
+    /// the HGL source type; an InputView parameter receives the corresponding
+    /// live hgraph input view rather than a materialized payload.
     struct ValueType
     {
-        ValueTypeCategory category{ValueTypeCategory::Scalar};
-        ScalarType        scalar{ScalarType::Bool};
-        std::string       native_identity{};
+        ValueTypeCategory      category{ValueTypeCategory::Scalar};
+        ScalarType             scalar{ScalarType::Bool};
+        std::string            native_identity{};
+        std::string            parameter_name{};
+        std::vector<ValueType> children{};
+        std::string            size_parameter{};
+        std::string            min_size_parameter{};
+        bool                   unbounded{false};
 
         [[nodiscard]] static ValueType canonical(ScalarType type) { return ValueType{.scalar = type}; }
 
         [[nodiscard]] static ValueType native(std::string identity) {
             return ValueType{.category = ValueTypeCategory::Native, .native_identity = std::move(identity)};
+        }
+
+        [[nodiscard]] static ValueType type_parameter(std::string name) {
+            return ValueType{.category = ValueTypeCategory::TypeParameter, .parameter_name = std::move(name)};
+        }
+
+        [[nodiscard]] static ValueType list(ValueType element, std::string size = {}, bool is_unbounded = false) {
+            return ValueType{.category       = ValueTypeCategory::List,
+                             .children       = {std::move(element)},
+                             .size_parameter = std::move(size),
+                             .unbounded      = is_unbounded};
+        }
+
+        [[nodiscard]] static ValueType set(ValueType element) {
+            return ValueType{.category = ValueTypeCategory::Set, .children = {std::move(element)}};
+        }
+
+        [[nodiscard]] static ValueType map(ValueType key, ValueType value) {
+            return ValueType{.category = ValueTypeCategory::Map, .children = {std::move(key), std::move(value)}};
+        }
+
+        [[nodiscard]] static ValueType rolling(ValueType element, std::string size, std::string min_size = {}) {
+            return ValueType{.category           = ValueTypeCategory::Rolling,
+                             .children           = {std::move(element)},
+                             .size_parameter     = std::move(size),
+                             .min_size_parameter = std::move(min_size)};
         }
 
         friend bool operator==(const ValueType &, const ValueType &) = default;
@@ -104,6 +141,11 @@ namespace hgl::native
         Borrowed,
     };
 
+    enum class ParameterAccess : std::uint8_t {
+        Value,
+        InputView,
+    };
+
     enum class ExceptionPolicy : std::uint8_t {
         NoThrow,
         Translated,
@@ -124,28 +166,37 @@ namespace hgl::native
 
     struct Parameter
     {
-        std::string name{};
-        ValueType   type{};
-        bool        is_const{false};
-        ValuePolicy policy{};
+        std::string     name{};
+        ValueType       type{};
+        bool            is_const{false};
+        ValuePolicy     policy{};
+        ParameterAccess access{ParameterAccess::Value};
     };
 
-    /// One complete, nongeneric native declaration. cpp_symbol names either a
-    /// directly callable public C++ symbol or a package-owned wrapper which
-    /// has already normalized overload, template, exception, and ownership
-    /// details into this exact contract.
+    struct GenericParameter
+    {
+        std::string              name{};
+        bool                     is_const{false};
+        std::optional<ValueType> type{};
+    };
+
+    /// One native overload. Declarations may share identity when their HGL
+    /// signatures differ. cpp_symbol names either a directly callable public
+    /// C++ overload or a package-owned wrapper which has normalized exception
+    /// and ownership details into this contract.
     struct Declaration
     {
-        DeclarationCategory      category{DeclarationCategory::Function};
-        std::string              identity{};
-        std::string              cpp_symbol{};
-        std::vector<Parameter>   parameters{};
-        std::optional<ValueType> result_type{};
-        ValuePolicy              result_policy{};
-        std::vector<Phase>       phases{};
-        std::vector<Effect>      effects{};
-        ExceptionPolicy          exception_policy{ExceptionPolicy::NoThrow};
-        ThreadSafety             thread_safety{ThreadSafety::NodeLocal};
+        DeclarationCategory           category{DeclarationCategory::Function};
+        std::string                   identity{};
+        std::string                   cpp_symbol{};
+        std::vector<GenericParameter> generics{};
+        std::vector<Parameter>        parameters{};
+        std::optional<ValueType>      result_type{};
+        ValuePolicy                   result_policy{};
+        std::vector<Phase>            phases{};
+        std::vector<Effect>           effects{};
+        ExceptionPolicy               exception_policy{ExceptionPolicy::NoThrow};
+        ThreadSafety                  thread_safety{ThreadSafety::NodeLocal};
     };
 
     struct Lifecycle
@@ -165,9 +216,10 @@ namespace hgl::native
     };
 
     /// The deliberately small native-package authoring model. It cannot name
-    /// arbitrary HGL schema shapes, generic declarations, raw pointers, or
-    /// callbacks. descriptor_json() normalizes set-like inventories, seals the
-    /// descriptor, and applies the compiler's ordinary descriptor validator.
+    /// arbitrary HGL schema shapes, raw pointers, or callbacks. Its generic
+    /// surface is deliberately limited to structural collection-view patterns.
+    /// descriptor_json() normalizes set-like inventories, seals the descriptor,
+    /// and applies the compiler's ordinary descriptor validator.
     struct Package
     {
         std::string              module_identity{};

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -2438,16 +2438,24 @@ namespace hgl::codegen
                          "native function '" + target.identity + "' needs an argument for '" + parameter.name + "'");
                 }
                 const Value argument = eval_planned_expr(*bound[index], frame);
+                if (parameter.access == hir::NativeParameterAccess::InputView) {
+                    if (!frame.runtime || !argument.is_runtime() || argument.selector.empty()) {
+                        fail(Category::Type, argument.range,
+                             "native input-view parameter '" + parameter.name + "' requires a live runtime input");
+                    }
+                    args.push_back(argument.selector);
+                    continue;
+                }
                 const HType expected = planned_type(parameter.type, range);
                 if (!same_type(argument.type, expected)) {
-                    fail(Category::Type, argument.range, "native parameter '" + parameter.name + "' requires an exact scalar type");
+                    fail(Category::Type, argument.range, "native parameter '" + parameter.name + "' requires an exact value type");
                 }
                 if (parameter.is_const || !frame.runtime) {
                     args.push_back(as_const(argument, expected, argument.range, "native parameter '" + parameter.name + "'"));
                 } else {
                     if (!argument.is_const() && !argument.is_runtime()) {
                         fail(Category::Type, argument.range,
-                             "native parameter '" + parameter.name + "' requires an evaluation-time scalar value");
+                             "native parameter '" + parameter.name + "' requires an evaluation-time value");
                     }
                     args.push_back(argument.code);
                 }

--- a/language/src/descriptor/import_catalog.cpp
+++ b/language/src/descriptor/import_catalog.cpp
@@ -31,6 +31,61 @@ namespace hgl::descriptor
             return std::nullopt;
         }
 
+        [[nodiscard]] std::optional<semantics::ImportedConstant> imported_constant(const ModuleDescriptor &descriptor,
+                                                                                   SchemaId                id) noexcept {
+            using semantics::ImportedConstant;
+            using semantics::ImportedConstantKind;
+            if (id == no_schema_id) { return ImportedConstant{}; }
+            if (id >= descriptor.constant_expressions.size()) { return std::nullopt; }
+            const ConstantExpressionRecord &source = descriptor.constant_expressions[id];
+            if (source.category == ConstantExpressionCategory::Parameter) {
+                return ImportedConstant{.kind = ImportedConstantKind::Parameter, .binding_identity = source.parameter_identity};
+            }
+            if (source.category == ConstantExpressionCategory::Literal && source.literal) {
+                if (const auto *value = std::get_if<std::int64_t>(&*source.literal)) {
+                    return ImportedConstant{.kind = ImportedConstantKind::I64, .i64 = *value};
+                }
+            }
+            return std::nullopt;
+        }
+
+        [[nodiscard]] std::optional<semantics::ImportedType> imported_type(const ModuleDescriptor &descriptor,
+                                                                           SchemaId                id) noexcept {
+            using semantics::ImportedType;
+            using semantics::ImportedTypeKind;
+            if (id == no_schema_id || id >= descriptor.types.size()) { return std::nullopt; }
+            const TypeRecord &source = descriptor.types[id];
+            ImportedType      result;
+            if (const auto scalar = scalar_type(descriptor, id)) {
+                result.scalar = *scalar;
+                return result;
+            }
+            switch (source.category) {
+                case TypeCategory::Symbol:
+                    if (source.binding_identity.empty()) { return std::nullopt; }
+                    result.kind             = ImportedTypeKind::Symbol;
+                    result.binding_identity = source.binding_identity;
+                    break;
+                case TypeCategory::List: result.kind = ImportedTypeKind::List; break;
+                case TypeCategory::Set: result.kind = ImportedTypeKind::Set; break;
+                case TypeCategory::Map: result.kind = ImportedTypeKind::Map; break;
+                case TypeCategory::Rolling: result.kind = ImportedTypeKind::Rolling; break;
+                default: return std::nullopt;
+            }
+            for (SchemaId child : source.children) {
+                std::optional<ImportedType> lowered = imported_type(descriptor, child);
+                if (!lowered) { return std::nullopt; }
+                result.children.push_back(std::move(*lowered));
+            }
+            const auto size     = imported_constant(descriptor, source.size);
+            const auto min_size = imported_constant(descriptor, source.min_size);
+            if (!size || !min_size) { return std::nullopt; }
+            result.size      = *size;
+            result.min_size  = *min_size;
+            result.unbounded = source.unbounded;
+            return result;
+        }
+
         [[nodiscard]] std::string short_name(std::string_view module, std::string_view identity) {
             const std::string prefix = std::string{module} + "::";
             if (!identity.starts_with(prefix)) { return {}; }
@@ -46,6 +101,14 @@ namespace hgl::descriptor
                 case NativePhase::Start: return NativeCallPhase::Start;
                 case NativePhase::Evaluation: return NativeCallPhase::Evaluation;
                 case NativePhase::Stop: return NativeCallPhase::Stop;
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] semantics::NativeParameterAccess access(NativeParameterAccess value) noexcept {
+            switch (value) {
+                case NativeParameterAccess::Value: return semantics::NativeParameterAccess::Value;
+                case NativeParameterAccess::InputView: return semantics::NativeParameterAccess::InputView;
             }
             std::unreachable();
         }
@@ -65,6 +128,7 @@ namespace hgl::descriptor
             function.module_identity        = descriptor.module_identity;
             function.name                   = short_name(descriptor.module_identity, declaration.identity);
             function.identity               = declaration.identity;
+            function.candidate_identity     = declaration.identity + "#" + std::to_string(declaration_index);
             function.cpp_symbol             = declaration.cpp_symbol;
             function.public_headers         = descriptor.build.public_headers;
             function.cmake_packages         = descriptor.build.cmake_packages;
@@ -76,34 +140,47 @@ namespace hgl::descriptor
                                  "native function identity must be '" + descriptor.module_identity + "::<name>'"};
             }
             if (!declaration.effects.empty()) {
-                function.support_error = "native scalar calls with declared effects are not supported yet";
+                function.support_error = "native value calls with declared effects are not supported yet";
             }
             if (declaration.phases.size() != 1U || declaration.phases.front() != NativePhase::Evaluation) {
-                function.support_error = "native scalar calls currently require the evaluation phase only";
+                function.support_error = "native value calls currently require the evaluation phase only";
             }
             if (declaration.thread_safety == NativeThreadSafety::Serialized) {
-                function.support_error = "serialized native scalar calls are not supported yet";
+                function.support_error = "serialized native value calls are not supported yet";
             }
             if (declaration.result.ownership != NativeOwnership::Value || declaration.result.mutable_value ||
                 !declaration.result.dependent_on.empty()) {
-                function.support_error = "native scalar call results must use value ownership";
+                function.support_error = "native value call results must use value ownership";
+            }
+            for (const GenericParameter &generic : declaration.signature.generics) {
+                semantics::ImportedGeneric lowered{
+                    .name             = generic.name,
+                    .binding_identity = generic.binding_identity,
+                    .is_const         = generic.is_const,
+                };
+                if (generic.type != no_schema_id) { lowered.type = imported_type(descriptor, generic.type); }
+                if (generic.type != no_schema_id && !lowered.type) {
+                    function.support_error = "native generic constraints must use supported value types";
+                }
+                function.generics.push_back(std::move(lowered));
             }
             for (std::size_t index = 0; index < declaration.signature.parameters.size(); ++index) {
                 const Parameter &parameter = declaration.signature.parameters[index];
-                const auto       type      = scalar_type(descriptor, parameter.type);
+                const auto       type      = imported_type(descriptor, parameter.type);
                 if (!type) {
-                    function.support_error = "native exact calls currently require canonical scalar parameter types";
+                    function.support_error = "native calls require supported scalar or collection-view parameter types";
                     continue;
                 }
                 const NativeValuePolicy &policy = declaration.parameters[index].value;
                 if (policy.ownership != NativeOwnership::Value || policy.mutable_value || !policy.dependent_on.empty()) {
-                    function.support_error = "native scalar call parameters must use value ownership";
+                    function.support_error = "native value call parameters must use value ownership";
                 }
-                function.parameters.push_back(semantics::ImportedParameter{parameter.name, *type, parameter.is_const});
+                function.parameters.push_back(semantics::ImportedParameter{parameter.name, *type, parameter.is_const,
+                                                                           access(declaration.parameters[index].access)});
             }
             if (declaration.signature.result != no_schema_id) {
-                function.result = scalar_type(descriptor, declaration.signature.result);
-                if (!function.result) { function.support_error = "native exact calls currently require a canonical scalar result"; }
+                function.result = imported_type(descriptor, declaration.signature.result);
+                if (!function.result) { function.support_error = "native calls require a supported value result"; }
             }
             for (NativePhase allowed : declaration.phases) { function.phases.push_back(phase(allowed)); }
             module.functions.push_back(std::move(function));

--- a/language/src/descriptor/module_descriptor.h
+++ b/language/src/descriptor/module_descriptor.h
@@ -273,6 +273,11 @@ namespace hgl::descriptor
         Borrowed,
     };
 
+    enum class NativeParameterAccess : std::uint8_t {
+        Value,
+        InputView,
+    };
+
     enum class NativeExceptionPolicy : std::uint8_t {
         NoThrow,
         Translated,
@@ -297,8 +302,9 @@ namespace hgl::descriptor
 
     struct NativeParameterPolicy
     {
-        std::string       name{};
-        NativeValuePolicy value{};
+        std::string           name{};
+        NativeValuePolicy     value{};
+        NativeParameterAccess access{NativeParameterAccess::Value};
 
         friend bool operator==(const NativeParameterPolicy &, const NativeParameterPolicy &) = default;
     };

--- a/language/src/descriptor/module_descriptor_json.cpp
+++ b/language/src/descriptor/module_descriptor_json.cpp
@@ -84,6 +84,14 @@ namespace hgl::descriptor
             std::unreachable();
         }
 
+        [[nodiscard]] std::string_view native_parameter_access_name(NativeParameterAccess access) noexcept {
+            switch (access) {
+                case NativeParameterAccess::Value: return "value";
+                case NativeParameterAccess::InputView: return "input-view";
+            }
+            std::unreachable();
+        }
+
         [[nodiscard]] std::string_view native_exception_name(NativeExceptionPolicy policy) noexcept {
             switch (policy) {
                 case NativeExceptionPolicy::NoThrow: return "noexcept";
@@ -403,6 +411,10 @@ namespace hgl::descriptor
                     quote_json(out, parameter.name);
                     out << ",\n            \"value\": ";
                     native_value_policy(out, parameter.value, "            ");
+                    if (parameter.access != NativeParameterAccess::Value) {
+                        out << ",\n            \"access\": ";
+                        quote_json(out, native_parameter_access_name(parameter.access));
+                    }
                     out << "\n          }" << (parameter_index + 1U == declaration.parameters.size() ? "\n" : ",\n");
                 }
                 if (!declaration.parameters.empty()) { out << "        "; }

--- a/language/src/descriptor/module_descriptor_reader.cpp
+++ b/language/src/descriptor/module_descriptor_reader.cpp
@@ -856,6 +856,13 @@ namespace hgl::descriptor
                         !read_native_value_policy(*policy, member_path(item_path, "value"), parameter.value)) {
                         return false;
                     }
+                    if (const Element *access = fields.find("access")) {
+                        if (!enum_value(*access, member_path(item_path, "access"),
+                                        {{"value", NativeParameterAccess::Value}, {"input-view", NativeParameterAccess::InputView}},
+                                        parameter.access)) {
+                            return false;
+                        }
+                    }
                     out.push_back(std::move(parameter));
                     ++index;
                 }
@@ -1017,8 +1024,7 @@ namespace hgl::descriptor
                         return error_;
                     }
                     for (std::size_t parent = 0; parent < declaration.parents.size(); ++parent) {
-                        if (!non_signal_type_ref(declaration.parents[parent],
-                                                 index_path(member_path(path, "parents"), parent))) {
+                        if (!non_signal_type_ref(declaration.parents[parent], index_path(member_path(path, "parents"), parent))) {
                             return error_;
                         }
                     }
@@ -1087,8 +1093,7 @@ namespace hgl::descriptor
 
             bool non_signal_type_ref(SchemaId id, std::string_view path, bool optional = false) {
                 if (!type_ref(id, path, optional)) { return false; }
-                return !signal_type(id) ||
-                       fail(std::string{path}, "'signal' is only valid as a complete non-const parameter type");
+                return !signal_type(id) || fail(std::string{path}, "'signal' is only valid as a complete non-const parameter type");
             }
 
             bool constant_ref(SchemaId id, std::string_view path, bool optional = false) {
@@ -1196,40 +1201,123 @@ namespace hgl::descriptor
                 return true;
             }
 
-            bool native_value_type(SchemaId id, std::string_view path, bool optional = false) {
+            [[nodiscard]] bool native_generic_symbol(const Signature &signature, const TypeRecord &type) const noexcept {
+                return type.category == TypeCategory::Symbol && !type.binding_identity.empty() &&
+                       std::ranges::any_of(signature.generics, [&](const GenericParameter &generic) {
+                           return !generic.is_const && generic.binding_identity == type.binding_identity;
+                       });
+            }
+
+            bool native_constant_parameter(const Signature &signature, SchemaId id, std::string_view path) {
+                if (!constant_ref(id, path)) { return false; }
+                const ConstantExpressionRecord &value = descriptor_.constant_expressions[id];
+                if (value.category != ConstantExpressionCategory::Parameter || value.parameter_identity.empty() ||
+                    !std::ranges::any_of(signature.generics, [&](const GenericParameter &generic) {
+                        return generic.is_const && generic.binding_identity == value.parameter_identity;
+                    })) {
+                    return fail(std::string{path}, "native collection extent must name a const generic parameter");
+                }
+                return true;
+            }
+
+            bool native_value_type(const Signature &signature, SchemaId id, std::string_view path, bool optional = false,
+                                   bool allow_collection = true) {
                 if (id == no_schema_id) { return optional || fail(std::string{path}, "missing required native value type"); }
                 const TypeRecord &type = descriptor_.types[id];
                 if (type.category == TypeCategory::Scalar) { return true; }
-                if (type.category == TypeCategory::Symbol &&
-                    std::ranges::any_of(descriptor_.native_types, [&](const NativeTypeDeclaration &declaration) {
-                        return declaration.identity == type.nominal_identity;
-                    })) {
+                if (native_generic_symbol(signature, type) ||
+                    (type.category == TypeCategory::Symbol &&
+                     std::ranges::any_of(descriptor_.native_types, [&](const NativeTypeDeclaration &declaration) {
+                         return declaration.identity == type.nominal_identity;
+                     }))) {
                     return true;
                 }
-                return fail(std::string{path}, "native signature type is outside the initial scalar and declared-native envelope");
+                const bool collection = type.category == TypeCategory::List || type.category == TypeCategory::Set ||
+                                        type.category == TypeCategory::Map || type.category == TypeCategory::Rolling;
+                if (!collection || !allow_collection) {
+                    return fail(std::string{path},
+                                "native signature type is outside the scalar, declared-native, and collection-view envelope");
+                }
+                for (std::size_t index = 0; index < type.children.size(); ++index) {
+                    if (!native_value_type(signature, type.children[index], index_path(member_path(path, "children"), index))) {
+                        return false;
+                    }
+                }
+                if ((type.category == TypeCategory::Rolling || (type.category == TypeCategory::List && !type.unbounded)) &&
+                    !native_constant_parameter(signature, type.size, member_path(path, "size"))) {
+                    return false;
+                }
+                if (type.category == TypeCategory::Rolling && type.min_size != no_schema_id &&
+                    !native_constant_parameter(signature, type.min_size, member_path(path, "min_size"))) {
+                    return false;
+                }
+                return true;
             }
 
-            bool native_signature(const Signature &signature, std::string_view path) {
-                if (!signature.generics.empty()) {
-                    return fail(member_path(path, "generic_parameters"),
-                                "native declarations require one complete exact signature");
+            bool native_signature(const NativeDeclaration &declaration, std::string_view path) {
+                const Signature &signature = declaration.signature;
+                if (declaration.parameters.size() != signature.parameters.size()) {
+                    return fail(member_path(path, "parameters"), "native parameter policy count does not match the signature");
                 }
                 if (signature.requirements != no_schema_id) {
                     return fail(member_path(path, "requires"), "native declarations cannot carry unresolved constraints");
                 }
+                for (std::size_t index = 0; index < signature.generics.size(); ++index) {
+                    const GenericParameter &generic      = signature.generics[index];
+                    const std::string       generic_path = index_path(member_path(path, "generic_parameters"), index);
+                    if (!generic.is_const && generic.type != no_schema_id) {
+                        return fail(member_path(generic_path, "type"),
+                                    "native type generics are unconstrained in this ABI version");
+                    }
+                    if (generic.is_const &&
+                        (generic.type == no_schema_id || descriptor_.types[generic.type].category != TypeCategory::Scalar ||
+                         descriptor_.types[generic.type].scalar_name != "i64")) {
+                        return fail(member_path(generic_path, "type"), "native collection extents require an i64 const generic");
+                    }
+                }
                 for (std::size_t index = 0; index < signature.parameters.size(); ++index) {
-                    if (!native_value_type(signature.parameters[index].type,
+                    const SchemaId type_id = signature.parameters[index].type;
+                    if (!native_value_type(signature, type_id,
                                            member_path(index_path(member_path(path, "parameters"), index), "type"))) {
                         return false;
                     }
+                    const TypeCategory category   = descriptor_.types[type_id].category;
+                    const bool         collection = category == TypeCategory::List || category == TypeCategory::Set ||
+                                                    category == TypeCategory::Map || category == TypeCategory::Rolling;
+                    if (native_generic_symbol(signature, descriptor_.types[type_id])) {
+                        return fail(member_path(index_path(member_path(path, "parameters"), index), "type"),
+                                    "native type generics are supported only inside collection input-view patterns");
+                    }
+                    if (collection != (declaration.parameters[index].access == NativeParameterAccess::InputView)) {
+                        return fail(member_path(index_path(member_path(path, "parameters"), index), "type"),
+                                    collection ? "a native collection parameter requires input-view access"
+                                               : "input-view access requires a collection parameter");
+                    }
                 }
-                return native_value_type(signature.result, member_path(path, "result"), true);
+                if (!native_value_type(signature, signature.result, member_path(path, "result"), true, false)) { return false; }
+                if (signature.result != no_schema_id && native_generic_symbol(signature, descriptor_.types[signature.result])) {
+                    return fail(member_path(path, "result"),
+                                "native type generics are supported only inside collection input-view patterns");
+                }
+                return true;
+            }
+
+            bool unique_native_overload(const NativeDeclaration &declaration, std::string_view path) {
+                if (declaration.identity.empty()) { return fail(member_path(path, "identity"), "identity must not be empty"); }
+                if (std::ranges::any_of(native_declaration_signatures_, [&](const auto &item) {
+                        return item.first == declaration.identity && item.second == declaration.signature;
+                    })) {
+                    return fail(member_path(path, "identity"),
+                                "duplicate native overload for declaration identity '" + declaration.identity + "'");
+                }
+                native_declaration_signatures_.emplace_back(declaration.identity, declaration.signature);
+                return true;
             }
 
             bool native_declaration(const NativeDeclaration &declaration, std::string_view path) {
-                if (!unique_identity(declaration.identity, path, native_declaration_identities_) ||
+                if (!unique_native_overload(declaration, path) ||
                     !signature(declaration.signature, member_path(path, "signature")) ||
-                    !native_signature(declaration.signature, member_path(path, "signature"))) {
+                    !native_signature(declaration, member_path(path, "signature"))) {
                     return false;
                 }
                 if (!exact_cpp_symbol(declaration.cpp_symbol)) {
@@ -1454,12 +1542,12 @@ namespace hgl::descriptor
                 return true;
             }
 
-            const ModuleDescriptor  &descriptor_;
-            std::optional<ReadError> error_{};
-            std::vector<std::string> interface_identities_{};
-            std::vector<std::string> implementation_identities_{};
-            std::vector<std::string> native_type_identities_{};
-            std::vector<std::string> native_declaration_identities_{};
+            const ModuleDescriptor                        &descriptor_;
+            std::optional<ReadError>                       error_{};
+            std::vector<std::string>                       interface_identities_{};
+            std::vector<std::string>                       implementation_identities_{};
+            std::vector<std::string>                       native_type_identities_{};
+            std::vector<std::pair<std::string, Signature>> native_declaration_signatures_{};
         };
     }  // namespace
 

--- a/language/src/descriptor/module_descriptor_reader.cpp
+++ b/language/src/descriptor/module_descriptor_reader.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <initializer_list>
 #include <limits>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -1302,10 +1303,99 @@ namespace hgl::descriptor
                 return true;
             }
 
+            [[nodiscard]] static std::optional<std::size_t>
+            native_generic_index(const Signature &signature, std::string_view binding_identity, bool const_parameter) noexcept {
+                for (std::size_t index = 0; index < signature.generics.size(); ++index) {
+                    const GenericParameter &generic = signature.generics[index];
+                    if (generic.is_const == const_parameter && generic.binding_identity == binding_identity) { return index; }
+                }
+                return std::nullopt;
+            }
+
+            using SchemaPair = std::pair<SchemaId, SchemaId>;
+
+            [[nodiscard]] bool same_native_constant(const Signature &left_signature, SchemaId left_id,
+                                                    const Signature &right_signature, SchemaId right_id) const {
+                if (left_id == no_schema_id || right_id == no_schema_id) { return left_id == right_id; }
+                const ConstantExpressionRecord &left  = descriptor_.constant_expressions[left_id];
+                const ConstantExpressionRecord &right = descriptor_.constant_expressions[right_id];
+                if (left.category == ConstantExpressionCategory::Parameter &&
+                    right.category == ConstantExpressionCategory::Parameter) {
+                    const auto left_generic  = native_generic_index(left_signature, left.parameter_identity, true);
+                    const auto right_generic = native_generic_index(right_signature, right.parameter_identity, true);
+                    if (left_generic || right_generic) { return left_generic && right_generic && *left_generic == *right_generic; }
+                }
+                return left == right;
+            }
+
+            [[nodiscard]] bool same_native_type(const Signature &left_signature, SchemaId left_id, const Signature &right_signature,
+                                                SchemaId right_id, std::vector<SchemaPair> &seen_types) const {
+                if (left_id == no_schema_id || right_id == no_schema_id) { return left_id == right_id; }
+                const SchemaPair pair{left_id, right_id};
+                if (std::ranges::find(seen_types, pair) != seen_types.end()) { return true; }
+                seen_types.push_back(pair);
+
+                const TypeRecord &left  = descriptor_.types[left_id];
+                const TypeRecord &right = descriptor_.types[right_id];
+                if (left.category != right.category) { return false; }
+                if (left.category == TypeCategory::Symbol) {
+                    const auto left_generic  = native_generic_index(left_signature, left.binding_identity, false);
+                    const auto right_generic = native_generic_index(right_signature, right.binding_identity, false);
+                    if (left_generic || right_generic) { return left_generic && right_generic && *left_generic == *right_generic; }
+                }
+                if (left.scalar_name != right.scalar_name || left.nominal_identity != right.nominal_identity ||
+                    left.unbounded != right.unbounded || left.children.size() != right.children.size() ||
+                    left.arguments.size() != right.arguments.size()) {
+                    return false;
+                }
+                for (std::size_t index = 0; index < left.children.size(); ++index) {
+                    if (!same_native_type(left_signature, left.children[index], right_signature, right.children[index],
+                                          seen_types)) {
+                        return false;
+                    }
+                }
+                for (std::size_t index = 0; index < left.arguments.size(); ++index) {
+                    const TypeArgument &left_argument  = left.arguments[index];
+                    const TypeArgument &right_argument = right.arguments[index];
+                    if (left_argument.category != right_argument.category) { return false; }
+                    const bool same_argument = left_argument.category == TypeArgumentCategory::Type
+                                                   ? same_native_type(left_signature, left_argument.reference, right_signature,
+                                                                      right_argument.reference, seen_types)
+                                                   : same_native_constant(left_signature, left_argument.reference, right_signature,
+                                                                          right_argument.reference);
+                    if (!same_argument) { return false; }
+                }
+                return same_native_constant(left_signature, left.size, right_signature, right.size) &&
+                       same_native_constant(left_signature, left.min_size, right_signature, right.min_size);
+            }
+
+            [[nodiscard]] bool same_native_signature(const Signature &left, const Signature &right) const {
+                if (left.generics.size() != right.generics.size() || left.parameters.size() != right.parameters.size() ||
+                    left.requirements != right.requirements) {
+                    return false;
+                }
+                std::vector<SchemaPair> seen_types;
+                for (std::size_t index = 0; index < left.generics.size(); ++index) {
+                    if (left.generics[index].is_const != right.generics[index].is_const ||
+                        !same_native_type(left, left.generics[index].type, right, right.generics[index].type, seen_types)) {
+                        return false;
+                    }
+                }
+                for (std::size_t index = 0; index < left.parameters.size(); ++index) {
+                    if (left.parameters[index].is_const != right.parameters[index].is_const ||
+                        !same_native_type(left, left.parameters[index].type, right, right.parameters[index].type, seen_types) ||
+                        !same_native_constant(left, left.parameters[index].default_value, right,
+                                              right.parameters[index].default_value)) {
+                        return false;
+                    }
+                }
+                return same_native_type(left, left.result, right, right.result, seen_types);
+            }
+
             bool unique_native_overload(const NativeDeclaration &declaration, std::string_view path) {
                 if (declaration.identity.empty()) { return fail(member_path(path, "identity"), "identity must not be empty"); }
                 if (std::ranges::any_of(native_declaration_signatures_, [&](const auto &item) {
-                        return item.first == declaration.identity && item.second == declaration.signature;
+                        return item.first == declaration.identity && same_native_signature(item.second, declaration.signature);
                     })) {
                     return fail(member_path(path, "identity"),
                                 "duplicate native overload for declaration identity '" + declaration.identity + "'");
@@ -1315,9 +1405,8 @@ namespace hgl::descriptor
             }
 
             bool native_declaration(const NativeDeclaration &declaration, std::string_view path) {
-                if (!unique_native_overload(declaration, path) ||
-                    !signature(declaration.signature, member_path(path, "signature")) ||
-                    !native_signature(declaration, member_path(path, "signature"))) {
+                if (!signature(declaration.signature, member_path(path, "signature")) ||
+                    !native_signature(declaration, member_path(path, "signature")) || !unique_native_overload(declaration, path)) {
                     return false;
                 }
                 if (!exact_cpp_symbol(declaration.cpp_symbol)) {

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -222,9 +222,10 @@ namespace hgl::hgraph_ir
 
     struct NativeParameter
     {
-        std::string name{};
-        TypeId      type{};
-        bool        is_const{false};
+        std::string                    name{};
+        TypeId                         type{};
+        bool                           is_const{false};
+        ir::hir::NativeParameterAccess access{ir::hir::NativeParameterAccess::Value};
     };
 
     /// Descriptor-provided exact native callable, independent of descriptor

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -617,7 +617,7 @@ namespace hgl::hgraph_ir
                     target.descriptor_fingerprint = source.descriptor_fingerprint;
                     for (const hir::NativeParameter &parameter : source.parameters) {
                         target.parameters.push_back(
-                            NativeParameter{parameter.name, lower_type(parameter.type), parameter.is_const});
+                            NativeParameter{parameter.name, lower_type(parameter.type), parameter.is_const, parameter.access});
                     }
                     result_.native_functions.push_back(std::move(target));
                 }

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -610,6 +610,7 @@ namespace hgl::hgraph_ir
             for (std::size_t index = 0; index < native.parameters.size(); ++index) {
                 if (index != 0U) { out << ", "; }
                 if (native.parameters[index].is_const) { out << "const "; }
+                if (native.parameters[index].access == ir::hir::NativeParameterAccess::InputView) { out << "view "; }
                 out << native.parameters[index].name << ':';
                 print_type_id(out, native.parameters[index].type);
             }

--- a/language/src/ir/hir.h
+++ b/language/src/ir/hir.h
@@ -505,29 +505,38 @@ namespace hgl::ir::hir
         Stop,
     };
 
+    enum class NativeParameterAccess : std::uint8_t {
+        Value,
+        InputView,
+    };
+
     struct NativeParameter
     {
-        std::string name{};
-        TypeId      type{};
-        bool        is_const{false};
+        std::string           name{};
+        TypeId                type{};
+        bool                  is_const{false};
+        NativeParameterAccess access{NativeParameterAccess::Value};
     };
 
     /// An exact, descriptor-provided native callable. This is copied into HIR
     /// so later passes never depend on descriptor storage or a loaded module.
     struct NativeFunction
     {
-        SymbolId                     symbol{};
-        std::string                  module_identity{};
-        std::string                  identity{};
-        std::string                  cpp_symbol{};
-        std::vector<NativeParameter> parameters{};
-        TypeId                       result{};
-        std::vector<NativePhase>     phases{};
-        std::vector<std::string>     public_headers{};
-        std::vector<std::string>     cmake_packages{};
-        std::vector<std::string>     imported_targets{};
-        std::vector<std::string>     runtime_images{};
-        std::string                  descriptor_fingerprint{};
+        SymbolId                      symbol{};
+        SymbolId                      family{};
+        std::string                   module_identity{};
+        std::string                   identity{};
+        std::string                   candidate_identity{};
+        std::string                   cpp_symbol{};
+        std::vector<GenericParameter> generics{};
+        std::vector<NativeParameter>  parameters{};
+        TypeId                        result{};
+        std::vector<NativePhase>      phases{};
+        std::vector<std::string>      public_headers{};
+        std::vector<std::string>      cmake_packages{};
+        std::vector<std::string>      imported_targets{};
+        std::vector<std::string>      runtime_images{};
+        std::string                   descriptor_fingerprint{};
     };
     struct StructField
     {

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -301,6 +301,7 @@ namespace hgl::ir
                         if (index != 0U) { out_ << ", "; }
                         const hir::NativeParameter &parameter = function.parameters[index];
                         if (parameter.is_const) { out_ << "const "; }
+                        if (parameter.access == hir::NativeParameterAccess::InputView) { out_ << "view "; }
                         out_ << parameter.name << ':' << ref('t', parameter.type);
                     }
                     out_ << "] result=" << ref('t', function.result) << " phases=[";

--- a/language/src/ir/lower.cpp
+++ b/language/src/ir/lower.cpp
@@ -74,6 +74,26 @@ namespace hgl::ir
             std::unreachable();
         }
 
+        [[nodiscard]] constexpr hir::NativeParameterAccess lower_native_access(semantics::NativeParameterAccess access) noexcept {
+            switch (access) {
+                case semantics::NativeParameterAccess::Value: return hir::NativeParameterAccess::Value;
+                case semantics::NativeParameterAccess::InputView: return hir::NativeParameterAccess::InputView;
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] constexpr hir::TypeKind lower_imported_type_kind(semantics::ImportedTypeKind kind) noexcept {
+            switch (kind) {
+                case semantics::ImportedTypeKind::Scalar: return hir::TypeKind::Scalar;
+                case semantics::ImportedTypeKind::Symbol: return hir::TypeKind::Symbol;
+                case semantics::ImportedTypeKind::List: return hir::TypeKind::List;
+                case semantics::ImportedTypeKind::Set: return hir::TypeKind::Set;
+                case semantics::ImportedTypeKind::Map: return hir::TypeKind::Map;
+                case semantics::ImportedTypeKind::Rolling: return hir::TypeKind::Rolling;
+            }
+            std::unreachable();
+        }
+
         [[nodiscard]] constexpr hir::TypeKind lower_type_kind(ast::TypeKind kind) noexcept {
             using ast::TypeKind;
             switch (kind) {
@@ -550,9 +570,65 @@ namespace hgl::ir
                 return symbol;
             }
 
+            [[nodiscard]] hir::ExprId imported_constant(const semantics::ImportedConstant                    &source,
+                                                        const std::unordered_map<std::string, hir::SymbolId> &generics,
+                                                        syntax::SourceRange                                   range) {
+                using semantics::ImportedConstantKind;
+                if (source.kind == ImportedConstantKind::None) { return {}; }
+                if (source.kind == ImportedConstantKind::Parameter) {
+                    const auto found = generics.find(source.binding_identity);
+                    if (found == generics.end()) {
+                        diagnostics_.report(syntax::Category::Name, range,
+                                            "native type pattern names unknown const generic '" + source.binding_identity + "'");
+                        return {};
+                    }
+                    return synthesized_ref(found->second, range);
+                }
+                hir::Expr expression;
+                expression.range      = range;
+                expression.type       = literal_type(hir::ScalarType::I64);
+                expression.phase      = hir::Phase::Constant;
+                expression.value_kind = hir::ValueKind::Constant;
+                expression.constant   = hir::Constant{source.i64};
+                expression.node       = hir::Literal{source.i64};
+                const hir::ExprId id{static_cast<std::uint32_t>(result_.exprs.size())};
+                result_.exprs.push_back(std::move(expression));
+                return id;
+            }
+
+            [[nodiscard]] hir::TypeId imported_type(const semantics::ImportedType                        &source,
+                                                    const std::unordered_map<std::string, hir::SymbolId> &generics,
+                                                    syntax::SourceRange                                   range) {
+                if (source.kind == semantics::ImportedTypeKind::Scalar) { return literal_type(lower_scalar_type(source.scalar)); }
+                hir::Type target;
+                target.kind           = lower_imported_type_kind(source.kind);
+                target.range          = range;
+                target.value_position = true;
+                target.unbounded      = source.unbounded;
+                if (source.kind == semantics::ImportedTypeKind::Symbol) {
+                    const auto found = generics.find(source.binding_identity);
+                    if (found == generics.end()) {
+                        diagnostics_.report(syntax::Category::Name, range,
+                                            "native type pattern names unknown type generic '" + source.binding_identity + "'");
+                    } else {
+                        target.symbol = found->second;
+                    }
+                }
+                for (const semantics::ImportedType &child : source.children) {
+                    target.children.push_back(imported_type(child, generics, range));
+                }
+                target.size     = imported_constant(source.size, generics, range);
+                target.min_size = imported_constant(source.min_size, generics, range);
+                const hir::TypeId id{static_cast<std::uint32_t>(result_.types.size())};
+                result_.types.push_back(std::move(target));
+                return id;
+            }
+
             [[nodiscard]] hir::SymbolId imported_function(const semantics::Binding &binding, syntax::SourceRange range,
                                                           std::string_view spelling) {
-                if (binding.index >= resolved_.imported_functions.size()) {
+                const std::size_t count = binding.count == 0U ? 1U : binding.count;
+                if (binding.index >= resolved_.imported_functions.size() ||
+                    count > resolved_.imported_functions.size() - binding.index) {
                     diagnostics_.report(syntax::Category::Name, range,
                                         "imported function '" + std::string{spelling} + "' has no catalog record");
                     return {};
@@ -561,28 +637,54 @@ namespace hgl::ir
                     return found->second;
                 }
 
-                const semantics::ImportedFunction &source = resolved_.imported_functions[binding.index];
-                const hir::SymbolId                symbol =
-                    external_symbol(hir::SymbolKind::ImportedFunction, spelling, source.cpp_symbol, source.identity, range);
-                hir::NativeFunction target;
-                target.symbol                 = symbol;
-                target.module_identity        = source.module_identity;
-                target.identity               = source.identity;
-                target.cpp_symbol             = source.cpp_symbol;
-                target.result                 = source.result ? literal_type(lower_scalar_type(*source.result)) : void_type();
-                target.public_headers         = source.public_headers;
-                target.cmake_packages         = source.cmake_packages;
-                target.imported_targets       = source.imported_targets;
-                target.runtime_images         = source.runtime_images;
-                target.descriptor_fingerprint = source.descriptor_fingerprint;
-                for (const semantics::ImportedParameter &parameter : source.parameters) {
-                    target.parameters.push_back(
-                        hir::NativeParameter{parameter.name, literal_type(lower_scalar_type(parameter.type)), parameter.is_const});
+                const semantics::ImportedFunction &family_source = resolved_.imported_functions[binding.index];
+                const hir::SymbolId                family =
+                    external_symbol(hir::SymbolKind::ImportedFunction, spelling, {}, family_source.identity, range);
+                for (std::size_t offset = 0; offset < count; ++offset) {
+                    const semantics::ImportedFunction &source = resolved_.imported_functions[binding.index + offset];
+                    const std::string   candidate_identity    = source.candidate_identity.empty()
+                                                                    ? source.identity + "#native-" + std::to_string(offset)
+                                                                    : source.candidate_identity;
+                    const hir::SymbolId symbol =
+                        external_symbol(hir::SymbolKind::ImportedFunction, spelling, source.cpp_symbol, candidate_identity, range);
+                    std::unordered_map<std::string, hir::SymbolId> generic_symbols;
+                    hir::NativeFunction                            target;
+                    target.symbol                 = symbol;
+                    target.family                 = family;
+                    target.module_identity        = source.module_identity;
+                    target.identity               = source.identity;
+                    target.candidate_identity     = candidate_identity;
+                    target.cpp_symbol             = source.cpp_symbol;
+                    target.public_headers         = source.public_headers;
+                    target.cmake_packages         = source.cmake_packages;
+                    target.imported_targets       = source.imported_targets;
+                    target.runtime_images         = source.runtime_images;
+                    target.descriptor_fingerprint = source.descriptor_fingerprint;
+                    for (std::size_t index = 0; index < source.generics.size(); ++index) {
+                        const semantics::ImportedGeneric &generic        = source.generics[index];
+                        const hir::SymbolId               generic_symbol = add_symbol(
+                            generic.is_const ? hir::SymbolKind::ConstParameter : hir::SymbolKind::TypeParameter, generic.name,
+                            range, ast::no_node, static_cast<std::uint32_t>(index), {}, candidate_identity + "::" + generic.name);
+                        generic_symbols.emplace(generic.binding_identity, generic_symbol);
+                        target.generics.push_back(hir::GenericParameter{generic_symbol, generic.is_const, {}});
+                    }
+                    for (std::size_t index = 0; index < source.generics.size(); ++index) {
+                        if (!source.generics[index].type) { continue; }
+                        const hir::TypeId type      = imported_type(*source.generics[index].type, generic_symbols, range);
+                        target.generics[index].type = type;
+                        result_.symbols[target.generics[index].symbol.value].type = type;
+                    }
+                    for (const semantics::ImportedParameter &parameter : source.parameters) {
+                        target.parameters.push_back(
+                            hir::NativeParameter{parameter.name, imported_type(parameter.type, generic_symbols, range),
+                                                 parameter.is_const, lower_native_access(parameter.access)});
+                    }
+                    target.result = source.result ? imported_type(*source.result, generic_symbols, range) : void_type();
+                    for (semantics::NativeCallPhase phase : source.phases) { target.phases.push_back(lower_native_phase(phase)); }
+                    result_.native_functions.push_back(std::move(target));
                 }
-                for (semantics::NativeCallPhase phase : source.phases) { target.phases.push_back(lower_native_phase(phase)); }
-                result_.native_functions.push_back(std::move(target));
-                imported_function_symbols_.emplace(binding.index, symbol);
-                return symbol;
+                imported_function_symbols_.emplace(binding.index, family);
+                return family;
             }
 
             [[nodiscard]] hir::SymbolId symbol_for(const semantics::Binding &binding, syntax::SourceRange range,

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -1509,7 +1509,10 @@ namespace hgl::ir
                 }
                 if (expected.valid() && !bindings.unify(function.result, expected)) { return false; }
                 for (const GenericParameter &generic : function.generics) {
-                    if (generic.is_const ? !bindings.has_value(generic.symbol) : !bindings.has_type(generic.symbol)) {
+                    if (generic.is_const) {
+                        const std::optional<ExprId> value = bindings.value_binding(generic.symbol);
+                        if (!value || !canonical_types_.assignable(generic.type, module_.expr(*value).type)) { return false; }
+                    } else if (!bindings.has_type(generic.symbol)) {
                         return false;
                     }
                 }

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -186,6 +186,14 @@ namespace hgl::ir
                 return found == module_.native_functions.end() ? nullptr : &*found;
             }
 
+            [[nodiscard]] std::vector<const NativeFunction *> native_candidates(SymbolId symbol) const {
+                std::vector<const NativeFunction *> result;
+                for (const NativeFunction &function : module_.native_functions) {
+                    if (function.symbol == symbol || function.family == symbol) { result.push_back(&function); }
+                }
+                return result;
+            }
+
             void check_implementation_conformance(const Declaration &declaration, const FunctionDecl &implementation,
                                                   const OperatorDecl &contract, detail::GenericSubstitution &substitution) {
                 if (implementation.signature.parameters.size() != contract.signature.parameters.size()) {
@@ -409,9 +417,10 @@ namespace hgl::ir
                 if (!symbol.valid()) { return make_type(TypeKind::Callable); }
                 const Symbol &target = module_.symbol(symbol);
                 if (target.kind == SymbolKind::ImportedFunction) {
-                    const NativeFunction *native = native_function(symbol);
-                    if (native == nullptr) { return make_type(TypeKind::Callable); }
-                    std::vector<TypeId> children;
+                    const std::vector<const NativeFunction *> candidates = native_candidates(symbol);
+                    if (candidates.size() != 1U) { return make_type(TypeKind::Callable); }
+                    const NativeFunction *native = candidates.front();
+                    std::vector<TypeId>   children;
                     children.reserve(native->parameters.size() + 1U);
                     for (const NativeParameter &parameter : native->parameters) { children.push_back(parameter.type); }
                     children.push_back(native->result);
@@ -1464,6 +1473,55 @@ namespace hgl::ir
                                                   .substitutions = bindings.materialize(fn.generics)};
             }
 
+            [[nodiscard]] bool try_bind_native_arguments(const NativeFunction &function, const std::vector<Argument> &arguments,
+                                                         std::vector<ExprId> &bound) const {
+                bound.assign(function.parameters.size(), {});
+                std::size_t next = 0U;
+                for (const Argument &argument : arguments) {
+                    if (argument.name.empty()) {
+                        while (next < bound.size() && bound[next].valid()) { ++next; }
+                        if (next >= bound.size()) { return false; }
+                        bound[next++] = argument.value;
+                        continue;
+                    }
+                    const auto found = std::ranges::find(function.parameters, argument.name, &NativeParameter::name);
+                    if (found == function.parameters.end()) { return false; }
+                    const std::size_t index = static_cast<std::size_t>(found - function.parameters.begin());
+                    if (bound[index].valid()) { return false; }
+                    bound[index] = argument.value;
+                }
+                return std::ranges::all_of(bound, &ExprId::valid);
+            }
+
+            [[nodiscard]] bool native_candidate_matches(const NativeFunction &function, const std::vector<Argument> &arguments,
+                                                        TypeId expected, std::vector<Substitution> *substitutions = nullptr) {
+                if (std::ranges::find(function.phases, active_native_phase_) == function.phases.end()) { return false; }
+                std::vector<ExprId> bound;
+                if (!try_bind_native_arguments(function, arguments, bound)) { return false; }
+                detail::GenericSubstitution bindings{module_, canonical_types_};
+                for (std::size_t index = 0; index < bound.size(); ++index) {
+                    const Expr            &argument  = module_.expr(bound[index]);
+                    const NativeParameter &parameter = function.parameters[index];
+                    if (parameter.is_const && argument.phase != Phase::Constant) { return false; }
+                    if (active_native_phase_ == NativePhase::Wiring && argument.phase != Phase::Constant) { return false; }
+                    if (!bindings.unify(parameter.type, argument.type)) { return false; }
+                    if (!same(bindings.apply(parameter.type), argument.type)) { return false; }
+                }
+                if (expected.valid() && !bindings.unify(function.result, expected)) { return false; }
+                for (const GenericParameter &generic : function.generics) {
+                    if (generic.is_const ? !bindings.has_value(generic.symbol) : !bindings.has_type(generic.symbol)) {
+                        return false;
+                    }
+                }
+                if (substitutions != nullptr) {
+                    *substitutions = bindings.materialize(function.generics);
+                    for (Substitution &substitution : *substitutions) {
+                        if (substitution.value.valid()) { substitution.constant = module_.expr(substitution.value).constant; }
+                    }
+                }
+                return true;
+            }
+
             void check_native_call(Expr &expression, const Call &call, SymbolId target, const NativeFunction &function,
                                    TypeId expected) {
                 const std::vector<ExprId> bound = bind_native_arguments(function, call.arguments, expression.range);
@@ -1476,11 +1534,13 @@ namespace hgl::ir
                 }
 
                 expression.effects = Effect::None;
+                detail::GenericSubstitution bindings{module_, canonical_types_};
                 for (std::size_t index = 0; index < bound.size(); ++index) {
                     if (!bound[index].valid()) { continue; }
-                    Expr &argument = check_expr(bound[index], function.parameters[index].type);
+                    Expr &argument = check_expr(bound[index]);
                     expression.effects |= argument.effects;
-                    if (!same(function.parameters[index].type, argument.type)) {
+                    if (!bindings.unify(function.parameters[index].type, argument.type) ||
+                        !same(bindings.apply(function.parameters[index].type), argument.type)) {
                         type_error(argument.range, "native argument has type " + type_name(argument.type) + ", expected exactly " +
                                                        type_name(function.parameters[index].type));
                     }
@@ -1490,15 +1550,23 @@ namespace hgl::ir
                     }
                     if (active_native_phase_ == NativePhase::Wiring && argument.phase != Phase::Constant) {
                         diagnostics_.report(syntax::Category::Phase, argument.range,
-                                            "a wiring-phase native scalar call requires compile-time arguments");
+                                            "a wiring-phase native value call requires compile-time arguments");
                     }
                 }
 
-                expression.type       = canonical(function.result);
+                require_complete_bindings(function.generics, bindings, expression.range, "native function call");
+
+                expression.type       = bindings.apply(function.result);
                 expression.phase      = active_native_phase_ == NativePhase::Wiring ? Phase::Constant : Phase::Runtime;
                 expression.value_kind = expression.type == void_type_ ? ValueKind::Void : value_kind_for_phase(expression.phase);
-                expression.operation =
-                    Operation{.kind = OperationKind::ExactFunction, .target = target, .identity = function.identity};
+                std::vector<Substitution> substitutions = bindings.materialize(function.generics);
+                for (Substitution &substitution : substitutions) {
+                    if (substitution.value.valid()) { substitution.constant = module_.expr(substitution.value).constant; }
+                }
+                expression.operation = Operation{.kind          = OperationKind::ExactFunction,
+                                                 .target        = target,
+                                                 .identity      = function.identity,
+                                                 .substitutions = std::move(substitutions)};
                 contextualize(expression, expected);
             }
 
@@ -1695,8 +1763,8 @@ namespace hgl::ir
             }
 
             void check_call(Expr &expression, const Call &call, TypeId expected) {
-                Expr       &callee    = check_expr(call.callee);
-                const auto *reference = std::get_if<SymbolRef>(&callee.node);
+                Expr &callee    = check_expr(call.callee);
+                auto *reference = std::get_if<SymbolRef>(&callee.node);
                 if (reference && reference->symbol.valid()) {
                     const Symbol &symbol = module_.symbol(reference->symbol);
                     if (symbol.kind == SymbolKind::Function) {
@@ -1705,8 +1773,32 @@ namespace hgl::ir
                         return;
                     }
                     if (symbol.kind == SymbolKind::ImportedFunction) {
-                        const NativeFunction *native = native_function(reference->symbol);
-                        if (native != nullptr) { check_native_call(expression, call, reference->symbol, *native, expected); }
+                        for (const Argument &argument : call.arguments) { (void)check_expr(argument.value); }
+                        const std::vector<const NativeFunction *> candidates = native_candidates(reference->symbol);
+                        std::vector<const NativeFunction *>       matches;
+                        for (const NativeFunction *candidate : candidates) {
+                            if (native_candidate_matches(*candidate, call.arguments, expected)) { matches.push_back(candidate); }
+                        }
+                        if (matches.empty()) {
+                            std::string arguments;
+                            for (const Argument &argument : call.arguments) {
+                                if (!arguments.empty()) { arguments += ", "; }
+                                arguments += type_name(module_.expr(argument.value).type);
+                            }
+                            type_error(expression.range, "no native overload of '" + operator_identity(reference->symbol) +
+                                                             "' accepts (" + arguments + ")");
+                            if (!candidates.empty()) { matches.push_back(candidates.front()); }
+                        } else if (matches.size() > 1U) {
+                            type_error(expression.range, "native call to '" + operator_identity(reference->symbol) +
+                                                             "' is ambiguous between " + std::to_string(matches.size()) +
+                                                             " overloads");
+                        }
+                        if (!matches.empty()) {
+                            const NativeFunction &native = *matches.front();
+                            reference->symbol            = native.symbol;
+                            callee.type                  = callable_type(native.symbol);
+                            check_native_call(expression, call, native.symbol, native, expected);
+                        }
                         return;
                     }
                     if (symbol.kind == SymbolKind::Operator) {

--- a/language/src/native/native_package.cpp
+++ b/language/src/native/native_package.cpp
@@ -91,6 +91,14 @@ namespace hgl::native
             throw std::invalid_argument{"unknown native ownership policy"};
         }
 
+        [[nodiscard]] descriptor::NativeParameterAccess parameter_access(ParameterAccess value) {
+            switch (value) {
+                case ParameterAccess::Value: return descriptor::NativeParameterAccess::Value;
+                case ParameterAccess::InputView: return descriptor::NativeParameterAccess::InputView;
+            }
+            throw std::invalid_argument{"unknown native parameter access"};
+        }
+
         [[nodiscard]] descriptor::NativeExceptionPolicy exception_policy(ExceptionPolicy value) {
             switch (value) {
                 case ExceptionPolicy::NoThrow: return descriptor::NativeExceptionPolicy::NoThrow;
@@ -118,10 +126,35 @@ namespace hgl::native
 
         struct Schema
         {
+            Descriptor                                              &out;
             std::map<ScalarType, descriptor::SchemaId>               scalar{};
             std::map<std::string, descriptor::SchemaId, std::less<>> native{};
 
-            [[nodiscard]] descriptor::SchemaId at(const ValueType &type) const {
+            [[nodiscard]] static std::string binding(const Declaration &declaration, std::string_view name) {
+                return declaration.identity + "::" + std::string{name};
+            }
+
+            [[nodiscard]] const GenericParameter &generic(const Declaration &declaration, std::string_view name,
+                                                          bool is_const) const {
+                const auto found = std::ranges::find(declaration.generics, name, &GenericParameter::name);
+                if (found == declaration.generics.end() || found->is_const != is_const) {
+                    throw std::invalid_argument{std::string{is_const ? "constant" : "type"} + " parameter '" + std::string{name} +
+                                                "' is not declared by native overload '" + declaration.identity + "'"};
+                }
+                return *found;
+            }
+
+            [[nodiscard]] descriptor::SchemaId constant_parameter(const Declaration &declaration, std::string_view name) {
+                (void)generic(declaration, name, true);
+                const auto id = static_cast<descriptor::SchemaId>(out.constant_expressions.size());
+                out.constant_expressions.push_back(descriptor::ConstantExpressionRecord{
+                    .category           = descriptor::ConstantExpressionCategory::Parameter,
+                    .parameter_identity = binding(declaration, name),
+                });
+                return id;
+            }
+
+            [[nodiscard]] descriptor::SchemaId at(const ValueType &type, const Declaration &declaration) {
                 switch (type.category) {
                     case ValueTypeCategory::Scalar: return scalar.at(type.scalar);
                     case ValueTypeCategory::Native:
@@ -133,21 +166,88 @@ namespace hgl::native
                             }
                             return found->second;
                         }
+                    case ValueTypeCategory::TypeParameter:
+                        {
+                            (void)generic(declaration, type.parameter_name, false);
+                            const auto id = static_cast<descriptor::SchemaId>(out.types.size());
+                            out.types.push_back(descriptor::TypeRecord{
+                                .category         = descriptor::TypeCategory::Symbol,
+                                .nominal_identity = type.parameter_name,
+                                .binding_identity = binding(declaration, type.parameter_name),
+                            });
+                            return id;
+                        }
+                    case ValueTypeCategory::List:
+                    case ValueTypeCategory::Set:
+                    case ValueTypeCategory::Map:
+                    case ValueTypeCategory::Rolling:
+                        {
+                            const std::size_t expected_children = type.category == ValueTypeCategory::Map ? 2U : 1U;
+                            if (type.children.size() != expected_children) {
+                                throw std::invalid_argument{"native collection type has the wrong number of type arguments"};
+                            }
+                            descriptor::TypeRecord record;
+                            switch (type.category) {
+                                case ValueTypeCategory::List: record.category = descriptor::TypeCategory::List; break;
+                                case ValueTypeCategory::Set: record.category = descriptor::TypeCategory::Set; break;
+                                case ValueTypeCategory::Map: record.category = descriptor::TypeCategory::Map; break;
+                                case ValueTypeCategory::Rolling: record.category = descriptor::TypeCategory::Rolling; break;
+                                default: std::unreachable();
+                            }
+                            for (const ValueType &child : type.children) { record.children.push_back(at(child, declaration)); }
+                            if (!type.size_parameter.empty()) {
+                                record.size = constant_parameter(declaration, type.size_parameter);
+                            }
+                            if (!type.min_size_parameter.empty()) {
+                                record.min_size = constant_parameter(declaration, type.min_size_parameter);
+                            }
+                            record.unbounded = type.unbounded;
+                            const auto id    = static_cast<descriptor::SchemaId>(out.types.size());
+                            out.types.push_back(std::move(record));
+                            return id;
+                        }
                 }
                 throw std::invalid_argument{"unknown native value type category"};
             }
         };
 
+        void collect_scalars(const ValueType &type, std::vector<ScalarType> &out) {
+            if (type.category == ValueTypeCategory::Scalar) { out.push_back(type.scalar); }
+            for (const ValueType &child : type.children) { collect_scalars(child, out); }
+        }
+
+        [[nodiscard]] std::string value_type_key(const ValueType &type) {
+            std::string result = std::to_string(static_cast<unsigned>(type.category)) + ':' +
+                                 std::to_string(static_cast<unsigned>(type.scalar)) + ':' + type.native_identity + ':' +
+                                 type.parameter_name + ':' + type.size_parameter + ':' + type.min_size_parameter + ':' +
+                                 (type.unbounded ? "1" : "0");
+            for (const ValueType &child : type.children) { result += '<' + value_type_key(child) + '>'; }
+            return result;
+        }
+
+        [[nodiscard]] std::string declaration_key(const Declaration &declaration) {
+            std::string result = declaration.identity + '|' + declaration.cpp_symbol;
+            for (const GenericParameter &generic : declaration.generics) {
+                result += "|g:" + generic.name + ':' + (generic.is_const ? "1" : "0") + ':' +
+                          (generic.type ? value_type_key(*generic.type) : std::string{});
+            }
+            for (const Parameter &parameter : declaration.parameters) {
+                result += "|p:" + parameter.name + ':' + value_type_key(parameter.type) + ':' +
+                          std::to_string(static_cast<unsigned>(parameter.access));
+            }
+            result += "|r:" + (declaration.result_type ? value_type_key(*declaration.result_type) : std::string{});
+            return result;
+        }
+
         [[nodiscard]] Schema make_schema(const Package &package, Descriptor &out) {
-            Schema                  result;
+            Schema                  result{out};
             std::vector<ScalarType> scalars;
             for (const Declaration &declaration : package.declarations) {
-                for (const Parameter &parameter : declaration.parameters) {
-                    if (parameter.type.category == ValueTypeCategory::Scalar) { scalars.push_back(parameter.type.scalar); }
+                for (const GenericParameter &generic : declaration.generics) {
+                    if (generic.type) { collect_scalars(*generic.type, scalars); }
                 }
-                if (declaration.result_type && declaration.result_type->category == ValueTypeCategory::Scalar) {
-                    scalars.push_back(declaration.result_type->scalar);
-                }
+                for (const Parameter &parameter : declaration.parameters) { collect_scalars(parameter.type, scalars); }
+                if (declaration.result_type) { collect_scalars(*declaration.result_type, scalars); }
             }
             std::ranges::sort(scalars);
             scalars.erase(std::ranges::unique(scalars).begin(), scalars.end());
@@ -200,7 +300,7 @@ namespace hgl::native
             normalize(out.build.imported_targets);
             normalize(out.build.runtime_images);
 
-            const Schema schema = make_schema(package, out);
+            Schema schema = make_schema(package, out);
 
             std::vector<Type> types = package.types;
             normalize(types, &Type::identity);
@@ -214,7 +314,7 @@ namespace hgl::native
             }
 
             std::vector<Declaration> declarations = package.declarations;
-            normalize(declarations, &Declaration::identity);
+            normalize(declarations, declaration_key);
             for (const Declaration &declaration : declarations) {
                 descriptor::NativeDeclaration native;
                 native.category         = declaration_category(declaration.category);
@@ -223,19 +323,28 @@ namespace hgl::native
                 native.result           = value_policy(declaration.result_policy);
                 native.exception_policy = exception_policy(declaration.exception_policy);
                 native.thread_safety    = thread_safety(declaration.thread_safety);
+                for (const GenericParameter &generic : declaration.generics) {
+                    native.signature.generics.push_back(descriptor::GenericParameter{
+                        .name             = generic.name,
+                        .binding_identity = Schema::binding(declaration, generic.name),
+                        .is_const         = generic.is_const,
+                        .type             = generic.type ? schema.at(*generic.type, declaration) : descriptor::no_schema_id,
+                    });
+                }
                 for (const Parameter &parameter : declaration.parameters) {
                     native.signature.parameters.push_back(descriptor::Parameter{
                         .name             = parameter.name,
                         .binding_identity = declaration.identity + "::" + parameter.name,
                         .is_const         = parameter.is_const,
-                        .type             = schema.at(parameter.type),
+                        .type             = schema.at(parameter.type, declaration),
                     });
                     native.parameters.push_back(descriptor::NativeParameterPolicy{
-                        .name  = parameter.name,
-                        .value = value_policy(parameter.policy),
+                        .name   = parameter.name,
+                        .value  = value_policy(parameter.policy),
+                        .access = parameter_access(parameter.access),
                     });
                 }
-                if (declaration.result_type) { native.signature.result = schema.at(*declaration.result_type); }
+                if (declaration.result_type) { native.signature.result = schema.at(*declaration.result_type, declaration); }
                 for (Phase allowed : declaration.phases) { native.phases.push_back(phase(allowed)); }
                 for (Effect observable : declaration.effects) { native.effects.push_back(effect(observable)); }
                 std::ranges::sort(native.phases);

--- a/language/src/semantics/module_catalog.h
+++ b/language/src/semantics/module_catalog.h
@@ -4,8 +4,10 @@
 #include <algorithm>
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -39,33 +41,90 @@ namespace hgl::semantics
         Stop,
     };
 
-    struct ImportedParameter
-    {
-        std::string        name{};
-        ImportedScalarType type{ImportedScalarType::Bool};
-        bool               is_const{false};
+    enum class ImportedTypeKind : std::uint8_t {
+        Scalar,
+        Symbol,
+        List,
+        Set,
+        Map,
+        Rolling,
     };
 
-    /// One exact native function exported by an importable module. The first
-    /// executable slice admits effect-free canonical scalar signatures only.
-    /// Other descriptor declarations remain visible through support_error so
-    /// name resolution fails with the actual unsupported boundary rather than
-    /// pretending that the declaration does not exist.
+    enum class ImportedConstantKind : std::uint8_t {
+        None,
+        Parameter,
+        I64,
+    };
+
+    struct ImportedConstant
+    {
+        ImportedConstantKind kind{ImportedConstantKind::None};
+        std::string          binding_identity{};
+        std::int64_t         i64{};
+
+        friend bool operator==(const ImportedConstant &, const ImportedConstant &) = default;
+    };
+
+    struct ImportedType
+    {
+        ImportedTypeKind          kind{ImportedTypeKind::Scalar};
+        ImportedScalarType        scalar{ImportedScalarType::Bool};
+        std::string               binding_identity{};
+        std::vector<ImportedType> children{};
+        ImportedConstant          size{};
+        ImportedConstant          min_size{};
+        bool                      unbounded{false};
+
+        ImportedType() = default;
+        ImportedType(ImportedScalarType value) : scalar{value} {}
+
+        friend bool operator==(const ImportedType &, const ImportedType &) = default;
+        friend bool operator==(const ImportedType &lhs, ImportedScalarType rhs) noexcept {
+            return lhs.kind == ImportedTypeKind::Scalar && lhs.scalar == rhs;
+        }
+    };
+
+    enum class NativeParameterAccess : std::uint8_t {
+        Value,
+        InputView,
+    };
+
+    struct ImportedGeneric
+    {
+        std::string                 name{};
+        std::string                 binding_identity{};
+        bool                        is_const{false};
+        std::optional<ImportedType> type{};
+    };
+
+    struct ImportedParameter
+    {
+        std::string           name{};
+        ImportedType          type{};
+        bool                  is_const{false};
+        NativeParameterAccess access{NativeParameterAccess::Value};
+    };
+
+    /// One native overload exported by an importable module. identity is the
+    /// public overload-family identity; candidate_identity is unique within
+    /// the descriptor and remains stable through typed lowering.
     struct ImportedFunction
     {
-        std::string                       module_identity{};
-        std::string                       name{};
-        std::string                       identity{};
-        std::string                       cpp_symbol{};
-        std::vector<ImportedParameter>    parameters{};
-        std::optional<ImportedScalarType> result{};
-        std::vector<NativeCallPhase>      phases{};
-        std::vector<std::string>          public_headers{};
-        std::vector<std::string>          cmake_packages{};
-        std::vector<std::string>          imported_targets{};
-        std::vector<std::string>          runtime_images{};
-        std::string                       descriptor_fingerprint{};
-        std::string                       support_error{};
+        std::string                    module_identity{};
+        std::string                    name{};
+        std::string                    identity{};
+        std::string                    candidate_identity{};
+        std::string                    cpp_symbol{};
+        std::vector<ImportedGeneric>   generics{};
+        std::vector<ImportedParameter> parameters{};
+        std::optional<ImportedType>    result{};
+        std::vector<NativeCallPhase>   phases{};
+        std::vector<std::string>       public_headers{};
+        std::vector<std::string>       cmake_packages{};
+        std::vector<std::string>       imported_targets{};
+        std::vector<std::string>       runtime_images{};
+        std::string                    descriptor_fingerprint{};
+        std::string                    support_error{};
     };
 
     struct ImportableModule
@@ -92,11 +151,17 @@ namespace hgl::semantics
             if (find(module.identity) != nullptr) {
                 return CatalogError{"$.module.identity", "module '" + module.identity + "' is supplied more than once"};
             }
-            std::ranges::sort(module.functions, {}, &ImportedFunction::name);
+            for (ImportedFunction &function : module.functions) {
+                if (function.candidate_identity.empty()) { function.candidate_identity = function.identity; }
+            }
+            std::ranges::sort(module.functions, [](const ImportedFunction &lhs, const ImportedFunction &rhs) {
+                return std::tie(lhs.name, lhs.candidate_identity) < std::tie(rhs.name, rhs.candidate_identity);
+            });
             for (std::size_t index = 1; index < module.functions.size(); ++index) {
-                if (module.functions[index - 1U].name == module.functions[index].name) {
-                    return CatalogError{"$.native.declarations", "module '" + module.identity + "' exports native function '" +
-                                                                     module.functions[index].name + "' more than once"};
+                if (module.functions[index - 1U].candidate_identity == module.functions[index].candidate_identity) {
+                    return CatalogError{"$.native.declarations",
+                                        "module '" + module.identity + "' exports native overload candidate '" +
+                                            module.functions[index].candidate_identity + "' more than once"};
                 }
             }
             modules_.push_back(std::move(module));
@@ -110,10 +175,18 @@ namespace hgl::semantics
         }
 
         [[nodiscard]] const ImportedFunction *find_function(std::string_view module, std::string_view name) const noexcept {
+            const std::span<const ImportedFunction> functions = find_functions(module, name);
+            return functions.empty() ? nullptr : &functions.front();
+        }
+
+        [[nodiscard]] std::span<const ImportedFunction> find_functions(std::string_view module,
+                                                                       std::string_view name) const noexcept {
             const ImportableModule *owner = find(module);
-            if (owner == nullptr) { return nullptr; }
+            if (owner == nullptr) { return {}; }
             const auto found = std::ranges::lower_bound(owner->functions, name, {}, &ImportedFunction::name);
-            return found != owner->functions.end() && found->name == name ? &*found : nullptr;
+            if (found == owner->functions.end() || found->name != name) { return {}; }
+            const auto last = std::ranges::upper_bound(found, owner->functions.end(), name, {}, &ImportedFunction::name);
+            return {&*found, static_cast<std::size_t>(last - found)};
         }
 
         [[nodiscard]] const std::vector<ImportableModule> &modules() const noexcept { return modules_; }

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <optional>
+#include <span>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -205,12 +207,12 @@ namespace hgl::semantics
                 }
                 for (const ast::Name &name : use.names) {
                     if (!kernel) {
-                        const ImportedFunction *function = catalog_.find_function(path, name.text);
-                        if (function == nullptr) {
+                        const std::span<const ImportedFunction> functions = catalog_.find_functions(path, name.text);
+                        if (functions.empty()) {
                             report(Category::Module, name.range, path + " does not export '" + std::string{name.text} + "'");
                             continue;
                         }
-                        const std::optional<Binding> binding = imported_function(*function, name.range);
+                        const std::optional<Binding> binding = imported_function(functions, name.range);
                         if (binding) { declare(name, *binding, "in the module"); }
                         continue;
                     }
@@ -236,23 +238,28 @@ namespace hgl::semantics
                 }
             }
 
-            [[nodiscard]] std::optional<Binding> imported_function(const ImportedFunction &function, SourceRange range) {
-                if (!function.support_error.empty()) {
+            [[nodiscard]] std::optional<Binding> imported_function(std::span<const ImportedFunction> functions, SourceRange range) {
+                if (functions.empty()) { return std::nullopt; }
+                std::vector<const ImportedFunction *> supported;
+                for (const ImportedFunction &function : functions) {
+                    if (function.support_error.empty()) { supported.push_back(&function); }
+                }
+                if (supported.empty()) {
                     report(Category::Module, range,
-                           "native function '" + function.identity + "' is unavailable: " + function.support_error);
+                           "native function '" + functions.front().identity +
+                               "' is unavailable: " + functions.front().support_error);
                     return std::nullopt;
                 }
-                const auto  found = std::ranges::find(result_.imported_functions, function.identity, &ImportedFunction::identity);
-                std::size_t index = 0U;
-                if (found == result_.imported_functions.end()) {
-                    index = result_.imported_functions.size();
-                    result_.imported_functions.push_back(function);
-                } else {
-                    index = static_cast<std::size_t>(found - result_.imported_functions.begin());
+                const std::string family = functions.front().module_identity + "::" + functions.front().name;
+                if (const auto found = imported_function_bindings_.find(family); found != imported_function_bindings_.end()) {
+                    return found->second;
                 }
                 Binding binding;
                 binding.kind  = BindingKind::ImportedFunction;
-                binding.index = static_cast<std::uint32_t>(index);
+                binding.index = static_cast<std::uint32_t>(result_.imported_functions.size());
+                binding.count = static_cast<std::uint32_t>(supported.size());
+                for (const ImportedFunction *function : supported) { result_.imported_functions.push_back(*function); }
+                imported_function_bindings_.emplace(family, binding);
                 return binding;
             }
 
@@ -642,13 +649,13 @@ namespace hgl::semantics
                 for (const ModuleAlias &alias : result_.aliases) {
                     if (alias.alias != ref.qualifier.text) { continue; }
                     if (alias.module != kernel_std && alias.module != kernel_analytics) {
-                        const ImportedFunction *function = catalog_.find_function(alias.module, ref.name.text);
-                        if (function == nullptr) {
+                        const std::span<const ImportedFunction> functions = catalog_.find_functions(alias.module, ref.name.text);
+                        if (functions.empty()) {
                             report(Category::Module, ref.name.range,
                                    alias.module + " does not export '" + std::string{ref.name.text} + "'");
                             return;
                         }
-                        const std::optional<Binding> binding = imported_function(*function, ref.name.range);
+                        const std::optional<Binding> binding = imported_function(functions, ref.name.range);
                         if (binding) { result_.bindings[id] = *binding; }
                         return;
                     }
@@ -1102,13 +1109,14 @@ namespace hgl::semantics
                 diagnostics_.report(category, range, std::move(message));
             }
 
-            const ast::Module        &module_;
-            const ModuleCatalog      &catalog_;
-            const OperatorLookup     &has_operator_;
-            syntax::DiagnosticSink   &diagnostics_;
-            ResolvedModule            result_{};
-            std::vector<Scope>        scopes_{};
-            std::vector<std::uint8_t> struct_states_{};
+            const ast::Module                       &module_;
+            const ModuleCatalog                     &catalog_;
+            const OperatorLookup                    &has_operator_;
+            syntax::DiagnosticSink                  &diagnostics_;
+            ResolvedModule                           result_{};
+            std::vector<Scope>                       scopes_{};
+            std::unordered_map<std::string, Binding> imported_function_bindings_{};
+            std::vector<std::uint8_t>                struct_states_{};
         };
     }  // namespace
 

--- a/language/src/semantics/resolve.h
+++ b/language/src/semantics/resolve.h
@@ -41,6 +41,7 @@ namespace hgl::semantics
         ast::DeclId   decl{ast::no_node};
         ast::StmtId   stmt{ast::no_node};
         std::uint32_t index{0};
+        std::uint32_t count{0};       ///< imported native overload count beginning at index
         bool          second{false};  ///< compatibility marker for the second `for` binder
         std::string   registry_name{};
         /// Canonical defining-module identity for an operator binding. This is
@@ -86,21 +87,21 @@ namespace hgl::semantics
 
     struct ResolvedModule
     {
-        std::string                   module_path;
-        std::vector<Binding>          bindings;                 ///< indexed by ExprId
-        std::vector<Binding>          type_bindings;            ///< indexed by TypeId
-        std::vector<Binding>          constraint_bindings;      ///< indexed by ConstraintId
-        std::vector<Binding>          implementation_bindings;  ///< selected operator, indexed by DeclId
+        std::string                       module_path;
+        std::vector<Binding>              bindings;                 ///< indexed by ExprId
+        std::vector<Binding>              type_bindings;            ///< indexed by TypeId
+        std::vector<Binding>              constraint_bindings;      ///< indexed by ConstraintId
+        std::vector<Binding>              implementation_bindings;  ///< selected operator, indexed by DeclId
         std::vector<std::vector<Binding>> instantiation_bindings;   ///< local operator per instantiate entry, indexed by DeclId
-        std::vector<FunctionKind>     kinds;                    ///< indexed by DeclId
-        std::vector<ImportedOperator> imports;
-        std::vector<ImportedFunction> imported_functions;
-        std::vector<ModuleAlias>      aliases;
-        std::vector<ast::DeclId>      functions;
-        std::vector<ast::DeclId>      structs;
-        std::vector<ast::DeclId>      operators;
-        std::vector<ast::DeclId>      tests;
-        std::vector<StructInfo>       struct_info;  ///< indexed by DeclId
+        std::vector<FunctionKind>         kinds;                    ///< indexed by DeclId
+        std::vector<ImportedOperator>     imports;
+        std::vector<ImportedFunction>     imported_functions;
+        std::vector<ModuleAlias>          aliases;
+        std::vector<ast::DeclId>          functions;
+        std::vector<ast::DeclId>          structs;
+        std::vector<ast::DeclId>          operators;
+        std::vector<ast::DeclId>          tests;
+        std::vector<StructInfo>           struct_info;  ///< indexed by DeclId
 
         [[nodiscard]] const Binding &binding(ast::ExprId id) const noexcept { return bindings[id]; }
         [[nodiscard]] const Binding &type_binding(ast::TypeId id) const noexcept { return type_bindings[id]; }
@@ -109,7 +110,7 @@ namespace hgl::semantics
         [[nodiscard]] const std::vector<Binding> &instantiation_binding(ast::DeclId id) const noexcept {
             return instantiation_bindings[id];
         }
-        [[nodiscard]] FunctionKind   kind(ast::DeclId id) const noexcept { return kinds[id]; }
+        [[nodiscard]] FunctionKind      kind(ast::DeclId id) const noexcept { return kinds[id]; }
         [[nodiscard]] const StructInfo &structure(ast::DeclId id) const noexcept { return struct_info[id]; }
     };
 

--- a/language/tests/codegen/generated_native_tests.cpp
+++ b/language/tests/codegen/generated_native_tests.cpp
@@ -11,3 +11,12 @@ using namespace hgraph::testing;
 TEST_CASE("generated runtime nodes call exact native scalar functions", "[codegen][runtime][native]") {
     CHECK_OUTPUT(eval_node<checks::native_consumer::smooth>(values<Float>(1.0, 2.5)), values<Float>(4.0, 5.5));
 }
+
+TEST_CASE("generated runtime nodes select native collection-view overloads", "[codegen][runtime][native]") {
+    CHECK_OUTPUT(eval_node<checks::native_consumer::list_size>(values<Value>(list_delta<TS<Int>>({1, 2}))), values<Int>(2));
+    CHECK_OUTPUT((eval_node<checks::native_consumer::set_size>(values<Value>(set_delta<Int>({1, 2}, {}), set_delta<Int>({}, {1})))),
+                 values<Int>(2, 1));
+    CHECK_OUTPUT((eval_node<checks::native_consumer::map_size>(
+                     values<Value>(dict_delta<Int, TS<Float>>({{1, 1.0}, {2, 2.0}}), dict_delta<Int, TS<Float>>({}, {1})))),
+                 values<Int>(2, 1));
+}

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -187,6 +187,38 @@ namespace
         return result;
     }
 
+    descriptor::ModuleDescriptor collection_native_descriptor() {
+        descriptor::ModuleDescriptor result = minimal_descriptor();
+        result.types                        = {
+            descriptor::TypeRecord{.category = descriptor::TypeCategory::Scalar, .scalar_name = "i64"},
+            descriptor::TypeRecord{
+                .category = descriptor::TypeCategory::Symbol, .nominal_identity = "T", .binding_identity = "checks.reader::len::T"},
+            descriptor::TypeRecord{.category = descriptor::TypeCategory::List, .children = {1U}, .size = 0U},
+            descriptor::TypeRecord{.category = descriptor::TypeCategory::Set, .children = {1U}},
+        };
+        result.constant_expressions = {descriptor::ConstantExpressionRecord{
+            .category           = descriptor::ConstantExpressionCategory::Parameter,
+            .parameter_identity = "checks.reader::len::N",
+        }};
+
+        descriptor::NativeDeclaration list_len;
+        list_len.identity             = "checks.reader::len";
+        list_len.cpp_symbol           = "checks::reader::len";
+        list_len.signature.generics   = {{"T", "checks.reader::len::T", false, descriptor::no_schema_id},
+                                         {"N", "checks.reader::len::N", true, 0U}};
+        list_len.signature.parameters = {{"value", "checks.reader::len::value", false, 2U, descriptor::no_schema_id}};
+        list_len.signature.result     = 0U;
+        list_len.phases               = {descriptor::NativePhase::Evaluation};
+        list_len.parameters           = {{"value", {}, descriptor::NativeParameterAccess::InputView}};
+
+        descriptor::NativeDeclaration set_len = list_len;
+        set_len.signature.generics.resize(1U);
+        set_len.signature.parameters.front().type = 3U;
+        result.native_declarations                = {std::move(list_len), std::move(set_len)};
+        descriptor::seal(result);
+        return result;
+    }
+
     void replace_once(std::string &text, std::string_view from, std::string_view to) {
         const std::size_t offset = text.find(from);
         REQUIRE(offset != std::string::npos);
@@ -231,6 +263,19 @@ TEST_CASE("validated native scalar functions form a deterministic import catalog
     CHECK(function->runtime_images == std::vector<std::string>{"libchecks_reader.so"});
 }
 
+TEST_CASE("validated native collection views form one overload family", "[descriptor][catalog]") {
+    hgl::semantics::ModuleCatalog catalog;
+    REQUIRE_FALSE(descriptor::add_to_catalog(collection_native_descriptor(), catalog));
+
+    const std::span<const hgl::semantics::ImportedFunction> functions = catalog.find_functions("checks.reader", "len");
+    REQUIRE(functions.size() == 2U);
+    CHECK(functions[0].identity == "checks.reader::len");
+    CHECK(functions[1].identity == "checks.reader::len");
+    CHECK(functions[0].candidate_identity != functions[1].candidate_identity);
+    CHECK(functions[0].parameters.front().access == hgl::semantics::NativeParameterAccess::InputView);
+    CHECK(functions[1].parameters.front().access == hgl::semantics::NativeParameterAccess::InputView);
+}
+
 TEST_CASE("catalog import rejects native identities outside their module namespace", "[descriptor][catalog]") {
     descriptor::ModuleDescriptor source         = scalar_native_descriptor();
     source.native_declarations.front().identity = "checks.reader.blend";
@@ -256,7 +301,7 @@ TEST_CASE("catalog preserves unsupported native declarations for precise import 
         REQUIRE_FALSE(descriptor::add_to_catalog(source, catalog));
         const hgl::semantics::ImportedFunction *function = catalog.find_function("checks.reader", "blend");
         REQUIRE(function != nullptr);
-        CHECK(function->support_error == "native scalar calls with declared effects are not supported yet");
+        CHECK(function->support_error == "native value calls with declared effects are not supported yet");
     }
 
     SECTION("phase") {
@@ -269,7 +314,7 @@ TEST_CASE("catalog preserves unsupported native declarations for precise import 
         REQUIRE_FALSE(descriptor::add_to_catalog(source, catalog));
         const hgl::semantics::ImportedFunction *function = catalog.find_function("checks.reader", "blend");
         REQUIRE(function != nullptr);
-        CHECK(function->support_error == "native scalar calls currently require the evaluation phase only");
+        CHECK(function->support_error == "native value calls currently require the evaluation phase only");
     }
 }
 
@@ -396,7 +441,7 @@ TEST_CASE("module descriptor reader rejects malformed schema records", "[descrip
 
 TEST_CASE("module descriptors restrict signal to non-const inputs", "[descriptor][reader][signal]") {
     descriptor::ModuleDescriptor source = minimal_descriptor();
-    source.types = {
+    source.types                        = {
         descriptor::TypeRecord{.category = descriptor::TypeCategory::Scalar, .scalar_name = "i64"},
         descriptor::TypeRecord{.category = descriptor::TypeCategory::Signal},
     };
@@ -417,8 +462,7 @@ TEST_CASE("module descriptors restrict signal to non-const inputs", "[descriptor
     }
 
     SECTION("signal cannot have a default") {
-        source.constant_expressions.push_back(
-            descriptor::ConstantExpressionRecord{.literal = hgl::ir::hir::Constant{true}});
+        source.constant_expressions.push_back(descriptor::ConstantExpressionRecord{.literal = hgl::ir::hir::Constant{true}});
         source.interface.front().signature.parameters.front().default_value = 0U;
         check_error(descriptor::read_json(descriptor::to_json(source)), "$.interface[0].signature.parameters[0].default",
                     "a 'signal' input cannot have a default value");
@@ -431,9 +475,9 @@ TEST_CASE("module descriptors restrict signal to non-const inputs", "[descriptor
     }
 
     SECTION("signal cannot be a struct field") {
-        source.interface.front().category = descriptor::DeclarationCategory::Structure;
+        source.interface.front().category  = descriptor::DeclarationCategory::Structure;
         source.interface.front().signature = {};
-        source.interface.front().fields = {{"pulse", 1U, descriptor::no_schema_id, "checks.reader.observe", false}};
+        source.interface.front().fields    = {{"pulse", 1U, descriptor::no_schema_id, "checks.reader.observe", false}};
         check_error(descriptor::read_json(descriptor::to_json(source)), "$.interface[0].fields[0].type",
                     "'signal' is only valid as a complete non-const parameter type");
     }
@@ -471,6 +515,30 @@ TEST_CASE("module descriptor validation rejects incomplete semantic records", "[
 }
 
 TEST_CASE("native descriptor validation enforces the initial safety envelope", "[descriptor][reader][native]") {
+    SECTION("native overloads require distinct signatures") {
+        descriptor::ModuleDescriptor source = scalar_native_descriptor();
+        source.native_declarations.push_back(source.native_declarations.front());
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[1].identity",
+                    "duplicate native overload for declaration identity 'checks.reader::blend'");
+    }
+
+    SECTION("collection parameters require explicit input-view access") {
+        descriptor::ModuleDescriptor source                          = collection_native_descriptor();
+        source.native_declarations.front().parameters.front().access = descriptor::NativeParameterAccess::Value;
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].signature.parameters[0].type",
+                    "a native collection parameter requires input-view access");
+    }
+
+    SECTION("input-view access requires a collection pattern") {
+        descriptor::ModuleDescriptor source                          = scalar_native_descriptor();
+        source.native_declarations.front().parameters.front().access = descriptor::NativeParameterAccess::InputView;
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].signature.parameters[0].type",
+                    "input-view access requires a collection parameter");
+    }
+
     SECTION("native types name a nominal descriptor type") {
         descriptor::ModuleDescriptor source  = rich_descriptor();
         source.native_types.front().identity = "checks.reader.Missing";
@@ -535,12 +603,13 @@ TEST_CASE("native descriptor validation enforces the initial safety envelope", "
                     "mutation requires exactly one explicitly mutable borrowed argument");
     }
 
-    SECTION("native signatures reject temporal and container types") {
+    SECTION("native collection patterns reject undeclared generics") {
         descriptor::ModuleDescriptor source                             = rich_descriptor();
         source.native_declarations.front().signature.parameters[1].type = 2U;
         source.descriptor_fingerprint.clear();
-        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].signature.parameters[1].type",
-                    "native signature type is outside the initial scalar and declared-native envelope");
+        check_error(descriptor::read_json(descriptor::to_json(source)),
+                    "$.native.declarations[0].signature.parameters[1].type.children[0]",
+                    "native signature type is outside the scalar, declared-native, and collection-view envelope");
     }
 
     SECTION("native signatures reject undeclared nominal types") {
@@ -548,11 +617,11 @@ TEST_CASE("native descriptor validation enforces the initial safety envelope", "
         source.native_types.clear();
         source.descriptor_fingerprint.clear();
         check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].signature.parameters[0].type",
-                    "native signature type is outside the initial scalar and declared-native envelope");
+                    "native signature type is outside the scalar, declared-native, and collection-view envelope");
     }
 
     SECTION("constructors declare their owned result type") {
-        descriptor::ModuleDescriptor source = rich_descriptor();
+        descriptor::ModuleDescriptor source                = rich_descriptor();
         source.native_declarations.back().signature.result = descriptor::no_schema_id;
         source.descriptor_fingerprint.clear();
         check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[1].signature.result",

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -523,6 +523,33 @@ TEST_CASE("native descriptor validation enforces the initial safety envelope", "
                     "duplicate native overload for declaration identity 'checks.reader::blend'");
     }
 
+    SECTION("native overload signatures compare schema structure and alpha-equivalent generics") {
+        descriptor::ModuleDescriptor source = collection_native_descriptor();
+        const descriptor::SchemaId   i64{static_cast<descriptor::SchemaId>(source.types.size())};
+        source.types.push_back({.category = descriptor::TypeCategory::Scalar, .scalar_name = "i64"});
+        const descriptor::SchemaId element{static_cast<descriptor::SchemaId>(source.types.size())};
+        source.types.push_back({.category         = descriptor::TypeCategory::Symbol,
+                                .nominal_identity = "Element",
+                                .binding_identity = "checks.reader::len#duplicate::Element"});
+        const descriptor::SchemaId extent{static_cast<descriptor::SchemaId>(source.constant_expressions.size())};
+        source.constant_expressions.push_back({.category           = descriptor::ConstantExpressionCategory::Parameter,
+                                               .parameter_identity = "checks.reader::len#duplicate::Extent"});
+        const descriptor::SchemaId list{static_cast<descriptor::SchemaId>(source.types.size())};
+        source.types.push_back({.category = descriptor::TypeCategory::List, .children = {element}, .size = extent});
+
+        descriptor::NativeDeclaration duplicate = source.native_declarations.front();
+        duplicate.cpp_symbol                    = "checks::reader::duplicate_len";
+        duplicate.signature.generics = {{"Element", "checks.reader::len#duplicate::Element", false, descriptor::no_schema_id},
+                                        {"Extent", "checks.reader::len#duplicate::Extent", true, i64}};
+        duplicate.signature.parameters.front().binding_identity = "checks.reader::len#duplicate::value";
+        duplicate.signature.parameters.front().type             = list;
+        source.native_declarations.push_back(std::move(duplicate));
+        source.descriptor_fingerprint.clear();
+
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[2].identity",
+                    "duplicate native overload for declaration identity 'checks.reader::len'");
+    }
+
     SECTION("collection parameters require explicit input-view access") {
         descriptor::ModuleDescriptor source                          = collection_native_descriptor();
         source.native_declarations.front().parameters.front().access = descriptor::NativeParameterAccess::Value;

--- a/language/tests/driver/include/checks/native_dependency.h
+++ b/language/tests/driver/include/checks/native_dependency.h
@@ -2,12 +2,21 @@
 #define HGL_TESTS_CHECKS_NATIVE_DEPENDENCY_H
 
 #include <hgraph/types/primitive_types.h>
+#include <hgraph/types/time_series/ts_input/dict_view.h>
+#include <hgraph/types/time_series/ts_input/list_view.h>
+#include <hgraph/types/time_series/ts_input/set_view.h>
 
 namespace checks::native_dependency
 {
     inline hgraph::Float blend(hgraph::Float value, hgraph::Int window) noexcept {
         return value + static_cast<hgraph::Float>(window);
     }
+
+    inline hgraph::Int len(const hgraph::TSLInputView &value) noexcept { return static_cast<hgraph::Int>(value.size()); }
+
+    inline hgraph::Int len(const hgraph::TSSInputView &value) noexcept { return static_cast<hgraph::Int>(value.size()); }
+
+    inline hgraph::Int len(const hgraph::TSDInputView &value) noexcept { return static_cast<hgraph::Int>(value.size()); }
 }  // namespace checks::native_dependency
 
 #endif  // HGL_TESTS_CHECKS_NATIVE_DEPENDENCY_H

--- a/language/tests/driver/native-scalar-import.hgl
+++ b/language/tests/driver/native-scalar-import.hgl
@@ -7,3 +7,21 @@ export fn smooth(value: f64) -> f64 {
         return native::blend(value, 3)
     }
 }
+
+export fn list_size(value: list<i64, 2>) -> i64 {
+    when modified(value) && valid(value) {
+        return native::len(value)
+    }
+}
+
+export fn set_size(value: set<i64>) -> i64 {
+    when modified(value) && valid(value) {
+        return native::len(value)
+    }
+}
+
+export fn map_size(value: map<i64, f64>) -> i64 {
+    when modified(value) && valid(value) {
+        return native::len(value)
+    }
+}

--- a/language/tests/driver/native_scalar_descriptor_fixture.cpp
+++ b/language/tests/driver/native_scalar_descriptor_fixture.cpp
@@ -11,7 +11,11 @@ int main(int argc, char **argv) {
     }
     try {
         using namespace hgl::native;
-        Package package{
+        const ValueType i64 = ValueType::canonical(ScalarType::I64);
+        const ValueType t   = ValueType::type_parameter("T");
+        const ValueType k   = ValueType::type_parameter("K");
+        const ValueType v   = ValueType::type_parameter("V");
+        Package         package{
             .module_identity   = "checks.native_dependency",
             .language_version  = "0.1-test",
             .provider_identity = "checks.native_dependency",
@@ -26,6 +30,43 @@ int main(int argc, char **argv) {
                                 Parameter{.name = "window", .type = ValueType::canonical(ScalarType::I64), .is_const = true},
                             },
                         .result_type = ValueType::canonical(ScalarType::F64),
+                        .phases      = {Phase::Evaluation},
+                    },
+                    Declaration{
+                        .identity   = "checks.native_dependency::len",
+                        .cpp_symbol = "checks::native_dependency::len",
+                        .generics =
+                            {
+                                GenericParameter{.name = "T"},
+                                GenericParameter{.name = "N", .is_const = true, .type = i64},
+                            },
+                        .parameters =
+                            {
+                                Parameter{.name = "value", .type = ValueType::list(t, "N"), .access = ParameterAccess::InputView},
+                            },
+                        .result_type = i64,
+                        .phases      = {Phase::Evaluation},
+                    },
+                    Declaration{
+                        .identity   = "checks.native_dependency::len",
+                        .cpp_symbol = "checks::native_dependency::len",
+                        .generics   = {GenericParameter{.name = "T"}},
+                        .parameters =
+                            {
+                                Parameter{.name = "value", .type = ValueType::set(t), .access = ParameterAccess::InputView},
+                            },
+                        .result_type = i64,
+                        .phases      = {Phase::Evaluation},
+                    },
+                    Declaration{
+                        .identity   = "checks.native_dependency::len",
+                        .cpp_symbol = "checks::native_dependency::len",
+                        .generics   = {GenericParameter{.name = "K"}, GenericParameter{.name = "V"}},
+                        .parameters =
+                            {
+                                Parameter{.name = "value", .type = ValueType::map(k, v), .access = ParameterAccess::InputView},
+                            },
+                        .result_type = i64,
                         .phases      = {Phase::Evaluation},
                     },
                 },

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -105,6 +105,40 @@ namespace
         REQUIRE_FALSE(catalog.add(std::move(module)));
         return catalog;
     }
+
+    hgl::semantics::ModuleCatalog rolling_native_catalog() {
+        using namespace hgl::semantics;
+        ImportedType element;
+        element.kind             = ImportedTypeKind::Symbol;
+        element.binding_identity = "acme.windows::len::T";
+        ImportedType rolling;
+        rolling.kind     = ImportedTypeKind::Rolling;
+        rolling.children = {element};
+        rolling.size     = ImportedConstant{.kind = ImportedConstantKind::Parameter, .binding_identity = "acme.windows::len::N"};
+
+        ImportableModule module;
+        module.identity = "acme.windows";
+        module.functions.push_back(ImportedFunction{
+            .module_identity        = module.identity,
+            .name                   = "len",
+            .identity               = "acme.windows::len",
+            .cpp_symbol             = "acme::windows::len",
+            .generics               = {{"T", "acme.windows::len::T", false, std::nullopt},
+                                       {"N", "acme.windows::len::N", true, ImportedType{ImportedScalarType::I64}}},
+            .parameters             = {{"value", rolling, false, NativeParameterAccess::InputView}},
+            .result                 = ImportedType{ImportedScalarType::I64},
+            .phases                 = {NativeCallPhase::Evaluation},
+            .public_headers         = {"acme/windows.h"},
+            .cmake_packages         = {"acme"},
+            .imported_targets       = {"acme::windows"},
+            .runtime_images         = {"libacme_windows.so"},
+            .descriptor_fingerprint = "sha256:test",
+        });
+
+        ModuleCatalog catalog;
+        REQUIRE_FALSE(catalog.add(std::move(module)));
+        return catalog;
+    }
 }  // namespace
 
 TEST_CASE("HIR owns backend operator spellings", "[ir][architecture]") {
@@ -219,6 +253,22 @@ fn smooth(value: f64) -> f64 {
         CHECK(expression.phase == hir::Phase::Runtime);
     }
     CHECK(found);
+}
+
+TEST_CASE("native const generics enforce their declared value type", "[ir][native]") {
+    const hgl::semantics::ModuleCatalog catalog = rolling_native_catalog();
+    Lowered                             lowered{R"(
+module checks.native_const_type
+use acme.windows::{len}
+
+fn recent(value: rolling<f64, 5m>) -> i64 {
+    when modified(value) && valid(value) { return len(value) }
+}
+)",
+                                                catalog};
+    require_clean(lowered);
+    CHECK_FALSE(complete(lowered));
+    CHECK(lowered.diagnostics.render(lowered.file).find("no native overload") != std::string::npos);
 }
 
 TEST_CASE("native calls enforce exact scalar and descriptor phase contracts", "[ir][native]") {

--- a/language/tests/native/native_package_tests.cpp
+++ b/language/tests/native/native_package_tests.cpp
@@ -114,6 +114,58 @@ TEST_CASE("native package descriptor order is canonical") {
     CHECK(hgl::native::descriptor_json(reordered) == hgl::native::descriptor_json(canonical));
 }
 
+TEST_CASE("native package API describes overloaded collection-view functions") {
+    using namespace hgl::native;
+
+    const ValueType i64 = ValueType::canonical(ScalarType::I64);
+    const ValueType t   = ValueType::type_parameter("T");
+    Package         source{
+        .module_identity  = "acme.collections",
+        .language_version = "0.1-test",
+        .declarations =
+            {
+                Declaration{
+                    .identity   = "acme.collections::len",
+                    .cpp_symbol = "acme::collections::len",
+                    .generics =
+                        {
+                            GenericParameter{.name = "T"},
+                            GenericParameter{.name = "N", .is_const = true, .type = i64},
+                        },
+                    .parameters =
+                        {
+                            Parameter{.name = "value", .type = ValueType::list(t, "N"), .access = ParameterAccess::InputView},
+                        },
+                    .result_type = i64,
+                    .phases      = {Phase::Evaluation},
+                },
+                Declaration{
+                    .identity   = "acme.collections::len",
+                    .cpp_symbol = "acme::collections::len",
+                    .generics   = {GenericParameter{.name = "T"}},
+                    .parameters =
+                        {
+                            Parameter{.name = "value", .type = ValueType::set(t), .access = ParameterAccess::InputView},
+                        },
+                    .result_type = i64,
+                    .phases      = {Phase::Evaluation},
+                },
+            },
+    };
+
+    const std::string canonical = descriptor_json(source);
+    std::ranges::reverse(source.declarations);
+    CHECK(descriptor_json(source) == canonical);
+
+    const auto parsed = hgl::descriptor::read_json(canonical);
+    REQUIRE(parsed);
+    REQUIRE(parsed.value->native_declarations.size() == 2U);
+    CHECK(parsed.value->native_declarations[0].identity == "acme.collections::len");
+    CHECK(parsed.value->native_declarations[1].identity == "acme.collections::len");
+    CHECK(parsed.value->native_declarations[0].parameters.front().access == hgl::descriptor::NativeParameterAccess::InputView);
+    CHECK(parsed.value->native_declarations[1].parameters.front().access == hgl::descriptor::NativeParameterAccess::InputView);
+}
+
 TEST_CASE("native package API applies the descriptor safety envelope") {
     hgl::native::Package invalid = package();
     invalid.declarations[1].effects.push_back(hgl::native::Effect::Blocking);


### PR DESCRIPTION
## Summary

- allow native descriptor declarations to form overload families with generic list, set, map, and rolling type patterns
- add explicit input-view parameter access so evaluation functions can inspect live collection metadata without materializing values or performing per-tick schema dispatch
- select the exact overload during HGL type checking and emit a direct readable C++ call such as `native::len(value)`
- document the distinction between compile-time type markers, instantiation parameters, and runtime view information

## Validation

- complete HGL suite: 55/55 passed
- generated native behavior fixture: list, set, and map `len` cases passed
- complete native C++ suite: 1,735/1,735 passed
- Python 3.14 compatibility suite from a Python 3.12-built ABI3 wheel: 3,284 passed, 10 skipped
- `git diff --check`

## Stack

Depends on #786. The stdlib/spec prototype in #785 will be rebased onto this PR and updated to consume the native `len` operation.