### PR TITLE
feat(hgl): add core native library

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -50,6 +50,27 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
+      # The installed static hgraph SDK deliberately resolves its public C++
+      # dependencies from the consuming environment. Ubuntu's distro packages
+      # are older than the supported fmt/spdlog/simdjson floors, so give the
+      # installed HGL consumer the same real package environment used by the
+      # repository's installed-SDK validation.
+      - uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3
+        if: runner.os == 'Linux'
+        with:
+          environment-name: hgraph-language
+          cache-environment: true
+          create-args: >-
+            libarrow=25
+            libarrow-compute=25
+            libarrow-acero=25
+            fmt
+            spdlog>=1.15
+            simdjson>=4.5
+      - name: Expose Linux SDK dependencies
+        if: runner.os == 'Linux'
+        shell: micromamba-shell {0}
+        run: echo "HGL_DEPENDENCY_PREFIX=$CONDA_PREFIX" >> "$GITHUB_ENV"
       - name: Configure current Clang on macOS
         if: runner.os == 'macOS'
         shell: bash
@@ -106,6 +127,7 @@ jobs:
           -DHGRAPH_BUILD_WEB_EXTENSION=OFF
           -DHGRAPH_BUILD_PERSISTENCE_EXTENSION=OFF
           -DHGRAPH_BUILD_FABRIC_EXTENSION=OFF
+          -DCMAKE_PREFIX_PATH="$HGL_DEPENDENCY_PREFIX"
       - name: Build hgl and its suites
         run: >-
           cmake --build build-language --parallel ${{ matrix.parallel }} --target

--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -51,12 +51,11 @@ jobs:
         with:
           python-version: "3.12"
       # The installed static hgraph SDK deliberately resolves its public C++
-      # dependencies from the consuming environment. Ubuntu's distro packages
-      # are older than the supported fmt/spdlog/simdjson floors, so give the
-      # installed HGL consumer the same real package environment used by the
-      # repository's installed-SDK validation.
+      # dependencies from the consuming environment. Give the installed HGL
+      # consumer the same real package environment on both platforms rather
+      # than letting a developer machine's package-manager state hide a missing
+      # dependency prefix.
       - uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3
-        if: runner.os == 'Linux'
         with:
           environment-name: hgraph-language
           cache-environment: true
@@ -67,8 +66,7 @@ jobs:
             fmt
             spdlog>=1.15
             simdjson>=4.5
-      - name: Expose Linux SDK dependencies
-        if: runner.os == 'Linux'
+      - name: Expose SDK dependencies
         shell: micromamba-shell {0}
         run: echo "HGL_DEPENDENCY_PREFIX=$CONDA_PREFIX" >> "$GITHUB_ENV"
       - name: Configure current Clang on macOS

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -387,6 +387,27 @@ hgl_apply_warnings(hgl)
 # own codegen tests use the same function an installed SDK ships.
 include(cmake/HglLanguage.cmake)
 
