### PR TITLE
feat(hgl): distinguish collection elements from values

### DIFF
--- a/language/docs/design/iteration.md
+++ b/language/docs/design/iteration.md
@@ -185,7 +185,8 @@ the shared `offset` connection. Lexical capture analysis preserves temporal
 input types and REF access boundaries, as with generated conditional branches.
 Here the body is outputless, so the lowering uses a sink map. The runnable
 [dynamic-collection-iteration.hgl](../../examples/dynamic-collection-iteration.hgl)
-example covers both `values` and `items` over maps and unbounded lists.
+example covers `values`/`items` over maps and `elements`/`items` over
+unbounded lists.
 
 The current compiler accepts temporal captures such as `offset`. Capturing a
 `const` configuration value in a dynamic child is still unsupported: the
@@ -219,7 +220,7 @@ the following records a candidate shape that is initially unsupported:
 ```hgl
 fn total(samples: map<str, f64>, factor: f64) -> f64 {
     var result: f64 = 0.0
-    for value in values(samples) {
+    for value in elements(samples) {
         result = result + value * factor
     }
     return result
@@ -297,14 +298,15 @@ policies is introduced here.
 
 ## Implementation status
 
-The classifier and typed HIR keep `for`, `keys`, `values`, and `items`
-phase-neutral. In a composition function, both direct wiring and generated C++
-implement `values(fixed_list)` and `items(fixed_list)` by statically expanding
-the body in index order. `items` supplies an `i64` wiring-time index and a child
-time-series connection.
+The classifier and typed HIR keep `for`, `keys`, `values`, `elements`, and
+`items` phase-neutral. In a composition function, both direct wiring and
+generated C++ implement `elements(fixed_list)` and `items(fixed_list)` by
+statically expanding the body in index order. `items` supplies an `i64`
+wiring-time index and a child time-series connection.
 
-For maps and unbounded lists, both backends lower independent `values` and
-`items` bodies to hgraph's outputless native `map_` path. The child signature
+For maps and unbounded lists, both backends lower independent map
+`values`/`items` bodies and list `elements`/`items` bodies to hgraph's
+outputless native `map_` path. The child signature
 uses the native `key` or `ndx` convention for `items`; temporal captures are
 explicit pass-through broadcast inputs, including captured maps and lists. The
 shared HGraph-IR `TraversalPlan` rejects

--- a/language/docs/design/iteration.md
+++ b/language/docs/design/iteration.md
@@ -220,7 +220,7 @@ the following records a candidate shape that is initially unsupported:
 ```hgl
 fn total(samples: map<str, f64>, factor: f64) -> f64 {
     var result: f64 = 0.0
-    for value in elements(samples) {
+    for value in values(samples) {
         result = result + value * factor
     }
     return result

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -560,11 +560,11 @@ any of these constructs makes the complete body a runtime function:
 - an `inject` declaration;
 - a `start`, `when`, or `stop` block.
 
-Under the agreed [iteration model](iteration.md), `for`, `keys`, `values`, and
-`items` follow the containing phase and do not themselves force runtime
+Under the agreed [iteration model](iteration.md), `for`, `keys`, `values`,
+`elements`, and `items` follow the containing phase and do not themselves force runtime
 classification. The classifier and typed HIR implement this rule; backend
-support reaches fixed temporal-list traversal and independent `values` and
-`items` bodies over dynamic maps and unbounded lists.
+support reaches fixed temporal-list traversal and independent map/list bodies
+over dynamic maps and unbounded lists.
 
 Mixing wiring-only and runtime-only constructs is an error. Classification is
 based on the resolved source body, not on the implementation kind selected for
@@ -762,9 +762,10 @@ iteration over a supported wiring-time iterable visits scalar values, and
 iteration over a fixed temporal
 structure visits child connections. The calls do not themselves make a
 function a runtime node. Dynamic graph loops initially admit independent bodies
-lowered through per-key or per-index mapping. The compiler currently expands
-`values` and `items` over fixed temporal lists at wiring time and lowers
-independent bodies over maps and unbounded lists through native sink mapping.
+lowered through per-key or per-index mapping. The compiler expands `elements`
+and `items` over fixed temporal lists at wiring time and lowers independent
+`values` bodies over maps and `elements` bodies over unbounded lists through
+native sink mapping.
 Temporal captures are explicit child inputs; scalar captures remain pending.
 Loop-carried reductions are deferred, with unordered map reduction and linear
 list reduction documented as future options. See
@@ -775,8 +776,7 @@ the earlier no-`elements` design. `values` remains the value-only spelling for
 TSB and TSD. `items` yields `(field, value)` for TSB, `(key, value)` for TSD,
 and `(i64, value)` for TSL. Among these collections, `keys` applies only to TSB
 and TSD. Lists preserve index order; sets do not promise a sorted or insertion
-order. The compiler still uses `values` for lists and sets; `elements` support
-and the compatibility status of that older spelling remain separate work.
+order. `values` and `elements` are deliberately distinct rather than aliases.
 
 Every traversal accepts an optional predicate:
 
@@ -901,10 +901,9 @@ exists, and a backend description is not a substitute for one.
   every temporal parameter and `"const"` for a `const` one, so the label
   collides with the `signal` type. A rename is a format v2 decision with
   reader compatibility.
-- **`elements` and `values`.** List and set traversal is implemented under
-  `values`; `elements` is agreed but unknown to the compiler. Whether
-  `values` remains an alias after `elements` lands is undecided
-  ([Iteration](iteration.md)).
+- **`elements` and `values`.** `elements` traverses lists and sets; `values`
+  projects values from keyed or named structures. They are distinct operations,
+  not compatibility aliases ([Iteration](iteration.md)).
 - **Type-keyword callees.** `str(...)` and `Mode(...)` need a grammar rule for
   a type keyword or type name in callee position; today `str` is not an
   expression start and `Mode(...)` is an ordinary call to an unknown name.

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -183,9 +183,10 @@ planning is implemented.
 - [x] preserve explicit reference schemas and reference-transparent
   compatibility through HIR, hgraph IR, and native type materialization.
 - [x] classify traversal by its containing phase and directly expand
-  independent `values` and `items` bodies over fixed temporal lists.
-- [x] lower independent `values` and `items` bodies over maps and unbounded
-  lists to native sink child graphs with explicit temporal captures.
+  independent `elements` and `items` bodies over fixed temporal lists.
+- [x] lower independent `values`/`items` bodies over maps and
+  `elements`/`items` bodies over unbounded lists to native sink child graphs
+  with explicit temporal captures.
 - [x] retain explicit generic implementation materializations and their
   concrete/retained substitutions through HIR and hgraph IR.
 
@@ -332,9 +333,8 @@ today (#767, "Readiness").
 | Typed `const` generic struct metadata (`Vector<T, const size>`) | blocked | hgraph nominal Bundle `generic_arguments` carry type arguments only; both backends report "const generic struct arguments require typed constant Bundle metadata in hgraph". |
 | `const` parameters, `const` generics, `--set` | implemented | |
 | `let`, `var`, typed uninitialized `var`, definite assignment | implemented | An assignment cannot change a `var`'s type; a runtime uninitialized local must be scalar. |
-| Graph-phase `for`: `values` and `items` over fixed lists, independent bodies over maps and unbounded lists | partial | Both backends; `for` is phase-neutral. Graph-phase `keys`, predicates, scalar and `const` captures, sets, bundles, reductions, loop results, escaping assignments, and `return` fail closed; `for` in a `test` body is a `phase` diagnostic; dynamic-body tests are structure-only (#767 item 4). |
-| Runtime `for`, `keys`/`values`/`items` with predicates, `key_set` | partial | Generated C++ only: the direct backend never evaluates a runtime body, so the scripted path is the C++ backend plus a loaded image. `key_set` inside a runtime body is rejected; unbounded-list added/removed views need a public hgraph view API. |
-| `elements(list_or_set)` | provisional | Agreed 2026-09-06; `elements` is `name: unknown name 'elements'` today; retention of the `values` spelling is undecided (#767 item 6). |
+| Graph-phase `for`: `elements`/`items` over fixed lists, independent bodies over maps and unbounded lists | partial | Both backends; maps use `values`/`items` and lists use `elements`/`items`. `for` is phase-neutral. Graph-phase `keys`, predicates, scalar and `const` captures, sets, bundles, reductions, loop results, escaping assignments, and `return` fail closed; `for` in a `test` body is a `phase` diagnostic; dynamic-body tests are structure-only (#767 item 4). |
+| Runtime `for`, `keys`/`values`/`elements`/`items` with predicates, `key_set` | partial | Generated C++ only: the direct backend never evaluates a runtime body, so the scripted path is the C++ backend plus a loaded image. `values` is the keyed/named value projection and `elements` is list/set traversal; they are not aliases. `key_set` inside a runtime body is rejected; unbounded-list added/removed views need a public hgraph view API. |
 | Runtime nodes | partial | Implemented, in generated C++ and scripted on Unix: activation from `modified`, variadic `valid`, ordered `when` handlers, `return`, scalar recordable `state` with an initializer, `inject out` (whole, prior, and keyed writes), `inject logger` (`info` only), one `start` and one `stop` block, passive sampled inputs, scalar/collection/rolling/ref/`signal` inputs. Fail closed: calls to other HGL functions, non-scalar state, zero-input sources, `key_set`, temporal inputs or `out` in lifecycle blocks, a runtime `if` used as a value. Declaration placement (`state`/`inject` before handlers, one `start` and `stop`, no nested `when`, no `out` or `return` in a lifecycle block) and the approved injectable list are `hgl check` diagnostics (PR #780); validity-dominance ordering is still checked by `emit-cpp` only. |
 | `inject clock`, `inject scheduler` | provisional | Documented in the user guide; neither word occurs in `src/`; `emit-cpp` reports "injectable 'clock' is not supported by emit-cpp yet". |
 | Scalar (wiring-time) `if`, including `else if` | implemented | |
@@ -450,7 +450,7 @@ Deliverables:
   `when` syntax, including mixed-form diagnostics;
 - grouped inject declarations, ordered activation blocks, state aggregation,
   and output access grammar;
-- `key_set`, `keys`, `values`, and `items`, including built-in, named, and
+- `key_set`, `keys`, `values`, `elements`, and `items`, including built-in, named, and
   inline traversal predicates;
 - name resolution and kind-specific phase checking;
 - `test` declarations, `assert`, `eval` with dense harness sequences and the

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -150,10 +150,10 @@ surface.
 - Source does not spell hgraph `TS`, `TSB`, `TSL`, `TSS`, `TSD`, or `TSW`
   wrappers.
 - Source does not expose endpoint `.value`, `.valid`, or `.modified` members.
-- Runtime collection traversal uses `keys`, `values`, and `items` with optional
-  built-in, named, or inline predicates; its borrowed iterators cannot escape an
-  evaluation. The agreed list/set spelling is now `elements`, awaiting compiler
-  migration from the currently implemented `values` spelling.
+- Runtime collection traversal uses `keys`, `values`, `elements`, and `items`
+  with optional built-in, named, or inline predicates; its borrowed iterators
+  cannot escape an evaluation. `values` projects from keyed or named
+  collections, while `elements` traverses lists and sets.
 - Selective imports establish the unqualified operator names an `impl fn` may
   bind to; module aliases provide qualified names such as `mm::my_op` without
   binding implementations.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -414,7 +414,7 @@ The classifier consumes resolved syntax and assigns `CompositionFn` or
 - no runtime-only construct produces `CompositionFn`;
 - the presence of `state`, `inject`, `start`, `when`, or `stop` anywhere in
   the body produces `RuntimeFn` for the complete body;
-- `for`, `keys`, `values`, and `items` are phase-neutral: they follow the
+- `for`, `keys`, `values`, `elements`, and `items` are phase-neutral: they follow the
   containing function's phase and never select it
   ([Iteration](../design/iteration.md));
 - a function that mixes phases is rejected. Invalid declaration order,
@@ -1042,7 +1042,7 @@ shape. A runtime call obtains the current `TSDDataView::key_set()` borrowed
 view. Both paths use public hgraph APIs.
 
 For runtime collection-value operands, the typed HIR represents `keys`,
-`values`, and `items` as borrowed
+`values`, `elements`, and `items` as borrowed
 `RuntimeIterator` values carrying:
 
 - the source collection and concrete hgraph shape;
@@ -1054,16 +1054,12 @@ The iterator type is compiler-internal. It is valid only as the source of a
 `for` loop and has no scalar schema, time-series schema, state representation,
 or callable ABI.
 
-The agreed source spelling for list/set element traversal is now `elements`,
-superseding the earlier no-`elements` rule. The compiler still recognizes
-`values` for those structures; migration must preserve the existing iteration
-plan, child/membership provenance, predicates, and phase restrictions. Native
-method names need not change to match HGL spelling. For example, the target
-node-time mappings are `elements(tsl)` to `tsl.values()` and
-`elements(tss, added)` to the typed TSS input's `added()` range. See the
-[paired HGL/C++ examples](../design/iteration.md). Whether source `values`
-remains a list/set compatibility alias is unresolved. Map/bundle traversal is
-unchanged, and graph-phase set traversal remains unsupported.
+List and set traversal uses `elements`, while `values` is reserved for the
+value projection of keyed or named structures. They are not aliases. Native
+method names need not match HGL spelling: `elements(tsl)` lowers to
+`tsl.values()` and `elements(tss, added)` to the typed TSS input's `added()`
+range. See the [paired HGL/C++ examples](../design/iteration.md). Map/bundle
+traversal is unchanged, and graph-phase set traversal remains unsupported.
 
 Recognized metadata predicates select the matching public native range
 directly. This includes the delta predicates and other filters such as
@@ -1073,8 +1069,9 @@ directly. This includes the delta predicates and other filters such as
 items(tsd, modified)  -> tsd.modified_items()
 keys(tsd, removed)    -> tsd.removed_keys()
 values(tsd, added)    -> tsd.added_values()
-values(tss, added)    -> tss.added_values()
+elements(tss, added)  -> tss.added()
 items(tsl, modified)  -> tsl.modified_items()
+elements(tsl, modified) -> tsl.modified_values()
 values(tsd, valid)    -> tsd.valid_values()
 ```
 
@@ -1624,7 +1621,7 @@ expression is read from the syntax tree.
   invalid fields before running an explicit state-and-configuration start
   block. `inject logger` lowers `logger.info(message)` to `LoggerView::log`.
   Runtime `map`, `set`, and `list` parameters retain their typed selectors;
-  `keys`, `values`, and `items` become ordinary C++ range loops over current,
+  `keys`, `values`, `elements`, and `items` become ordinary C++ range loops over current,
   `modified`, `added`, or `removed` views. A concise iterator predicate is
   inlined as a readable loop guard. Keyed `out[key] = value` uses the typed TSD
   output selector and accumulates child writes in the cycle's delta.

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -5,8 +5,8 @@ phase-neutral iteration rule below are implemented through the parser, typed
 HIR, and both backends for the forms the
 [roadmap status matrix](../design/roadmap.md#feature-status-matrix-2026-09-07)
 marks implemented; runtime-function semantics are partial; the `enum`,
-`switch`, `str(value)`, and `elements` extensions are provisional and not
-parsed. The EBNF is descriptive: where it admits a form the compiler rejects,
+`switch`, and `str(value)` extensions are provisional and not parsed. The EBNF
+is descriptive: where it admits a form the compiler rejects,
 the surrounding prose names the boundary.
 
 This chapter specifies the syntax agreed so far and records the rule for
@@ -105,11 +105,12 @@ no ambiguity to resolve by making them contextual; they are withheld from
 parameter and variable names deliberately to keep a runtime body readable.
 
 No other word is reserved. In particular `switch`, `case`, `default`, `enum`,
-and `elements` lex as ordinary identifiers today, so the agreed
-[switch](../design/switch.md), [enum](../design/type-extensions.md#enum-types),
-and [`elements`](../design/iteration.md) extensions are provisional: a program
-using them gets generic parse or name diagnostics, not one that names the
-construct. The agreed `str(value)` extension uses the reserved `str` token in
+and `elements` lex as ordinary identifiers today. `elements` is a checked
+prelude intrinsic, like `values`, and does not need to be reserved. The agreed
+[switch](../design/switch.md) and
+[enum](../design/type-extensions.md#enum-types) extensions remain provisional:
+a program using them gets generic parse or name diagnostics, not one that names
+the construct. The agreed `str(value)` extension uses the reserved `str` token in
 an expression position as a conversion call; it remains a type name in an
 annotation and does not become an unrestricted identifier or a general
 type-constructor call rule. It is provisional too: `str` is not an expression
@@ -1010,7 +1011,8 @@ An unqualified name resolves, innermost first, to:
    (a `test` is not a value and is a `name` diagnostic in an expression);
 4. a selectively imported operator;
 5. a prelude intrinsic: `valid`, `modified`, `all_valid`, `last_modified`,
-   `delta`, `key_set`, `keys`, `values`, `items`, `added`, `removed`.
+   `delta`, `key_set`, `keys`, `values`, `elements`, `items`, `added`,
+   `removed`.
 
 A module alias is only a qualifier: `alias::name` resolves `name` in that
 module's public interface and nothing else. Declaring a name twice in one
@@ -1563,8 +1565,7 @@ TSD key set.
 
 In runtime evaluation, `keys`, `values`, `elements`, and `items` produce
 evaluation-local iterator types. They accept the collection followed by an
-optional predicate. This is the agreed target grammar; `elements` for lists
-and sets is not yet implemented:
+optional predicate:
 
 ```ebnf
 collection_iterator
@@ -1580,11 +1581,12 @@ interpretation: the iterator must be consumed directly by `for`; it is neither
 a canonical value nor a temporal port and cannot escape the current
 evaluation. In graph composition, a supported wiring-time iterable provides
 scalar values and a fixed temporal structure provides child connections. The
-current compiler implements `values` and `items` over a fixed TSL by statically
+compiler implements `elements` and `items` over a fixed TSL by statically
 unrolling the body and projecting children through hgraph's public
-`tsl_element` contract. Independent `values` and `items` bodies over a TSD or
-unbounded TSL lower through hgraph's per-key/per-index sink mapping in both
-backends; temporal captures become explicit broadcast child inputs. The
+`tsl_element` contract. Independent `values`/`items` bodies over a TSD and
+`elements`/`items` bodies over an unbounded TSL lower through hgraph's
+per-key/per-index sink mapping in both backends; temporal captures become
+explicit broadcast child inputs. The
 current subset rejects predicates, graph-phase `keys`, scalar captures,
 assignments to enclosing variables, and loop returns. Unordered map reduction
 and ordered, linear list reduction are deferred options, not initial lowering
@@ -1606,11 +1608,10 @@ Traversal and built-in delta-predicate support is:
 | `list<T>` (unbounded TSL) | `elements`, `items` | `added`, `modified`, `removed` |
 | TSS | `elements` | `added`, `removed` |
 
-The table uses the agreed list/set spelling, superseding the earlier absence
-of `elements`. Current compiler support and executable examples still use
-`values` for lists and sets. Retaining that spelling as a compatibility alias
-has not been decided. Do not infer `elements` support for maps or bundles, or
-new graph-phase support for sets, from this extension.
+`values` and `elements` are not aliases: the former is a projection from keyed
+or named collections, while the latter traverses list positions or set
+membership. Do not infer `elements` support for maps or bundles, or new
+graph-phase support for sets, from this distinction.
 
 `items` yields two bindings. TSB yields `str` field names and the corresponding
 field bindings; TSD yields its canonical key type and value-child bindings;
@@ -1663,7 +1664,7 @@ these rules:
    the body, including inside a `for` body or an `if` branch, makes the
    complete function a `RuntimeFn`, even when nested syntax is later rejected
    by phase checking.
-3. `for`, `keys`, `values`, and `items` are phase-neutral: iteration follows
+3. `for`, `keys`, `values`, `elements`, and `items` are phase-neutral: iteration follows
    the phase of its containing function and never selects it. A body whose
    only special statement is `for` is therefore a composition function, as in
    `examples/fixed-list-iteration.hgl` and

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -347,12 +347,12 @@ Runtime semantic tests additionally cover:
 Collection-view semantic tests additionally cover:
 
 - phase-specific `key_set(tsd)` results in composition and runtime functions;
-- `keys`, `values`, and `items` result arity and types for TSB, TSD, TSL, and
-  TSS, including `i64` TSL indices;
-- the agreed `elements` traversal for lists and sets, with one yielded binding,
-  list index order, set membership/delta semantics, and unchanged phase/REF
-  restrictions (pending compiler migration; the earlier no-`elements` rule is
-  superseded, and `values` compatibility remains open);
+- `keys`, `values`, `elements`, and `items` result arity and types for their
+  supported TSB, TSD, TSL, and TSS shapes, including `i64` TSL indices;
+- `elements` traversal for lists and sets, with one yielded binding, list index
+  order, set membership/delta semantics, and unchanged phase/REF restrictions;
+- rejection of `values` on lists and sets, so the two projection names never
+  become compatibility aliases;
 - built-in `added`, `modified`, and `removed` predicates for every supported
   structure/traversal pair, plus diagnostics for unsupported pairs;
 - built-in, named, and inline predicates, captures, short-circuit validity,

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -465,8 +465,9 @@ Loop-carried reductions are initially unsupported: unordered map reduction
 and the linear reduction option for ordered lists are documented future
 extensions. In a node, traversal visits the current child views or scalar
 elements. The classifier is phase-neutral and both compiler backends implement
-fixed temporal-list traversal plus independent `values` and `items` bodies over
-dynamic maps and unbounded lists. Dynamic bodies may capture temporal inputs;
+fixed temporal-list traversal plus independent `values`/`items` bodies over
+dynamic maps and `elements`/`items` bodies over unbounded lists. Dynamic bodies
+may capture temporal inputs;
 `const` captures, graph iterator predicates, escaping assignments, and loop
 returns remain unsupported.
 

--- a/language/docs/user-guide/language-tour.md
+++ b/language/docs/user-guide/language-tour.md
@@ -199,10 +199,10 @@ true only when every argument is valid. `valid(value)` tests the endpoint
 itself; use `all_valid(value)` when every child of a structural or collection
 endpoint must also be valid.
 
-The agreed collection traversal surface uses `keys`, `values`, `elements`,
-and `items`. `elements` is the list/set spelling and awaits compiler support.
-An optional built-in, named, or inline predicate filters the traversal without
-changing those base names:
+The collection traversal surface uses `keys`, `values`, `elements`, and
+`items`. `values` projects values from keyed or named collections;
+`elements` traverses lists and sets. An optional built-in, named, or inline
+predicate filters the traversal without changing those base names:
 
 ```hgl
 for key, value in items(book, modified) {
@@ -226,10 +226,9 @@ for symbol in elements(symbols, added) {
 composition and runtime functions and produces the set-shaped key view, while
 `keys`, `values`, `elements`, and `items` yield evaluation-local iterators
 inside nodes. Lists and sets use `elements` for element-only traversal; lists
-also use `items` for `(i64, value)` traversal. This replaces the earlier
-no-`elements` design. Current executable examples still use `values` for lists
-and sets; its possible retention as an alias remains open. Graph traversal
-retains the [phase-specific restrictions](../design/iteration.md).
+also use `items` for `(i64, value)` traversal. `values` is not an alias for
+`elements`. Graph traversal retains the
+[phase-specific restrictions](../design/iteration.md).
 
 An ordinary body such as `maybe_smooth` runs at wiring time and composes
 operators. Runtime-only declarations and blocks instead implement one generated

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -935,15 +935,15 @@ This section describes collection-value operands. Enum-type calls such as
 `elements(Mode)` instead produce the immutable fixed-size scalar lists
 described above; they are not subject to borrowed-iterator escape restrictions.
 
-Status: `elements` is the agreed element-iteration spelling for lists and sets,
-awaiting compiler support. Like `for`, `keys`, `values`, and `items`, it follows
-the containing phase rather than itself forcing a runtime node. The compiler
-currently implements graph-phase `values` and `items` over fixed temporal
-lists by expanding the body once per
+Status: `elements` is the element-iteration spelling for lists and sets. Like
+`for`, `keys`, `values`, and `items`, it follows the containing phase rather
+than itself forcing a runtime node. The compiler implements graph-phase
+`elements` and `items` over fixed temporal lists by expanding the body once per
 child connection; `items` also supplies its wiring-time `i64` index. Scalar
 wiring-time iterables and bundles remain future compiler work. Independent
-`values` and `items` bodies over maps and unbounded lists run as one native
-child graph per key or index, with temporal captures broadcast to every child.
+`values`/`items` bodies over maps and `elements`/`items` bodies over unbounded
+lists run as one native child graph per key or index, with temporal captures
+broadcast to every child.
 Graph-phase predicates, graph-phase `keys`, and `const` captures remain
 unsupported.
 Loop-carried reductions are initially unsupported; future map reductions are
@@ -987,10 +987,9 @@ in node evaluation, with its metadata and REF boundaries intact. Set members
 are scalar values, not independent time-series children.
 
 This supersedes the earlier design that used `values` for lists and sets and
-excluded `elements`. The current compiler and executable examples still use
-`values` for those structures; whether it remains a compatibility alias is
-not yet decided. The examples below use the agreed target spelling, not
-implemented `elements` support. Graph-phase set traversal remains unsupported.
+excluded `elements`. `values` and `elements` are not aliases: `values` projects
+from keyed or named collections, while `elements` traverses a sequence or
+membership collection. Graph-phase set traversal remains unsupported.
 
 Each traversal accepts an optional predicate. The built-in `modified`, `added`,
 and `removed` predicates select the corresponding hgraph delta range:

--- a/language/examples/README.md
+++ b/language/examples/README.md
@@ -27,7 +27,8 @@ has no `test` block, the note below says which unit tests carry its behaviour.
   in `generated_example_tests.cpp`, and the `--dump-hir` /
   `--dump-hgraph-ir` CTest cases read this example.
 - [`collection-views.hgl`](collection-views.hgl) demonstrates dual-phase
-  `key_set`, runtime `keys`/`values`/`items`, built-in and inline predicates,
+  `key_set`, runtime `keys`/`values`/`elements`/`items`, built-in and inline
+  predicates,
   `last_modified`, and mutable lexical `var`. Tests: none in the file; native
   behaviour in `generated_example_tests.cpp`.
 - [`native-functions.hgl`](native-functions.hgl) defines real top-level C++
@@ -55,7 +56,7 @@ has no `test` block, the note below says which unit tests carry its behaviour.
   in the file; routing ticks in `generated_reference_tests.cpp` and, for the
   composition shapes, `../tests/wiring/backend_coverage_tests.cpp`.
 - [`fixed-list-iteration.hgl`](fixed-list-iteration.hgl) demonstrates a
-  graph-phase `for` over a fixed temporal list with `values` and `items`,
+  graph-phase `for` over a fixed temporal list with `elements` and `items`,
   wiring one body per child connection. Tests: none in the file; per-child
   wiring in `generated_iteration_tests.cpp` and
   `../tests/wiring/backend_tests.cpp`.

--- a/language/examples/collection-views.hgl
+++ b/language/examples/collection-views.hgl
@@ -47,11 +47,11 @@ fn audit_membership(symbols: set<str>) {
     inject logger
 
     when modified(symbols) && valid(symbols) {
-        for symbol in values(symbols, added) {
+        for symbol in elements(symbols, added) {
             logger.info(symbol)
         }
 
-        for symbol in values(symbols, removed) {
+        for symbol in elements(symbols, removed) {
             logger.info(symbol)
         }
     }

--- a/language/examples/dynamic-collection-iteration.hgl
+++ b/language/examples/dynamic-collection-iteration.hgl
@@ -18,8 +18,8 @@ export fn observe_items(book: map<str, f64>, offset: f64) {
     }
 }
 
-export fn observe_list_values(samples: list<f64>, offset: f64) {
-    for value in values(samples) {
+export fn observe_list_elements(samples: list<f64>, offset: f64) {
+    for value in elements(samples) {
         null_sink(value + offset)
     }
 }
@@ -33,7 +33,7 @@ export fn observe_list_items(samples: list<f64>, offset: f64) {
 // Collection captures are passed to each child whole; they do not become a
 // second collection over which the child graph is multiplexed.
 export fn observe_list_capture(samples: list<f64>, peers: list<f64>) {
-    for value in values(samples) {
+    for value in elements(samples) {
         null_sink(valid(peers))
     }
 }

--- a/language/examples/fixed-list-iteration.hgl
+++ b/language/examples/fixed-list-iteration.hgl
@@ -6,7 +6,7 @@ module examples.fixed_list_iteration
 use hgraph.std::{null_sink}
 
 export fn observe(samples: list<f64, 3>) {
-    for sample in values(samples) {
+    for sample in elements(samples) {
         null_sink(sample)
     }
 }

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -2767,7 +2767,7 @@ namespace hgl::codegen
                 return wire(name == "key_set" ? "hgraph::stdlib::keys_" : "hgraph::stdlib::last_modified_time", {value.code},
                             range);
             }
-            if (name == "keys" || name == "values" || name == "items") {
+            if (name == "keys" || name == "values" || name == "elements" || name == "items") {
                 if (!frame.runtime) {
                     // The first-pass iterator rules are reported once by the
                     // shared traversal analysis; the iterator only has to exist.
@@ -2817,12 +2817,12 @@ namespace hgl::codegen
                     }
                 }
 
-                std::string method = name;
+                std::string method = name == "elements" ? "values" : name;
                 if (!predicate.empty()) {
-                    if (source.type.kind == HType::Kind::Set && name == "values") {
-                        method = predicate == "added" ? "added" : predicate == "removed" ? "removed" : name;
+                    if (source.type.kind == HType::Kind::Set && name == "elements") {
+                        method = predicate == "added" ? "added" : predicate == "removed" ? "removed" : "values";
                     } else {
-                        method = predicate + "_" + name;
+                        method = predicate + "_" + (name == "elements" ? "values" : name);
                     }
                 }
 
@@ -2841,10 +2841,10 @@ namespace hgl::codegen
                     } else {
                         result.iterator_types = {source.type.children[0], source.type.children[1]};
                     }
-                } else if (source.type.kind == HType::Kind::Set && name == "values") {
+                } else if (source.type.kind == HType::Kind::Set && name == "elements") {
                     result.iterator_types.push_back(source.type.children[0]);
                 } else if (source.type.kind == HType::Kind::List) {
-                    if (name == "values") {
+                    if (name == "elements") {
                         result.iterator_types.push_back(source.type.children[0]);
                     } else {
                         result.iterator_types = {scalar_type(hir::ScalarType::I64), source.type.children[0]};
@@ -3059,7 +3059,7 @@ namespace hgl::codegen
             const Value       iterator            = eval_planned_expr(traversal.iterable, frame);
             if (!iterator.is_iterator()) {
                 fail(Category::Type, iterable_expression.range,
-                     "a graph 'for' loop needs values(...) or items(...) over a temporal map or list");
+                     "a graph 'for' loop needs values(...) over a temporal map, or elements(...) or items(...) over a temporal list");
             }
             if (traversal.bindings.empty() || traversal.bindings.size() > 2U ||
                 traversal.bindings.size() != iterator.iterator_types.size()) {
@@ -3485,7 +3485,7 @@ namespace hgl::codegen
                         const Value       iterator = eval_planned_expr(node.iterable, frame);
                         if (!iterator.is_iterator()) {
                             fail(Category::Type, iterable.range,
-                                 "a runtime 'for' loop needs keys(...), values(...), or items(...)");
+                                 "a runtime 'for' loop needs keys(...), values(...), elements(...), or items(...)");
                         }
                         if (node.bindings.empty() || node.bindings.size() > 2U) {
                             backend(statement.range, "hgraph IR traversal needs one or two loop bindings");
@@ -3535,7 +3535,9 @@ namespace hgl::codegen
                         const bool         list = iterator.type.kind == HType::Kind::List;
                         std::vector<Value> loop_values;
                         loop_values.push_back(bind_value(first_raw, iterator.iterator_types[0],
-                                                         !pair && (map || list) && iterator.name == "values", pair && list,
+                                                         !pair && ((map && iterator.name == "values") ||
+                                                                   (list && iterator.name == "elements")),
+                                                         pair && list,
                                                          map && (pair || iterator.name == "keys")));
                         if (pair) { loop_values.push_back(bind_value(second_raw, iterator.iterator_types[1], true, false, false)); }
                         for (std::size_t index = 0; index < node.bindings.size(); ++index) {

--- a/language/src/hgraph_ir/control_flow.cpp
+++ b/language/src/hgraph_ir/control_flow.cpp
@@ -556,14 +556,15 @@ namespace hgl::hgraph_ir
         if (plan.returns) { issue(range, "return from a graph 'for' body is not defined yet"); }
 
         // The iterator forms the first pass defines for a graph-phase loop:
-        // one-argument values(...) or items(...) over a temporal map or list.
+        // one-argument values(...) over a temporal map, or elements(...) or
+        // items(...) over a temporal list.
         // Runtime loops (a traversal inside node evaluation) are unrestricted.
         const Value *iterable = value_at(module, traversal.iterable);
         if (iterable == nullptr || iterable->phase != ir::hir::Phase::Wiring) { return plan; }
         bool dynamic = true;
         if (const auto *call = std::get_if<Call>(&iterable->node)) {
             const std::string_view name = intrinsic_name(module, call->callee);
-            if (name == "keys" || name == "values" || name == "items") {
+            if (name == "keys" || name == "values" || name == "elements" || name == "items") {
                 if (call->arguments.size() != 1U) {
                     issue(iterable->range, "graph-phase iterator predicates are not defined yet");
                 } else {
@@ -823,7 +824,8 @@ namespace hgl::hgraph_ir
 
             [[nodiscard]] static bool composition_intrinsic(std::string_view name) noexcept {
                 return name == "valid" || name == "modified" || name == "all_valid" || name == "last_modified" ||
-                       name == "last_modified_time" || name == "key_set" || name == "keys" || name == "values" || name == "items";
+                       name == "last_modified_time" || name == "key_set" || name == "keys" || name == "values" ||
+                       name == "elements" || name == "items";
             }
 
             const Module                     &module_;

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -2301,22 +2301,33 @@ namespace hgl::ir
                     }
                 } else if (name == "keys" || name == "values" || name == "elements" || name == "items") {
                     Expr               &collection = check_expr(args.empty() ? ExprId{} : args.front());
-                    std::vector<TypeId> items      = collection_items(collection.type);
-                    if (items.empty()) { type_error(collection.range, "'" + name + "' takes a collection"); }
-                    const TypeKind kind = type(unwrap_atomic(collection.type)).kind;
-                    if (name == "keys") {
-                        if (kind != TypeKind::Map) { type_error(collection.range, "'keys' takes a map"); }
-                        items.resize(1U);
-                    } else if (name == "values") {
-                        if (kind != TypeKind::Map) { type_error(collection.range, "'values' takes a map"); }
-                        items.erase(items.begin());
-                    } else if (name == "elements") {
-                        if (kind != TypeKind::List && kind != TypeKind::Set) {
-                            type_error(collection.range, "'elements' takes a list or set");
+                    const TypeId        collection_type = unwrap_atomic(collection.type);
+                    std::vector<TypeId> items           = collection_items(collection_type);
+                    if (!collection_type.valid() || items.empty()) {
+                        type_error(collection.range, "'" + name + "' takes a collection");
+                    } else {
+                        const TypeKind kind = type(collection_type).kind;
+                        if (name == "keys") {
+                            if (kind != TypeKind::Map) {
+                                type_error(collection.range, "'keys' takes a map");
+                            } else {
+                                items.resize(1U);
+                            }
+                        } else if (name == "values") {
+                            if (kind != TypeKind::Map) {
+                                type_error(collection.range, "'values' takes a map");
+                            } else {
+                                items.erase(items.begin());
+                            }
+                        } else if (name == "elements") {
+                            if (kind != TypeKind::List && kind != TypeKind::Set) {
+                                type_error(collection.range, "'elements' takes a list or set");
+                            } else if (kind == TypeKind::List) {
+                                items.erase(items.begin());
+                            }
+                        } else if (kind == TypeKind::Set) {
+                            type_error(collection.range, "'items' takes a map or list");
                         }
-                        if (kind == TypeKind::List) { items.erase(items.begin()); }
-                    } else if (kind == TypeKind::Set) {
-                        type_error(collection.range, "'items' takes a map or list");
                     }
                     if (args.size() > 1U) {
                         Expr &predicate = module_.exprs[args[1].value];

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -2299,12 +2299,25 @@ namespace hgl::ir
                     } else {
                         type_error(value.range, "key_set takes a map");
                     }
-                } else if (name == "keys" || name == "values" || name == "items") {
+                } else if (name == "keys" || name == "values" || name == "elements" || name == "items") {
                     Expr               &collection = check_expr(args.empty() ? ExprId{} : args.front());
                     std::vector<TypeId> items      = collection_items(collection.type);
                     if (items.empty()) { type_error(collection.range, "'" + name + "' takes a collection"); }
-                    if (name == "keys" && !items.empty()) { items.resize(1U); }
-                    if (name == "values" && items.size() == 2U) { items.erase(items.begin()); }
+                    const TypeKind kind = type(unwrap_atomic(collection.type)).kind;
+                    if (name == "keys") {
+                        if (kind != TypeKind::Map) { type_error(collection.range, "'keys' takes a map"); }
+                        items.resize(1U);
+                    } else if (name == "values") {
+                        if (kind != TypeKind::Map) { type_error(collection.range, "'values' takes a map"); }
+                        items.erase(items.begin());
+                    } else if (name == "elements") {
+                        if (kind != TypeKind::List && kind != TypeKind::Set) {
+                            type_error(collection.range, "'elements' takes a list or set");
+                        }
+                        if (kind == TypeKind::List) { items.erase(items.begin()); }
+                    } else if (kind == TypeKind::Set) {
+                        type_error(collection.range, "'items' takes a map or list");
+                    }
                     if (args.size() > 1U) {
                         Expr &predicate = module_.exprs[args[1].value];
                         if (std::holds_alternative<Lambda>(predicate.node)) {

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -27,7 +27,8 @@ namespace hgl::semantics
         constexpr std::string_view kernel_analytics = "hgraph.analytics";
 
         constexpr std::string_view intrinsics[] = {"valid", "modified", "all_valid", "last_modified", "delta",  "key_set",
-                                                   "keys",  "values",   "items",     "added",         "removed"};
+                                                   "keys",  "values",   "elements",  "items",         "added",
+                                                   "removed"};
 
         [[nodiscard]] std::string join_path(const std::vector<ast::Name> &path) {
             std::string result;

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -1293,7 +1293,7 @@ namespace hgl::wiring
                 }
                 return wire(name == "key_set" ? "keys_" : "last_modified_time", {time_series_arg(item.port)}, range);
             }
-            if (name == "keys" || name == "values" || name == "items") {
+            if (name == "keys" || name == "values" || name == "elements" || name == "items") {
                 // The first-pass iterator rules (one argument, values or
                 // items, a temporal map or list) are reported once by the
                 // shared traversal analysis; the iterator only has to exist.
@@ -2018,7 +2018,7 @@ namespace hgl::wiring
             Slot iterator = eval_value(traversal.iterable, frame);
             if (iterator.kind != Slot::Kind::Iterator || iterator.port.schema == nullptr) {
                 fail(Category::Type, value(traversal.iterable).range,
-                     "a graph 'for' loop needs values(...) or items(...) over a temporal map or list");
+                     "a graph 'for' loop needs values(...) over a temporal map, or elements(...) or items(...) over a temporal list");
             }
             const bool items = iterator.name == "items";
             if (traversal.bindings.size() != (items ? 2U : 1U)) {

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -141,9 +141,10 @@ fixtures, not passing compiler examples or a blanket Python formatting promise.
 `elements` spelling for list and set traversal, with paired HGL/C++ examples
 in the [iteration design](../docs/design/iteration.md). It covers fixed-list
 graph wiring and a node counting added set members. This supersedes the
-earlier no-`elements` rule but remains outside the executable corpus; the
-compiler examples below still use `values`. Compatibility for that older
-spelling remains undecided. Existing graph-loop restrictions are unchanged.
+earlier no-`elements` rule. The compiler now keeps `values` for keyed/named
+value projections and uses `elements` for list/set membership traversal; the
+two spellings are deliberately not aliases. Existing graph-loop restrictions
+are unchanged.
 
 Fixed temporal-list traversal has graduated from this design-only corpus into
 the executable compiler example
@@ -201,7 +202,8 @@ when the check fails and its output contains every expectation.
 | `invalid/conditional-unassigned-result.hgl` | definite assignment | registered as `hgraph_language_stdlib_invalid_conditional-unassigned-result`; the expectation is the checker's wording |
 | `invalid/switch-temporal-case.hgl`, `invalid/enum-switch-*.hgl` | `switch` | not registered: `switch` is not parsed yet |
 | `invalid/enum-*.hgl` | `enum` | not registered: `enum` is not parsed yet |
-| `switch-scenarios.hgl`, `enum-*.hgl`, `string-conversion.hgl`, `elements-iteration.hgl` | `switch`, `enum`, `str(value)`, `elements` | valid design fixtures; not checked until their construct parses |
+| `switch-scenarios.hgl`, `enum-*.hgl`, `string-conversion.hgl` | `switch`, `enum`, `str(value)` | valid design fixtures; not checked until their construct parses |
+| `elements-iteration.hgl` | `elements` | design fixture; spelling is implemented and covered by executable compiler examples |
 
 An unregistered fixture's `// expect:` substring records the agreed rule in
 the fixture's own words; it is aligned with the checker's diagnostic and the

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -1726,7 +1726,7 @@ module checks.fixed_iteration
 use hgraph.std::{null_sink}
 
 export fn observe(samples: list<f64, 3>) {
-    for sample in values(samples) {
+    for sample in elements(samples) {
         null_sink(sample)
     }
 }
@@ -1752,7 +1752,7 @@ export fn observe(book: map<str, f64>, samples: list<f64>, peers: list<f64>, off
     for key, value in items(book) {
         null_sink(value + offset)
     }
-    for value in values(samples) {
+    for value in elements(samples) {
         null_sink(value + offset)
         null_sink(valid(peers))
     }
@@ -1775,7 +1775,7 @@ export fn observe(book: map<str, f64>, samples: list<f64>, peers: list<f64>, off
 module checks.predicate_iteration
 use hgraph.std::{null_sink}
 export fn observe(samples: list<f64, 3>) {
-    for sample in values(samples, modified) { null_sink(sample) }
+    for sample in elements(samples, modified) { null_sink(sample) }
 }
 )"};
         CHECK_FALSE(predicate.emit());
@@ -1787,7 +1787,7 @@ export fn observe(samples: list<f64, 3>) {
 module checks.scalar_capture
 use hgraph.std::{null_sink}
 export fn observe(samples: list<f64>, const offset: f64) {
-    for sample in values(samples) { null_sink(sample + offset) }
+    for sample in elements(samples) { null_sink(sample + offset) }
 }
 )"};
         CHECK_FALSE(scalar_capture.emit());
@@ -1801,7 +1801,7 @@ module checks.escaping_iteration
 use hgraph.std::{null_sink}
 export fn observe(samples: list<f64, 3>) {
     var selected: f64
-    for sample in values(samples) { selected = sample }
+    for sample in elements(samples) { selected = sample }
 }
 )"};
         CHECK_FALSE(escaping.emit());

--- a/language/tests/codegen/generated_iteration_tests.cpp
+++ b/language/tests/codegen/generated_iteration_tests.cpp
@@ -56,7 +56,7 @@ namespace
         if (with_items) {
             dynamic_iteration::observe_list_items::compose(w, samples, offset);
         } else {
-            dynamic_iteration::observe_list_values::compose(w, samples, offset);
+            dynamic_iteration::observe_list_elements::compose(w, samples, offset);
         }
         return std::move(w).finish();
     }

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -518,7 +518,7 @@ module checks.traversal_escape
 
 fn examine(samples: list<f64, 3>) -> f64 {
     var result: f64 = 0.0
-    for sample in values(samples) {
+    for sample in elements(samples) {
         let local = sample
         result = local
         return local
@@ -587,7 +587,7 @@ fn examine(book: map<str, f64>, samples: list<f64, 3>, const scale: f64) -> f64 
     for key in keys(book) {
         let seen = key
     }
-    for sample in values(samples, modified) {
+    for sample in elements(samples, modified) {
         let seen = sample
     }
     return result
@@ -628,7 +628,7 @@ module checks.fixed_traversal_rules
 use hgraph.std::{null_sink}
 
 fn examine(samples: list<f64, 3>, const scale: f64) {
-    for sample in values(samples) {
+    for sample in elements(samples) {
         null_sink(sample * scale)
     }
 }

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -1590,6 +1590,19 @@ fn observe(samples: list<f64, 3>) {
 }
 
 TEST_CASE("typed HIR keeps values and elements as distinct projections", "[ir][typed][iteration]") {
+    SECTION("a missing collection is diagnosed without dereferencing an invalid type") {
+        Lowered lowered{R"(
+module checks.missing_collection
+
+fn observe() {
+    for value in elements() { value }
+}
+)"};
+        require_clean(lowered);
+        CHECK_FALSE(complete(lowered));
+        CHECK(lowered.diagnostics.render(lowered.file).find("'elements' takes a collection") != std::string::npos);
+    }
+
     SECTION("values is not a list alias") {
         Lowered lowered{R"(
 module checks.list_values

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -1564,7 +1564,7 @@ module checks.graph_iteration
 use hgraph.std::{null_sink}
 
 fn observe(samples: list<f64, 3>) {
-    for sample in values(samples) {
+    for sample in elements(samples) {
         null_sink(sample)
     }
 }
@@ -1587,6 +1587,34 @@ fn observe(samples: list<f64, 3>) {
         CHECK(expression.phase == hir::Phase::Wiring);
     }
     CHECK(found_loop_value);
+}
+
+TEST_CASE("typed HIR keeps values and elements as distinct projections", "[ir][typed][iteration]") {
+    SECTION("values is not a list alias") {
+        Lowered lowered{R"(
+module checks.list_values
+
+fn observe(samples: list<f64, 3>) {
+    for sample in values(samples) { sample }
+}
+)"};
+        require_clean(lowered);
+        CHECK_FALSE(complete(lowered));
+        CHECK(lowered.diagnostics.render(lowered.file).find("'values' takes a map") != std::string::npos);
+    }
+
+    SECTION("elements is not a map alias") {
+        Lowered lowered{R"(
+module checks.map_elements
+
+fn observe(book: map<str, f64>) {
+    for value in elements(book) { value }
+}
+)"};
+        require_clean(lowered);
+        CHECK_FALSE(complete(lowered));
+        CHECK(lowered.diagnostics.render(lowered.file).find("'elements' takes a list or set") != std::string::npos);
+    }
 }
 
 TEST_CASE("typed HIR rejects an invalid result without claiming completion", "[ir][typed][diagnostics]") {

--- a/language/tests/semantics/resolve_tests.cpp
+++ b/language/tests/semantics/resolve_tests.cpp
@@ -358,7 +358,7 @@ fn lifecycle(x: f64) -> f64 {
 }
 
 fn iterate(samples: list<f64, 2>) {
-    for value in values(samples) { value }
+    for value in elements(samples) { value }
 }
 )");
     CHECK(resolved.kind_of("compose") == FunctionKind::Composition);

--- a/language/tests/wiring/backend_coverage_tests.cpp
+++ b/language/tests/wiring/backend_coverage_tests.cpp
@@ -383,9 +383,9 @@ fn observe_items(trigger: f64, offset: f64) {
     }
 }
 
-fn observe_list_values(trigger: f64, offset: f64) {
+fn observe_list_elements(trigger: f64, offset: f64) {
     let samples: list<f64> = hgl_coverage_samples(trigger)
-    for value in values(samples) {
+    for value in elements(samples) {
         hgl_coverage_observe(value + offset)
     }
 }
@@ -405,8 +405,8 @@ test items_ticks {
     eval(observe_items, trigger: [1.0], offset: [10.0, 20.0])
 }
 
-test list_values_ticks {
-    eval(observe_list_values, trigger: [1.0], offset: [10.0, 20.0])
+test list_elements_ticks {
+    eval(observe_list_elements, trigger: [1.0], offset: [10.0, 20.0])
 }
 
 test list_items_ticks {
@@ -421,7 +421,7 @@ test list_items_ticks {
     const std::vector<Expectation> expectations{
         {"values_ticks", {11.0, 12.0, 21.0, 22.0}},
         {"items_ticks", {11.0, 12.0, 21.0, 22.0}},
-        {"list_values_ticks", {11.0, 12.0, 21.0, 22.0}},
+        {"list_elements_ticks", {11.0, 12.0, 21.0, 22.0}},
         {"list_items_ticks", {11.0, 13.0, 21.0, 23.0}},
     };
     for (const Expectation &expectation : expectations) {

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -823,7 +823,7 @@ use hgraph.std::{hgl_fixed_iteration_pair, null_sink}
 
 fn discard(a: f64, b: f64) {
     let samples: list<f64, 2> = hgl_fixed_iteration_pair(a, b)
-    for sample in values(samples) {
+    for sample in elements(samples) {
         null_sink(sample)
     }
     for index, sample in items(samples) {
@@ -860,7 +860,7 @@ fn discard(trigger: f64, offset: f64) {
     for key, value in items(book) {
         null_sink(value + offset)
     }
-    for value in values(samples) {
+    for value in elements(samples) {
         null_sink(valid(peers))
     }
     for index, value in items(samples) {


### PR DESCRIPTION
## Summary

- make elements the checked list/set traversal intrinsic in typed HIR and both backends
- keep values for keyed or named value projections; reject the two spellings as aliases
- migrate fixed-list, dynamic-list, and set examples and generated coverage
- update the user and developer guides to state the implemented distinction

## Semantics

- values(TSD/TSB) yields projected child values
- elements(TSL/TSS) yields sequence elements or set members
- items(TSL) continues to yield (i64, value)
- enum reflection retains its separate values(Enum) raw-value and elements(Enum) nominal-member distinction

## Stack

- #798 builds the first compiled hgraph.std operators on this terminology
- #796 tracks the independent backend-neutral hgspec design prototype

## Validation

- current compiler generated and compiled all changed HGL fixtures
- focused language tests: 7/7 passed (syntax, semantics, IR, HGraph IR, codegen, wiring, generated)
- full acceptance passed on stacked #798: 1,801 native tests; Python 3.12 ABI3 wheel under Python 3.14 with 3,323 passed and 10 skipped
- git diff check passed