+# The first production HGL library module: a small, concrete C++ substrate
+# for operations on scalar values and live hgraph input views. Higher-level
+# hgraph.std nodes depend on this target instead of repeating C++ projections.
+set(_hgl_core_native_include_dir ${CMAKE_CURRENT_BINARY_DIR}/generated/hgl_core_native/include)
+set(_hgl_core_native_src_dir ${CMAKE_CURRENT_BINARY_DIR}/generated/hgl_core_native/src)
+hgl_add_module(hgl_core_native STATIC
+    HGL stdlib/hgl/hgraph/native.hgl
+    INCLUDE_DIR ${_hgl_core_native_include_dir}
+    SRC_DIR ${_hgl_core_native_src_dir}
+)
+add_library(hgl::core_native ALIAS hgl_core_native)
+set_target_properties(hgl_core_native PROPERTIES EXPORT_NAME core_native)
+# hgl_add_module publishes a build-tree include directory. This target is also
+# installed, so replace only its exported interface with the relocatable SDK
+# location; its own INCLUDE_DIRECTORIES still contain the build path.
+set_property(TARGET hgl_core_native PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+    "$<BUILD_INTERFACE:${_hgl_core_native_include_dir}>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hgl>"
+)
+hgl_apply_warnings(hgl_core_native)
+
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
@@ -395,7 +416,7 @@ install(TARGETS hgl
     COMPONENT Runtime
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
-install(TARGETS hgl_native_interface hgl_native_package
+install(TARGETS hgl_native_interface hgl_native_package hgl_core_native
     EXPORT HglLanguageTargets
     COMPONENT Development
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -413,8 +434,25 @@ install(DIRECTORY include/hgl
     COMPONENT Development
 )
 install(FILES
+    ${_hgl_core_native_include_dir}/native.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hgl
+    COMPONENT Development
+)
+install(FILES
+    ${_hgl_core_native_src_dir}/native.hgl-module.json
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hgl/modules
+    COMPONENT Development
+)
+install(FILES
+    stdlib/hgl/hgraph/native.hgl
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/hgl/stdlib/hgraph
+    COMPONENT Development
+)
+install(FILES
     cmake/HglLanguage.cmake
     cmake/hgl_python_module.cpp.in
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hgl
     COMPONENT Development
 )
+unset(_hgl_core_native_include_dir)
+unset(_hgl_core_native_src_dir)

--- a/language/README.md
+++ b/language/README.md
@@ -99,3 +99,7 @@ and preserves those semantics through hgraph's public C++ APIs.
 Syntax remains provisional while the prototype evolves; compatibility is not
 yet a release constraint. Implemented forms are kept under grammar, semantic,
 and direct-wiring tests.
+
+The first compiled library module lives at
+[`stdlib/hgl/hgraph/native.hgl`](stdlib/hgl/hgraph/native.hgl) and is published
+as the `hgl::core_native` CMake target.

--- a/language/cmake/HglLanguage.cmake
+++ b/language/cmake/HglLanguage.cmake
@@ -62,6 +62,21 @@ if(NOT TARGET hgl::native_interface AND EXISTS "${_HGL_LANGUAGE_CMAKE_DIR}/HglLa
     include("${_HGL_LANGUAGE_CMAKE_DIR}/HglLanguageTargets.cmake")
 endif()
 
+# The installed core-native target carries a generated descriptor beside this
+# helper. Custom build-tree target properties are intentionally not exported;
+# reconstruct the relocatable path when an installed consumer loads the SDK.
+if(TARGET hgl::core_native)
+    get_target_property(_hgl_core_native_descriptors hgl::core_native HGL_MODULE_DESCRIPTORS)
+    if(NOT _hgl_core_native_descriptors OR _hgl_core_native_descriptors STREQUAL "_hgl_core_native_descriptors-NOTFOUND")
+        set(_hgl_core_native_descriptor "${_HGL_LANGUAGE_CMAKE_DIR}/modules/native.hgl-module.json")
+        if(EXISTS "${_hgl_core_native_descriptor}")
+            set_property(TARGET hgl::core_native PROPERTY HGL_MODULE_DESCRIPTORS "${_hgl_core_native_descriptor}")
+        endif()
+        unset(_hgl_core_native_descriptor)
+    endif()
+    unset(_hgl_core_native_descriptors)
+endif()
+
 function(_hgl_resolve_compiler out_var)
     if(TARGET hgl)
         set(${out_var} "$<TARGET_FILE:hgl>" PARENT_SCOPE)

--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -78,6 +78,13 @@ define those contracts before widening this form.
 This decision is recorded in
 [ADR 0005](decisions/0005-inline-cpp-native-functions.md).
 
+The first shipped use of this form is
+[`hgraph.native`](../../stdlib/hgl/hgraph/native.hgl). Its compiled
+`hgl::core_native` target provides `len` and `is_empty` for strings and the
+currently descriptor-safe TSL, TSS, TSD, and tick-window TSW input-view
+patterns. The source, generated library, header, and descriptor are installed
+together and exercised by an isolated SDK consumer.
+
 ## Descriptor is the contract
 
 A supporting native package publishes a versioned descriptor alongside its

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -264,6 +264,8 @@ HGraph IR; unsupported language-depth items remain explicit roadmap work.
 - [x] parse top-level `native fn` C++ projections, select generic overloads by
   their type patterns, emit formatted plain `noexcept` functions, publish them
   in generated descriptors, and consume them from downstream HGL modules;
+- [x] ship the compiled `hgraph.native` C++ substrate with `len` and
+  `is_empty` over strings and the currently importable TSL/TSS/TSD/TSW views;
 - generate normalized wrappers for C++ overloads, templates, exceptions, and
   ownership boundaries;
 - [x] add phase, effect, ownership, dependent-lifetime, exception,
@@ -278,8 +280,8 @@ remain rejected.
 
 ### G. Standard-library migration
 
-Status: ready to begin inventory; no core implementation has been selected or
-migrated yet.
+Status: the low-level `hgraph.native` substrate is compiled and installed; no
+core graph or node implementation has been migrated yet.
 
 - generate the complete core graph/node inventory and classify each item;
 - select representative composition, stateless scalar-node, stateful-node,
@@ -333,7 +335,7 @@ today (#767, "Readiness").
 | Graph-phase `for`: `values` and `items` over fixed lists, independent bodies over maps and unbounded lists | partial | Both backends; `for` is phase-neutral. Graph-phase `keys`, predicates, scalar and `const` captures, sets, bundles, reductions, loop results, escaping assignments, and `return` fail closed; `for` in a `test` body is a `phase` diagnostic; dynamic-body tests are structure-only (#767 item 4). |
 | Runtime `for`, `keys`/`values`/`items` with predicates, `key_set` | partial | Generated C++ only: the direct backend never evaluates a runtime body, so the scripted path is the C++ backend plus a loaded image. `key_set` inside a runtime body is rejected; unbounded-list added/removed views need a public hgraph view API. |
 | `elements(list_or_set)` | provisional | Agreed 2026-09-06; `elements` is `name: unknown name 'elements'` today; retention of the `values` spelling is undecided (#767 item 6). |
-| Runtime nodes | partial | Implemented, in generated C++ and scripted on Unix: activation from `modified`, variadic `valid`, ordered `when` handlers, `return`, scalar recordable `state` with an initializer, `inject out` (whole, prior, and keyed writes), `inject logger` (`info` only), one `start` and one `stop` block, passive sampled inputs, `signal` inputs. Fail closed: calls to other HGL functions, non-scalar state, `rolling` parameters, zero-input sources, `key_set`, temporal inputs or `out` in lifecycle blocks, a runtime `if` used as a value. Declaration placement (`state`/`inject` before handlers, one `start` and `stop`, no nested `when`, no `out` or `return` in a lifecycle block) and the approved injectable list are `hgl check` diagnostics (PR #780); validity-dominance ordering is still checked by `emit-cpp` only. |
+| Runtime nodes | partial | Implemented, in generated C++ and scripted on Unix: activation from `modified`, variadic `valid`, ordered `when` handlers, `return`, scalar recordable `state` with an initializer, `inject out` (whole, prior, and keyed writes), `inject logger` (`info` only), one `start` and one `stop` block, passive sampled inputs, scalar/collection/rolling/ref/`signal` inputs. Fail closed: calls to other HGL functions, non-scalar state, zero-input sources, `key_set`, temporal inputs or `out` in lifecycle blocks, a runtime `if` used as a value. Declaration placement (`state`/`inject` before handlers, one `start` and `stop`, no nested `when`, no `out` or `return` in a lifecycle block) and the approved injectable list are `hgl check` diagnostics (PR #780); validity-dominance ordering is still checked by `emit-cpp` only. |
 | `inject clock`, `inject scheduler` | provisional | Documented in the user guide; neither word occurs in `src/`; `emit-cpp` reports "injectable 'clock' is not supported by emit-cpp yet". |
 | Scalar (wiring-time) `if`, including `else if` | implemented | |
 | Temporal `if` | partial | Both backends: results, sinks, escaping and forwarded bindings, mixed results, omitted `else`, nested early-return continuations. Rejected: temporal `else if`, scalar captures in a branch, `return` from a branch that is not the function's return. The documented status of a temporal conditional embedded in another expression is under review (#767 items 4 and 5). |
@@ -344,7 +346,7 @@ today (#767, "Readiness").
 | Timed harness sequences (`[0s: v, ...]`) | provisional | Parsed and typed; "timed sequences are not supported by the first pass". |
 | `hgl run` | partial | `--entry`, `--mode`, `--start`, `--end`, `--set`; an entry is an `export fn` whose parameters are all `const`. |
 | `hgl run --config run.toml` (`[run]`, `[run.params]`) | provisional | Documented format; not read. |
-| Native interface | partial | JSON descriptor format v1, descriptor-only `hgl check`, `hgl::native_package`, lifecycle ABI v1 for scripted images, exact canonical-value plus overloaded generic collection-view calls, top-level source `native fn` C++ projections emitted as formatted plain functions and importable descriptor declarations, and literal module-local `cpp include` declarations. Native `requires` clauses fail closed until catalog constraint reconstruction exists. Linked source dependencies, owned opaque state, scripted external dependencies, transitive closure, and the AOT lifecycle ABI remain; direct wiring does not emulate native C++. Format v1 labels every temporal parameter `"kind": "signal"`; renaming is an open v2 decision (#767 item 6). |
+| Native interface | partial | JSON descriptor format v1, descriptor-only `hgl check`, `hgl::native_package`, lifecycle ABI v1 for scripted images, exact canonical-value plus overloaded generic collection-view calls, top-level source `native fn` C++ projections emitted as formatted plain functions and importable descriptor declarations, literal module-local `cpp include` declarations, and the installed `hgl::core_native` library/descriptor. Native `requires` clauses fail closed until catalog constraint reconstruction exists. Linked source dependencies, owned opaque state, scripted external dependencies, transitive closure, duration-window generics, nominal bundle/ref views, and the AOT lifecycle ABI remain; direct wiring does not emulate native C++. Format v1 labels every temporal parameter `"kind": "signal"`; renaming is an open v2 decision (#767 item 6). |
 | Tooling: `check` (`--dump-tokens`, `--dump-ast`, `--dump-hir`, `--dump-hgraph-ir`), `test`, `run`, `emit-cpp`, `repl`, `hgl_add_module()` with `PYTHON_MODULE`, native cache v3 | partial | Scripted loading and the cache are Unix-only; Windows, child orchestration, cache pruning, and dependency lock files are staged; there is no `hgl build`; the driver does not invoke `hgraph_ir::complete`. |
 
 The inventory comes next. Its first candidate set should prefer pure

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -110,6 +110,38 @@ C++ declarations and body.
 The complete, compiled example is
 [`native-functions.hgl`](../../examples/native-functions.hgl).
 
+## Using the core native substrate
+
+The opt-in language build ships one real source-native module today:
+`hgraph.native`. Its first surface provides `len` and `is_empty` for `str`,
+fixed and unbounded lists, sets, maps, and tick-count rolling windows. An HGL
+library imports it normally:
+
+```hgl
+use hgraph.native as native
+
+fn list_size<T, const size: i64>(value: list<T, size>) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+```
+
+Its CMake target supplies both the native library and descriptor:
+
+```cmake
+hgl_add_module(my_hgl_library STATIC
+    HGL my_library.hgl
+    LINK_LIBRARIES hgl::core_native)
+```
+
+See the compiled
+[`core-native-library.hgl`](../../stdlib/hgl/examples/core-native-library.hgl)
+example and
+the [native module inventory](../../stdlib/hgl/hgraph/README.md). Duration
+windows, nominal bundles, and reference views are not declared yet because
+descriptor ABI v1 cannot faithfully import those generic view patterns.
+
 ## Operator identity and implementation binding
 
 An operator is identified by its defining module and name, not by its short

--- a/language/stdlib/hgl/examples/core-native-library.hgl
+++ b/language/stdlib/hgl/examples/core-native-library.hgl
@@ -1,0 +1,78 @@
+module examples.core_native_library
+
+use hgraph.native as native
+
+// hgraph.native is the small C++ substrate beneath HGL library nodes. The
+// node remains responsible for scheduling; the selected native function sees
+// either the current scalar value or the live collection input view.
+export fn text_length(value: str) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+
+export fn text_is_empty(value: str) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+export fn fixed_list_length(value: list<i64, 2>) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+
+export fn fixed_list_is_empty(value: list<i64, 2>) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+export fn dynamic_list_length(value: list<i64, unbounded>) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+
+export fn dynamic_list_is_empty(value: list<i64, unbounded>) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+export fn set_length(value: set<i64>) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+
+export fn map_length(value: map<i64, f64>) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+
+export fn map_is_empty(value: map<i64, f64>) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+export fn window_length(value: rolling<i64, 3, 1>) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+
+export fn window_is_empty(value: rolling<i64, 3, 1>) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+export fn set_is_empty(value: set<i64>) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}

--- a/language/stdlib/hgl/hgraph/README.md
+++ b/language/stdlib/hgl/hgraph/README.md
@@ -9,6 +9,8 @@ header, module descriptor, and HGL source with the opt-in language SDK.
 This is a deliberately thin substrate for HGL library authors. It exposes
 current-value or live-view calculations; it does not own graph scheduling,
 state, lifecycle, or output mutation. Those remain in ordinary HGL functions.
+The module names each owning hgraph view header explicitly with `cpp include`,
+so its source-native signatures do not depend on incidental umbrella includes.
 
 ## Implemented surface
 

--- a/language/stdlib/hgl/hgraph/README.md
+++ b/language/stdlib/hgl/hgraph/README.md
@@ -1,0 +1,58 @@
+# Core native HGL module
+
+Status: compiled, tested, and installed C++ implementation
+
+[`native.hgl`](native.hgl) defines the `hgraph.native` module. It is built as
+the `hgl::core_native` CMake target and installs its generated C++ library,
+header, module descriptor, and HGL source with the opt-in language SDK.
+
+This is a deliberately thin substrate for HGL library authors. It exposes
+current-value or live-view calculations; it does not own graph scheduling,
+state, lifecycle, or output mutation. Those remain in ordinary HGL functions.
+
+## Implemented surface
+
+The first slice provides `len(value)` and `is_empty(value)` for:
+
+- `str`, passed as its current `hgraph::Str` value;
+- fixed `list<T, size>` and dynamic `list<T, unbounded>`, passed as a
+  `hgraph::TSLInputView`;
+- `set<T>`, passed as a `hgraph::TSSInputView`;
+- `map<K, V>`, passed as a `hgraph::TSDInputView`;
+- tick-count `rolling<T, max_size, min_size>`, passed as a
+  `hgraph::TSWInputView`.
+
+All casts and calls in the source are real C++ and are compiled with the same
+warnings as the rest of the language build. The runtime tests exercise every
+listed hgraph view, including list growth/truncation and window growth.
+
+An HGL module imports the descriptor by linking its generated target to
+`hgl::core_native`:
+
+```cmake
+hgl_add_module(my_hgl_library STATIC
+    HGL my_library.hgl
+    LINK_LIBRARIES hgl::core_native)
+```
+
+```hgl
+use hgraph.native as native
+
+fn list_size<T, const size: i64>(value: list<T, size>) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+```
+
+See the compiled consumer
+[`core-native-library.hgl`](../examples/core-native-library.hgl).
+
+## Honest boundaries
+
+Descriptor ABI v1 currently accepts native collection extents only through
+`const ...: i64` generics. Duration-based rolling windows therefore cannot yet
+join this generic overload family. Nominal bundle/struct views and `ref` views
+are also outside the current native input-view envelope. They are omitted from
+the module rather than represented by declarations that cannot be imported or
+run.

--- a/language/stdlib/hgl/hgraph/native.hgl
+++ b/language/stdlib/hgl/hgraph/native.hgl
@@ -1,5 +1,10 @@
 module hgraph.native
 
+cpp include <hgraph/types/time_series/ts_input/dict_view.h>
+cpp include <hgraph/types/time_series/ts_input/list_view.h>
+cpp include <hgraph/types/time_series/ts_input/set_view.h>
+cpp include <hgraph/types/time_series/ts_input/window_view.h>
+
 // This is the concrete C++ native substrate used by HGL library code. Keep
 // these functions small: they expose operations on current hgraph values and
 // live input views; graph scheduling and output mutation remain in HGL nodes.

--- a/language/stdlib/hgl/hgraph/native.hgl
+++ b/language/stdlib/hgl/hgraph/native.hgl
@@ -1,0 +1,81 @@
+module hgraph.native
+
+// This is the concrete C++ native substrate used by HGL library code. Keep
+// these functions small: they expose operations on current hgraph values and
+// live input views; graph scheduling and output mutation remain in HGL nodes.
+
+native fn len(value: str) -> i64 {
+    cpp(const hgraph::Str &value) {
+        return static_cast<hgraph::Int>(value.size());
+    }
+}
+
+native fn len<T, const size: i64>(value: list<T, size>) -> i64 {
+    cpp(const hgraph::TSLInputView &value) {
+        return static_cast<hgraph::Int>(value.size());
+    }
+}
+
+native fn len<T>(value: list<T, unbounded>) -> i64 {
+    cpp(const hgraph::TSLInputView &value) {
+        return static_cast<hgraph::Int>(value.size());
+    }
+}
+
+native fn len<T>(value: set<T>) -> i64 {
+    cpp(const hgraph::TSSInputView &value) {
+        return static_cast<hgraph::Int>(value.size());
+    }
+}
+
+native fn len<K, V>(value: map<K, V>) -> i64 {
+    cpp(const hgraph::TSDInputView &value) {
+        return static_cast<hgraph::Int>(value.size());
+    }
+}
+
+native fn len<T, const max_size: i64, const min_size: i64>(
+    value: rolling<T, max_size, min_size>
+) -> i64 {
+    cpp(const hgraph::TSWInputView &value) {
+        return static_cast<hgraph::Int>(value.size());
+    }
+}
+
+native fn is_empty(value: str) -> bool {
+    cpp(const hgraph::Str &value) {
+        return value.empty();
+    }
+}
+
+native fn is_empty<T, const size: i64>(value: list<T, size>) -> bool {
+    cpp(const hgraph::TSLInputView &value) {
+        return value.empty();
+    }
+}
+
+native fn is_empty<T>(value: list<T, unbounded>) -> bool {
+    cpp(const hgraph::TSLInputView &value) {
+        return value.empty();
+    }
+}
+
+native fn is_empty<T>(value: set<T>) -> bool {
+    cpp(const hgraph::TSSInputView &value) {
+        return value.empty();
+    }
+}
+
+native fn is_empty<K, V>(value: map<K, V>) -> bool {
+    cpp(const hgraph::TSDInputView &value) {
+        return value.empty();
+    }
+}
+
+native fn is_empty<T, const max_size: i64, const min_size: i64>(
+    value: rolling<T, max_size, min_size>
+) -> bool {
+    cpp(const hgraph::TSWInputView &value) {
+        return value.empty();
+    }
+}

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -333,12 +333,18 @@ hgl_add_module(hgl_inline_native_consumer_fixture STATIC
     LINK_LIBRARIES hgl_inline_native_fixture
 )
 hgl_apply_warnings(hgl_inline_native_consumer_fixture)
+hgl_add_module(hgl_core_native_consumer_fixture STATIC
+    HGL ../stdlib/hgl/examples/core-native-library.hgl
+    LINK_LIBRARIES hgl::core_native
+)
+hgl_apply_warnings(hgl_core_native_consumer_fixture)
 
 set(_hgl_generated_test_sources
     codegen/generated_tests.cpp
     codegen/generated_runtime_tests.cpp
     codegen/generated_native_tests.cpp
     codegen/generated_inline_native_tests.cpp
+    codegen/generated_core_native_tests.cpp
     codegen/generated_partial_materialization_tests.cpp
     codegen/generated_iteration_tests.cpp
     codegen/generated_reference_tests.cpp
@@ -354,6 +360,7 @@ set(_hgl_generated_test_libraries
     hgl_reference_fixture
     hgl_native_scalar_import_fixture
     hgl_inline_native_consumer_fixture
+    hgl_core_native_consumer_fixture
 )
 if(TARGET hgraph::analytics)
     # These two examples intentionally exercise an imported extension. Keep

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -210,6 +210,7 @@ add_test(
         -DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/cmake/native_package
         -DOUT=${CMAKE_CURRENT_BINARY_DIR}/native-package-consumer
         "-DGENERATOR=${CMAKE_GENERATOR}"
+        "-DDEPENDENCY_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
         -DHGL=$<TARGET_FILE:hgl>
         -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/native_package_test.cmake
 )

--- a/language/tests/cmake/native_package/CMakeLists.txt
+++ b/language/tests/cmake/native_package/CMakeLists.txt
@@ -2,14 +2,23 @@ cmake_minimum_required(VERSION 3.25)
 
 project(hgl_native_package_consumer LANGUAGES CXX)
 
-if(NOT HGL_LANGUAGE_TARGETS)
-    message(FATAL_ERROR "HGL_LANGUAGE_TARGETS is required")
+if(NOT HGL_LANGUAGE_CMAKE)
+    message(FATAL_ERROR "HGL_LANGUAGE_CMAKE is required")
 endif()
 
-include("${HGL_LANGUAGE_TARGETS}")
+find_package(hgraph CONFIG REQUIRED)
+include("${HGL_LANGUAGE_CMAKE}")
+
+if(NOT TARGET hgl::core_native)
+    message(FATAL_ERROR "the installed HGL SDK does not define hgl::core_native")
+endif()
+get_target_property(_core_native_descriptors hgl::core_native HGL_MODULE_DESCRIPTORS)
+if(NOT _core_native_descriptors OR NOT EXISTS "${_core_native_descriptors}")
+    message(FATAL_ERROR "hgl::core_native has no installed module descriptor: '${_core_native_descriptors}'")
+endif()
 
 add_executable(hgl_native_package_consumer main.cpp)
 target_compile_features(hgl_native_package_consumer PRIVATE cxx_std_23)
-target_link_libraries(hgl_native_package_consumer PRIVATE hgl::native_package)
+target_link_libraries(hgl_native_package_consumer PRIVATE hgl::native_package hgl::core_native)
 set_target_properties(hgl_native_package_consumer PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_CURRENT_BINARY_DIR}/bin>")

--- a/language/tests/cmake/native_package/main.cpp
+++ b/language/tests/cmake/native_package/main.cpp
@@ -1,4 +1,5 @@
 #include <hgl/native_package.h>
+#include <native.h>
 
 #include <filesystem>
 #include <iostream>
@@ -7,6 +8,12 @@ int main(int argc, char **argv) {
     if (argc != 2) {
         std::cerr << "usage: hgl_native_package_consumer <descriptor>\n";
         return 2;
+    }
+
+    if (hgraph_::native::native::len(hgraph::Str{"hgl"}) != 3 ||
+        hgraph_::native::native::is_empty(hgraph::Str{"hgl"})) {
+        std::cerr << "installed hgraph.native functions returned the wrong value\n";
+        return 3;
     }
 
     using namespace hgl::native;

--- a/language/tests/cmake/native_package_test.cmake
+++ b/language/tests/cmake/native_package_test.cmake
@@ -13,16 +13,34 @@ if(NOT _install_result EQUAL 0)
     message(FATAL_ERROR "native-package SDK install failed:\n${_install_out}\n${_install_err}")
 endif()
 
+# hgl::core_native is a real generated library and therefore links the hgraph
+# SDK. Install the ordinary (unclassified) hgraph targets beside the HGL
+# development component before configuring the isolated consumer.
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" --install "${BUILD}" --prefix "${OUT}/sdk" --component Unspecified
+    RESULT_VARIABLE _runtime_install_result
+    OUTPUT_VARIABLE _runtime_install_out
+    ERROR_VARIABLE _runtime_install_err)
+if(NOT _runtime_install_result EQUAL 0)
+    message(FATAL_ERROR "hgraph SDK install failed:\n${_runtime_install_out}\n${_runtime_install_err}")
+endif()
+
 file(GLOB_RECURSE _targets "${OUT}/sdk/*/cmake/hgl/HglLanguageTargets.cmake")
 list(LENGTH _targets _target_count)
 if(NOT _target_count EQUAL 1)
     message(FATAL_ERROR "expected one installed HglLanguageTargets.cmake, found: ${_targets}")
 endif()
 list(GET _targets 0 _target_file)
+get_filename_component(_hgl_cmake_dir "${_target_file}" DIRECTORY)
+set(_hgl_language_cmake "${_hgl_cmake_dir}/HglLanguage.cmake")
+if(NOT EXISTS "${_hgl_language_cmake}")
+    message(FATAL_ERROR "installed HglLanguage.cmake was not found beside '${_target_file}'")
+endif()
 
 execute_process(
     COMMAND "${CMAKE_COMMAND}" -S "${SOURCE}" -B "${OUT}/build" -G "${GENERATOR}"
-        "-DHGL_LANGUAGE_TARGETS=${_target_file}"
+        "-DCMAKE_PREFIX_PATH=${OUT}/sdk"
+        "-DHGL_LANGUAGE_CMAKE=${_hgl_language_cmake}"
     RESULT_VARIABLE _configure_result
     OUTPUT_VARIABLE _configure_out
     ERROR_VARIABLE _configure_err)

--- a/language/tests/cmake/native_package_test.cmake
+++ b/language/tests/cmake/native_package_test.cmake
@@ -39,7 +39,7 @@ endif()
 
 execute_process(
     COMMAND "${CMAKE_COMMAND}" -S "${SOURCE}" -B "${OUT}/build" -G "${GENERATOR}"
-        "-DCMAKE_PREFIX_PATH=${OUT}/sdk"
+        "-DCMAKE_PREFIX_PATH=${OUT}/sdk;${DEPENDENCY_PREFIX_PATH}"
         "-DHGL_LANGUAGE_CMAKE=${_hgl_language_cmake}"
     RESULT_VARIABLE _configure_result
     OUTPUT_VARIABLE _configure_out

--- a/language/tests/codegen/generated_core_native_tests.cpp
+++ b/language/tests/codegen/generated_core_native_tests.cpp
@@ -1,0 +1,45 @@
+#include <core-native-library.h>
+#include <native.h>
+
+#include <hgraph/lib/testing/check_output.h>
+#include <hgraph/lib/testing/eval_node.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace hgraph;
+using namespace hgraph::testing;
+namespace native_consumer = examples::core_native_library;
+
+TEST_CASE("the HGL core native library handles scalar and collection values", "[codegen][runtime][native][stdlib]") {
+    CHECK_OUTPUT(eval_node<native_consumer::text_length>(values<Str>("hgl", "")), values<Int>(3, 0));
+    CHECK_OUTPUT(eval_node<native_consumer::text_is_empty>(values<Str>("hgl", "")), values<Bool>(false, true));
+
+    CHECK_OUTPUT(eval_node<native_consumer::fixed_list_length>(values<Value>(list_delta<TS<Int>>({1, 2}))), values<Int>(2));
+    CHECK_OUTPUT(eval_node<native_consumer::fixed_list_is_empty>(values<Value>(list_delta<TS<Int>>({1, 2}))),
+                 values<Bool>(false));
+    CHECK_OUTPUT((eval_node<native_consumer::dynamic_list_length>(
+                     values<Value>(dynamic_list_delta<TS<Int>>({{0, 1}}), dynamic_list_delta<TS<Int>>({{1, 2}, {2, 3}}),
+                                                               dynamic_list_delta<TS<Int>>({}, {2})))),
+                 values<Int>(1, 3, 2));
+    CHECK_OUTPUT((eval_node<native_consumer::dynamic_list_is_empty>(
+                     values<Value>(dynamic_list_delta<TS<Int>>({{0, 1}}), dynamic_list_delta<TS<Int>>({}, {0})))),
+                 values<Bool>(false, true));
+    CHECK_OUTPUT((eval_node<native_consumer::set_length>(
+                     values<Value>(set_delta<Int>({1, 2}, {}), set_delta<Int>({}, {1})))),
+                 values<Int>(2, 1));
+    CHECK_OUTPUT((eval_node<native_consumer::map_length>(
+                     values<Value>(dict_delta<Int, TS<Float>>({{1, 1.0}, {2, 2.0}}),
+                                                           dict_delta<Int, TS<Float>>({}, {1})))),
+                 values<Int>(2, 1));
+    CHECK_OUTPUT((eval_node<native_consumer::map_is_empty>(
+                     values<Value>(dict_delta<Int, TS<Float>>({{1, 1.0}}), dict_delta<Int, TS<Float>>({}, {1})))),
+                 values<Bool>(false, true));
+    CHECK_OUTPUT((eval_node<native_consumer::set_is_empty>(
+                     values<Value>(set_delta<Int>({1}, {}), set_delta<Int>({}, {1})))),
+                 values<Bool>(false, true));
+}
+
+TEST_CASE("the HGL core native library reads the live rolling-window view", "[codegen][runtime][native][stdlib]") {
+    CHECK_OUTPUT(eval_node<native_consumer::window_length>(values<Int>(1, 2, 3, 4)), values<Int>(1, 2, 3, 3));
+    CHECK_OUTPUT(eval_node<native_consumer::window_is_empty>(values<Int>(1, 2)), values<Bool>(false, false));
+}


### PR DESCRIPTION
## Summary

- compile a real C++-backed `hgraph.native` HGL module with `len` and `is_empty` overloads for strings, fixed and unbounded lists, sets, maps, and tick-count rolling windows
- declare the exact owning collection-view headers through the module-level `cpp include` surface from #791, avoiding reliance on incidental generated umbrella includes
- expose the generated library as `hgl::core_native`, install its archive/header/descriptor/HGL source, and restore imported descriptor metadata for downstream HGL compilation
- add a package-backed HGL consumer example and runtime coverage against the actual hgraph input views

## Current boundaries

- duration-based rolling windows remain excluded because descriptor ABI v1 only represents integral const extents
- bundle/nominal-struct and reference views remain excluded until the native input-view ABI accepts them
- this is the low-level native substrate; it does not claim that graph/node implementations have already migrated into HGL

## Validation

- rebased onto updated #791 without unresolved conflicts
- generated `hgraph.native` header contains the four explicitly declared collection-view includes and compiles with repository warnings enabled
- focused generated core-native runtime tests: 12 assertions in 2 test cases passed
- #791 acceptance gates: 1793 native tests passed; 3288 Python 3.14 compatibility tests passed, 10 skipped
- complete documentation doctest build on the rebased stack: 67 passed
- `git diff --check`

## Stack

Depends on #791.
The runtime-spec / HGL standard-library prototype in #785 is rebased onto this PR and consumes the real module.
