### PR TITLE
feat(hgl): compile initial standard library operators

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -408,6 +408,25 @@ set_property(TARGET hgl_core_native PROPERTY INTERFACE_INCLUDE_DIRECTORIES
 )
 hgl_apply_warnings(hgl_core_native)
 
+# The first HGL-authored standard-library module. It consumes the native
+# collection-view substrate above, but owns operator contracts, candidate
+# materialization, activation, and output policy in readable HGL source.
+set(_hgl_standard_library_include_dir ${CMAKE_CURRENT_BINARY_DIR}/generated/hgl_standard_library/include)
+set(_hgl_standard_library_src_dir ${CMAKE_CURRENT_BINARY_DIR}/generated/hgl_standard_library/src)
+hgl_add_module(hgl_standard_library STATIC
+    HGL stdlib/hgl/hgraph/standard.hgl
+    INCLUDE_DIR ${_hgl_standard_library_include_dir}
+    SRC_DIR ${_hgl_standard_library_src_dir}
+    LINK_LIBRARIES hgl::core_native
+)
+add_library(hgl::standard_library ALIAS hgl_standard_library)
+set_target_properties(hgl_standard_library PROPERTIES EXPORT_NAME standard_library)
+set_property(TARGET hgl_standard_library PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+    "$<BUILD_INTERFACE:${_hgl_standard_library_include_dir}>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hgl>"
+)
+hgl_apply_warnings(hgl_standard_library)
+
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
@@ -416,7 +435,7 @@ install(TARGETS hgl
     COMPONENT Runtime
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
-install(TARGETS hgl_native_interface hgl_native_package hgl_core_native
+install(TARGETS hgl_native_interface hgl_native_package hgl_core_native hgl_standard_library
     EXPORT HglLanguageTargets
     COMPONENT Development
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -435,16 +454,19 @@ install(DIRECTORY include/hgl
 )
 install(FILES
     ${_hgl_core_native_include_dir}/native.h
+    ${_hgl_standard_library_include_dir}/standard.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hgl
     COMPONENT Development
 )
 install(FILES
     ${_hgl_core_native_src_dir}/native.hgl-module.json
+    ${_hgl_standard_library_src_dir}/standard.hgl-module.json
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hgl/modules
     COMPONENT Development
 )
 install(FILES
     stdlib/hgl/hgraph/native.hgl
+    stdlib/hgl/hgraph/standard.hgl
     DESTINATION ${CMAKE_INSTALL_DATADIR}/hgl/stdlib/hgraph
     COMPONENT Development
 )
@@ -456,3 +478,5 @@ install(FILES
 )
 unset(_hgl_core_native_include_dir)
 unset(_hgl_core_native_src_dir)
+unset(_hgl_standard_library_include_dir)
+unset(_hgl_standard_library_src_dir)

--- a/language/README.md
+++ b/language/README.md
@@ -100,6 +100,10 @@ Syntax remains provisional while the prototype evolves; compatibility is not
 yet a release constraint. Implemented forms are kept under grammar, semantic,
 and direct-wiring tests.
 
-The first compiled library module lives at
-[`stdlib/hgl/hgraph/native.hgl`](stdlib/hgl/hgraph/native.hgl) and is published
-as the `hgl::core_native` CMake target.
+The first compiled library modules live under
+[`stdlib/hgl/hgraph`](stdlib/hgl/hgraph). `native.hgl` is the deliberately thin
+C++ value/view substrate published as `hgl::core_native`; `standard.hgl` is the
+first HGL-authored operator module, published as `hgl::standard_library`.
+Its `len_` and `is_empty` families are real generated and runtime-tested code,
+with the remaining production-identity and first-tick parity gaps recorded next
+to the source.

--- a/language/cmake/HglLanguage.cmake
+++ b/language/cmake/HglLanguage.cmake
@@ -77,6 +77,23 @@ if(TARGET hgl::core_native)
     unset(_hgl_core_native_descriptors)
 endif()
 
+# The installed HGL-authored standard library is another generated module. Give
+# downstream hgl_add_module() calls its relocated descriptor for the same reason
+# as core_native above.
+if(TARGET hgl::standard_library)
+    get_target_property(_hgl_standard_library_descriptors hgl::standard_library HGL_MODULE_DESCRIPTORS)
+    if(NOT _hgl_standard_library_descriptors OR
+       _hgl_standard_library_descriptors STREQUAL "_hgl_standard_library_descriptors-NOTFOUND")
+        set(_hgl_standard_library_descriptor "${_HGL_LANGUAGE_CMAKE_DIR}/modules/standard.hgl-module.json")
+        if(EXISTS "${_hgl_standard_library_descriptor}")
+            set_property(TARGET hgl::standard_library PROPERTY
+                HGL_MODULE_DESCRIPTORS "${_hgl_standard_library_descriptor}")
+        endif()
+        unset(_hgl_standard_library_descriptor)
+    endif()
+    unset(_hgl_standard_library_descriptors)
+endif()
+
 function(_hgl_resolve_compiler out_var)
     if(TARGET hgl)
         set(${out_var} "$<TARGET_FILE:hgl>" PARENT_SCOPE)

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -67,10 +67,13 @@ record together. The user guide is the source of truth for observable language
 behavior; the developer guide is the source of truth for implementation
 constraints.
 
-## Standard-library design corpus
+## Standard library and design corpus
 
-The [standard-library folder](../stdlib/README.md) collects agreed HGL examples
-to drive core-library coverage and expose missing language features. It starts
+The [standard-library folder](../stdlib/README.md) contains the first compiled
+HGL-authored `len_` and `is_empty` operator families as well as agreed examples
+that drive broader core-library coverage and expose missing language features.
+Those first operators are an integration prototype with production identity and
+first-tick parity blockers stated beside the source. The design corpus starts
 with conditional-result examples; the fixed-list and independent dynamic
 collection cases have graduated into the compiler's runnable example corpus. A
 single escaping conditional result and a bundle of several escaping results
@@ -79,6 +82,7 @@ assignments and reference-preserving forwarding of initialized results.
 Value-producing temporal conditionals without `else` have also graduated with
 a typed never-ticking false path, and so have early-return continuations
 (`examples/conditional-early-return.hgl`). The `switch`, enum, `str(value)`,
-and `elements` fixtures remain in the design corpus. A complete component
+and `elements` fixtures remain in the design corpus, although the `elements`
+spelling itself is implemented. A complete component
 catalogue remains to be developed. Files left in the design corpus are not a
 claim of implemented support.

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -281,8 +281,13 @@ remain rejected.
 
 ### G. Standard-library migration
 
-Status: the low-level `hgraph.native` substrate is compiled and installed; no
-core graph or node implementation has been migrated yet.
+Status: the low-level `hgraph.native` substrate is compiled and installed. The
+HGL-authored `hgraph.std.len_` and `hgraph.std.is_empty` families are the first
+compiled integration examples, covering strings, fixed/unbounded lists, sets,
+and maps. They intentionally use parallel identities and do not replace the
+core implementations: imported-contract implementation, start/never-valid
+collection semantics, retained rolling sizes, and TSB schema metadata remain
+named blockers.
 
 - generate the complete core graph/node inventory and classify each item;
 - select representative composition, stateless scalar-node, stateful-node,
@@ -318,7 +323,7 @@ today (#767, "Readiness").
 | --- | --- | --- |
 | `module`, selective and aliased `use`, `export`, canonical JSON descriptors, generated registration | implemented | Only `hgraph.std`, `hgraph.analytics`, and modules named by `--module-descriptor` resolve; any other `use` is a `module` diagnostic. No wildcard imports or re-exports; dependency closure and lock files are not implemented. |
 | `fn`, `export fn`, anonymous `fn`, bodyless `operator`, `impl fn` | partial | Both backends. `emit-cpp` rejects an `impl fn` of an imported operator; direct wiring reaches an `impl fn` only through a loaded native image and rejects a direct call; direct wiring rejects a call to a generic plain `fn` ("generic functions are not supported by the first pass"); a concise `map(..., fn(a) => ...)` lambda is lowered by `emit-cpp` but rejected by direct wiring ("anonymous functions are not supported by the first pass"), #767 item 3. |
-| Generics and `requires` | partial | Closed constraint language (equality, membership, categories, reflection, nominal operator requirements, Boolean composition) in typed HIR. Residual `const` predicates, imported-contract conformance, native nominal-struct metadata, and source-candidate ranking fail closed; explicit generic arguments on calls are undefined. |
+| Generics and `requires` | partial | Closed constraint language (equality, membership, categories, reflection, nominal operator requirements, Boolean composition) in typed HIR. An unbounded generic in a temporal contract lowers to a complete `TsVar` source shape; scalar-only key positions use `ScalarVar`. Residual `const` predicates, imported-contract conformance, native nominal-struct metadata, and source-candidate ranking fail closed; explicit generic arguments on calls are undefined. |
 | `instantiate op<A, ...>` | partial for local contracts | Concrete arguments specialize a matching generic `impl fn`; `_` retains a resolver slot. Both IRs distinguish the cases, descriptors retain residual generics, and `emit-cpp` maps a retained fixed-list size to `SIZE<"name">`. Constraints over retained slots and retained values read by a body require residual-constraint/reification designs and fail closed. Materializing an `impl fn` of a selectively imported operator is blocked on descriptor-backed external contract metadata. |
 | Canonical scalars, the eight temporal types, `@` and duration literals | partial | Lexer, parser, HIR, and both backends for `bool`, `i64`, `f64`, `str`, `date`, `time`, `datetime`, `duration`. Zoned and civil literals are rejected by both backends. Of the arithmetic table in the language reference only `str + str`, `duration ± duration`, `datetime ± duration`, `datetime - datetime`, and `duration * i64` are typed; `date ± duration`, `date - date`, `duration * f64`, and `duration / ...` are "arithmetic operands must both be numeric" (#767 item 2b: the emitter needs temporal arithmetic helpers before the checker admits them). |
 | `zoned_time` scalar; `Time` and `CivilDateTime` ordering | blocked | hgraph-side asks recorded under Slice 2 with no RFC in `docs/source/rfc/` yet; both backends fail closed meanwhile. |

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1128,6 +1128,15 @@ ordinary `fn` lowers as an exact callable and is not placed in a registry.
 Only an ordinary `export fn` is emitted into the module's public exact-function
 surface.
 
+An unbounded source type such as `S` is a complete time-series shape, not only
+the scalar payload inside `TS`. At a temporal contract boundary it therefore
+lowers to `TsVar<"S">`. In a value-only position, such as a TSS key or the key
+of a TSD, it lowers to `ScalarVar<"S">`. Nested temporal positions preserve the
+same distinction: `list<T, size>` uses `TSL<TsVar<"T">, SIZE<"size">>`, while
+`map<K, V>` uses `TSD<ScalarVar<"K">, TsVar<"V">>`. The emitter must not narrow
+a complete source-shape generic to `TS<ScalarVar<...>>` merely because its
+spelling occurs where a concrete scalar would produce `TS<Scalar>`.
+
 The generated contract alias or descriptor mapping must preserve the full nominal
 identity rather than using an unqualified registry string that could collide
 with another module.
@@ -1573,9 +1582,10 @@ expression is read from the syntax tree.
   Constructors lower to `to_tsb`, an `atomic<S>` result aggregates that TSB
   through `combine_cs`, and a runtime `delta<S>` builds and applies only its
   supplied fields.
-- **Generic and window types.** Source type parameters become hgraph
-  `ScalarVar` patterns at operator boundaries and ordinary C++ template
-  parameters for structural declarations. A generic rolling parameter becomes
+- **Generic and window types.** Source type parameters become hgraph `TsVar`
+  patterns at temporal operator boundaries, `ScalarVar` in scalar-only value
+  positions, and ordinary C++ template parameters for structural declarations.
+  A generic rolling parameter becomes
   `TSWAny<T>` while a concrete tick or duration window becomes `TSW<T, N, M>`
   or `TSWDuration<T, period_us, minimum_us>`. A generic operator implementation
   is not emitted as a C++ template or type-erased catch-all. Each

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -135,6 +135,15 @@ hgl_add_module(my_hgl_library STATIC
     LINK_LIBRARIES hgl::core_native)
 ```
 
+The repository's first HGL-authored operator module consumes this substrate as
+`hgl::standard_library`. Its `len_` and `is_empty` implementations use compact
+`when {}` handlers, retained generic materializations, and `inject out` to avoid
+unchanged collection-size ticks. They are executable compiler examples, but do
+not yet replace the public C++ operators: imported-contract implementation,
+start scheduling, never-valid collection observation, and retained rolling
+extents are named blockers. See the
+[core HGL module inventory](../../stdlib/hgl/hgraph/README.md).
+
 See the compiled
 [`core-native-library.hgl`](../../stdlib/hgl/examples/core-native-library.hgl)
 example and

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -70,6 +70,7 @@ namespace hgl::codegen
             bool               duration_window{false};
             std::string        nominal_identity{};
             std::string        cpp_type{};
+            std::string        source_generic{};  ///< complete HGL source-shape variable, if any
 
             [[nodiscard]] bool is(hir::ScalarType s) const noexcept { return kind == Kind::Scalar && scalar == s; }
             [[nodiscard]] bool numeric() const noexcept { return is(hir::ScalarType::I64) || is(hir::ScalarType::F64); }
@@ -93,7 +94,10 @@ namespace hgl::codegen
         bool same_type(const HType &a, const HType &b) {
             if (a.kind != b.kind || a.children.size() != b.children.size()) { return false; }
             if (a.kind == HType::Kind::Scalar && a.scalar != b.scalar) { return false; }
-            if (a.nominal_identity != b.nominal_identity || a.cpp_type != b.cpp_type) { return false; }
+            if (a.nominal_identity != b.nominal_identity || a.cpp_type != b.cpp_type ||
+                a.source_generic != b.source_generic) {
+                return false;
+            }
             if (a.size != b.size || a.min_size != b.min_size || a.duration_window != b.duration_window) { return false; }
             for (std::size_t i = 0; i < a.children.size(); ++i) {
                 if (!same_type(a.children[i], b.children[i])) { return false; }
@@ -1080,8 +1084,9 @@ namespace hgl::codegen
                                 backend(range, "a non-type generic cannot be used as a value type");
                             }
                             HType result;
-                            result.kind     = HType::Kind::Generic;
-                            result.cpp_type = "hgraph::ScalarVar<" + quote(binding.name) + ">";
+                            result.kind           = HType::Kind::Generic;
+                            result.cpp_type       = "hgraph::ScalarVar<" + quote(binding.name) + ">";
+                            result.source_generic = binding.name;
                             return result;
                         }
                         const auto contract =
@@ -1462,7 +1467,9 @@ namespace hgl::codegen
                 case HType::Kind::Struct: return "typename " + type.cpp_type + "::time_series";
                 case HType::Kind::Reference: return "hgraph::REF<" + schema(type.children[0], range) + ">";
                 case HType::Kind::Signal: return "hgraph::SIGNAL";
-                case HType::Kind::Generic: return "hgraph::TS<" + value_type(type, range) + ">";
+                case HType::Kind::Generic:
+                    return type.source_generic.empty() ? "hgraph::TS<" + value_type(type, range) + ">"
+                                                       : "hgraph::TsVar<" + quote(type.source_generic) + ">";
                 case HType::Kind::Unknown: break;
             }
             backend(range, "this value has no time-series schema");

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -1,13 +1,16 @@
-# HGL standard-library design corpus
+# HGL standard library and design corpus
 
-This folder will describe the core hgraph node and graph library in HGL as the
-required language contracts are agreed. It starts with worked examples that
-exercise those contracts; these example functions are not new public library
-components. The component inventory and HGL declarations remain to be added.
+This folder develops the core hgraph node and graph library in HGL as the
+required language contracts are agreed. The compiled modules are under
+[`hgl/hgraph`](hgl/hgraph); `standard.hgl` now provides the first real HGL
+operator implementations, `len_` and `is_empty`, without replacing their
+production C++ identities yet. The worked examples below exercise broader
+contracts; those example functions are not new public library components. The
+complete component inventory remains to be added.
 
-Only agreed syntax belongs in the corpus. Open questions should be recorded
-in the owning design document, without filling gaps with speculative
-declarations or native-binding syntax.
+Only agreed syntax belongs in the corpus. Open questions are recorded in the
+owning design document or beside a compiled prototype with an explicit blocker,
+without filling gaps with speculative declarations or native-binding syntax.
 
 ## Conditional results
 

--- a/language/stdlib/hgl/hgraph/README.md
+++ b/language/stdlib/hgl/hgraph/README.md
@@ -1,6 +1,12 @@
-# Core native HGL module
+# Core HGL modules
 
-Status: compiled, tested, and installed C++ implementation
+Status: compiled native substrate; compiled HGL operator integration prototype
+
+This folder contains two different layers. [`native.hgl`](native.hgl) is a thin
+C++ value/view substrate. [`standard.hgl`](standard.hgl) is ordinary HGL that
+defines, materializes, and registers the first higher-level operator families.
+
+## Native substrate
 
 [`native.hgl`](native.hgl) defines the `hgraph.native` module. It is built as
 the `hgl::core_native` CMake target and installs its generated C++ library,
@@ -49,6 +55,62 @@ fn list_size<T, const size: i64>(value: list<T, size>) -> i64 {
 
 See the compiled consumer
 [`core-native-library.hgl`](../examples/core-native-library.hgl).
+
+## First HGL-authored operators
+
+[`standard.hgl`](standard.hgl) defines `hgraph.std.len_` and
+`hgraph.std.is_empty`. It is compiled with `hgl_add_module()` as
+`hgl::standard_library`, installed with its generated header and descriptor,
+and runtime-tested through the public operator registry. The implementation is
+HGL; its only native calls are the current-value/live-view projections from
+`hgraph.native`.
+
+The source is deliberately compact:
+
+```hgl
+impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
+    inject out
+
+    when {
+        let current = native::len(value)
+        if valid(out) {
+            if out != current {
+                out = current
+            }
+        } else {
+            out = current
+        }
+    }
+}
+
+instantiate len_<_, _>, len_<_>
+```
+
+`when {}` means any input modification activates the handler and all inputs must
+be valid. `inject out` lets the implementation compare with the previous result
+and avoid an unchanged tick. One partially materialized list implementation
+matches fixed and unbounded extents; the retained `size` selects the concrete
+hgraph schema without being read by the body. Separate retained materializations
+cover the set and map candidates.
+
+This is the first compiler/standard-library integration slice, not yet a
+replacement for the production C++ operators:
+
+- generated contracts currently have the module-qualified identities
+  `hgraph.std.len_` and `hgraph.std.is_empty`; emitting an implementation of the
+  existing imported public contracts is still blocked;
+- HGL has no contract for `schedule_on_start` or observing a bound collection
+  before it first becomes valid, so the production first-tick behavior of TSL,
+  TSS, and TSD is not yet expressible;
+- a retained rolling extent lowers to an any-window pattern and cannot
+  materialize the concrete node input schema, so rolling is intentionally
+  absent from this first module;
+- TSB length/emptiness is schema metadata and needs a graph-level metadata
+  operation rather than the live collection-view primitive used here.
+
+These are tracked as `HGL-LIB-001` through `HGL-LIB-004` beside the HGL source.
+The existing C++ registrations remain authoritative until identity and behavior
+parity are complete.
 
 ## Honest boundaries
 

--- a/language/stdlib/hgl/hgraph/standard.hgl
+++ b/language/stdlib/hgl/hgraph/standard.hgl
@@ -33,11 +33,7 @@ impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
 
     when {
         let current = native::len(value)
-        if valid(out) {
-            if out != current {
-                out = current
-            }
-        } else {
+        if !valid(out) || out != current {
             out = current
         }
     }
@@ -48,11 +44,7 @@ impl fn len_<T>(value: set<T>) -> i64 {
 
     when {
         let current = native::len(value)
-        if valid(out) {
-            if out != current {
-                out = current
-            }
-        } else {
+        if !valid(out) || out != current {
             out = current
         }
     }
@@ -63,11 +55,7 @@ impl fn len_<K, V>(value: map<K, V>) -> i64 {
 
     when {
         let current = native::len(value)
-        if valid(out) {
-            if out != current {
-                out = current
-            }
-        } else {
+        if !valid(out) || out != current {
             out = current
         }
     }
@@ -86,11 +74,7 @@ impl fn is_empty<T, const size: i64>(value: list<T, size>) -> bool {
 
     when {
         let current = native::is_empty(value)
-        if valid(out) {
-            if out != current {
-                out = current
-            }
-        } else {
+        if !valid(out) || out != current {
             out = current
         }
     }
@@ -101,11 +85,7 @@ impl fn is_empty<T>(value: set<T>) -> bool {
 
     when {
         let current = native::is_empty(value)
-        if valid(out) {
-            if out != current {
-                out = current
-            }
-        } else {
+        if !valid(out) || out != current {
             out = current
         }
     }
@@ -116,11 +96,7 @@ impl fn is_empty<K, V>(value: map<K, V>) -> bool {
 
     when {
         let current = native::is_empty(value)
-        if valid(out) {
-            if out != current {
-                out = current
-            }
-        } else {
+        if !valid(out) || out != current {
             out = current
         }
     }

--- a/language/stdlib/hgl/hgraph/standard.hgl
+++ b/language/stdlib/hgl/hgraph/standard.hgl
@@ -1,0 +1,129 @@
+// The first standard-library operators implemented in HGL. The functions
+// below are compiled, registered, and runtime-tested; they are not a design
+// sketch. hgraph.native supplies only the small C++ value/view projections.
+//
+// TODO(HGL-LIB-001): bind these implementations to the existing public
+// hgraph len_/is_empty identities once imported operator implementations can
+// be emitted. Until then hgraph.std.len_ and hgraph.std.is_empty are parallel
+// prototype contracts and do not replace the production C++ registrations.
+// TODO(HGL-LIB-002): collection parity needs a source contract for start
+// scheduling and bound-but-never-valid input observation. The compact
+// `when {}` form intentionally uses the language default: any input modifies,
+// and all inputs are valid.
+// TODO(HGL-LIB-003): restore rolling candidates once retained rolling extents
+// can materialize a concrete input schema.
+// TODO(HGL-LIB-004): TSB size/emptiness needs a graph-level schema metadata
+// operation rather than a runtime collection-view projection.
+
+module hgraph.std
+
+use hgraph.native as native
+
+operator len_<S>(value: S) -> i64
+operator is_empty<S>(value: S) -> bool
+
+impl fn len_(value: str) -> i64 {
+    when {
+        return native::len(value)
+    }
+}
+
+impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
+    inject out
+
+    when {
+        let current = native::len(value)
+        if valid(out) {
+            if out != current {
+                out = current
+            }
+        } else {
+            out = current
+        }
+    }
+}
+
+impl fn len_<T>(value: set<T>) -> i64 {
+    inject out
+
+    when {
+        let current = native::len(value)
+        if valid(out) {
+            if out != current {
+                out = current
+            }
+        } else {
+            out = current
+        }
+    }
+}
+
+impl fn len_<K, V>(value: map<K, V>) -> i64 {
+    inject out
+
+    when {
+        let current = native::len(value)
+        if valid(out) {
+            if out != current {
+                out = current
+            }
+        } else {
+            out = current
+        }
+    }
+}
+
+instantiate len_<_, _>, len_<_>
+
+impl fn is_empty(value: str) -> bool {
+    when {
+        return native::is_empty(value)
+    }
+}
+
+impl fn is_empty<T, const size: i64>(value: list<T, size>) -> bool {
+    inject out
+
+    when {
+        let current = native::is_empty(value)
+        if valid(out) {
+            if out != current {
+                out = current
+            }
+        } else {
+            out = current
+        }
+    }
+}
+
+impl fn is_empty<T>(value: set<T>) -> bool {
+    inject out
+
+    when {
+        let current = native::is_empty(value)
+        if valid(out) {
+            if out != current {
+                out = current
+            }
+        } else {
+            out = current
+        }
+    }
+}
+
+impl fn is_empty<K, V>(value: map<K, V>) -> bool {
+    inject out
+
+    when {
+        let current = native::is_empty(value)
+        if valid(out) {
+            if out != current {
+                out = current
+            }
+        } else {
+            out = current
+        }
+    }
+}
+
+instantiate is_empty<_, _>, is_empty<_>

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -346,6 +346,7 @@ set(_hgl_generated_test_sources
     codegen/generated_native_tests.cpp
     codegen/generated_inline_native_tests.cpp
     codegen/generated_core_native_tests.cpp
+    codegen/generated_standard_library_tests.cpp
     codegen/generated_partial_materialization_tests.cpp
     codegen/generated_iteration_tests.cpp
     codegen/generated_reference_tests.cpp
@@ -362,6 +363,7 @@ set(_hgl_generated_test_libraries
     hgl_native_scalar_import_fixture
     hgl_inline_native_consumer_fixture
     hgl_core_native_consumer_fixture
+    hgl::standard_library
 )
 if(TARGET hgraph::analytics)
     # These two examples intentionally exercise an imported extension. Keep

--- a/language/tests/cmake/native_package/CMakeLists.txt
+++ b/language/tests/cmake/native_package/CMakeLists.txt
@@ -17,8 +17,20 @@ if(NOT _core_native_descriptors OR NOT EXISTS "${_core_native_descriptors}")
     message(FATAL_ERROR "hgl::core_native has no installed module descriptor: '${_core_native_descriptors}'")
 endif()
 
+if(NOT TARGET hgl::standard_library)
+    message(FATAL_ERROR "the installed HGL SDK does not define hgl::standard_library")
+endif()
+get_target_property(_standard_library_descriptors hgl::standard_library HGL_MODULE_DESCRIPTORS)
+if(NOT _standard_library_descriptors OR NOT EXISTS "${_standard_library_descriptors}")
+    message(FATAL_ERROR
+        "hgl::standard_library has no installed module descriptor: '${_standard_library_descriptors}'")
+endif()
+
 add_executable(hgl_native_package_consumer main.cpp)
 target_compile_features(hgl_native_package_consumer PRIVATE cxx_std_23)
-target_link_libraries(hgl_native_package_consumer PRIVATE hgl::native_package hgl::core_native)
+target_link_libraries(hgl_native_package_consumer PRIVATE
+    hgl::native_package
+    hgl::core_native
+    hgl::standard_library)
 set_target_properties(hgl_native_package_consumer PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_CURRENT_BINARY_DIR}/bin>")

--- a/language/tests/cmake/native_package/main.cpp
+++ b/language/tests/cmake/native_package/main.cpp
@@ -1,5 +1,6 @@
 #include <hgl/native_package.h>
 #include <native.h>
+#include <standard.h>
 
 #include <filesystem>
 #include <iostream>
@@ -14,6 +15,11 @@ int main(int argc, char **argv) {
         hgraph_::native::native::is_empty(hgraph::Str{"hgl"})) {
         std::cerr << "installed hgraph.native functions returned the wrong value\n";
         return 3;
+    }
+    const auto provider = hgraph_::std_::register_operators();
+    if (!provider.active()) {
+        std::cerr << "installed hgraph.std operators did not register\n";
+        return 4;
     }
 
     using namespace hgl::native;

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -1251,6 +1251,24 @@ instantiate choose<i64>, choose<f64>
     }
 }
 
+TEST_CASE("emit-cpp preserves complete source-shape generics in operator contracts",
+          "[codegen][hgraph-ir][operators][generics]") {
+    Unit unit{R"(
+module generic_source_contract
+
+operator forward<S>(value: S) -> S
+impl fn forward(value: i64) -> i64 => value
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE(emitted);
+    CHECK(contains(emitted->header, "hgraph::In<\"value\", hgraph::TsVar<\"S\">>"));
+    CHECK(contains(emitted->header, "hgraph::Out<hgraph::TsVar<\"S\">>"));
+    CHECK_FALSE(contains(emitted->header, "hgraph::TS<hgraph::ScalarVar<\"S\">>"));
+}
+
 TEST_CASE("emit-cpp retains a size generic in a partially materialized list candidate",
           "[codegen][hgraph-ir][operators][generics]") {
     Unit unit{R"(
@@ -2134,7 +2152,7 @@ export fn logged(value: f64) -> f64 {
     CHECK(contains(emitted->header, "hgraph::NominalBundle<\"t\", \"Quote\", "
                                     "false, hgraph::BundleParents<>"));
     CHECK(contains(emitted->header, "template <typename T>\n    struct Box"));
-    CHECK(contains(emitted->header, "hgraph::ScalarVar<\"U\">"));
+    CHECK(contains(emitted->header, "hgraph::TsVar<\"U\">"));
     CHECK(contains(emitted->header, "hgraph::TSWDuration<hgraph::Float, 300000000, 300000000>"));
     CHECK(contains(emitted->header, "hgraph::LoggerView logger"));
     CHECK(contains(emitted->header, "logger.log(2, hgraph::Str{\"value\"});"));

--- a/language/tests/codegen/generated_standard_library_tests.cpp
+++ b/language/tests/codegen/generated_standard_library_tests.cpp
@@ -1,0 +1,64 @@
+#include <standard.h>
+
+#include "wiring/backend.h"
+
+#include <hgraph/lib/testing/check_output.h>
+#include <hgraph/lib/testing/eval_node.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace hgraph;
+using namespace hgraph::testing;
+namespace standard = hgraph_::std_;
+
+namespace
+{
+    void register_standard_hgl() {
+        hgl::wiring::ensure_session();
+        const auto provider = standard::register_operators();
+        REQUIRE(provider.active());
+    }
+}  // namespace
+
+TEST_CASE("the HGL standard library registers its first operator families", "[codegen][runtime][stdlib][hgl]") {
+    register_standard_hgl();
+
+    REQUIRE(hgl::wiring::has_operator("hgraph.std.len_"));
+    REQUIRE(hgl::wiring::has_operator("hgraph.std.is_empty"));
+}
+
+TEST_CASE("HGL len_ and is_empty handle scalar and collection inputs", "[codegen][runtime][stdlib][hgl]") {
+    register_standard_hgl();
+
+    CHECK_OUTPUT(eval_node<standard::operators::len_>(values<Str>("hgl", "")), values<Int>(3, 0));
+    CHECK_OUTPUT(eval_node<standard::operators::is_empty>(values<Str>("hgl", "")), values<Bool>(false, true));
+
+    CHECK_OUTPUT((eval_node<standard::operators::len_, TSL<TS<Int>, 2>>(values<Value>(list_delta<TS<Int>>({1, 2})))),
+                 values<Int>(2));
+    CHECK_OUTPUT((eval_node<standard::operators::is_empty, TSL<TS<Int>, 2>>(values<Value>(list_delta<TS<Int>>({1, 2})))),
+                 values<Bool>(false));
+
+    CHECK_OUTPUT((eval_node<standard::operators::len_, TSL<TS<Int>>>(values<Value>(dynamic_list_delta<TS<Int>>({{0, 1}}),
+                                                                                   dynamic_list_delta<TS<Int>>({{1, 2}, {2, 3}}),
+                                                                                   dynamic_list_delta<TS<Int>>({}, {2})))),
+                 values<Int>(1, 3, 2));
+    CHECK_OUTPUT((eval_node<standard::operators::is_empty, TSL<TS<Int>>>(
+                     values<Value>(dynamic_list_delta<TS<Int>>({{0, 1}}), dynamic_list_delta<TS<Int>>({}, {0})))),
+                 values<Bool>(false, true));
+
+    CHECK_OUTPUT(
+        (eval_node<standard::operators::len_, TSS<Int>>(values<Value>(set_delta<Int>({1, 2}, {}), set_delta<Int>({}, {1})))),
+        values<Int>(2, 1));
+    CHECK_OUTPUT(
+        (eval_node<standard::operators::is_empty, TSS<Int>>(values<Value>(set_delta<Int>({1}, {}), set_delta<Int>({}, {1})))),
+        values<Bool>(false, true));
+
+    CHECK_OUTPUT((eval_node<standard::operators::len_, TSD<Int, TS<Float>>>(
+                     values<Value>(dict_delta<Int, TS<Float>>({{1, 1.0}, {2, 2.0}}), dict_delta<Int, TS<Float>>({{2, 3.0}}),
+                                   dict_delta<Int, TS<Float>>({}, {1})))),
+                 values<Int>(2, none, 1));
+    CHECK_OUTPUT(
+        (eval_node<standard::operators::is_empty, TSD<Int, TS<Float>>>(values<Value>(
+            dict_delta<Int, TS<Float>>({{1, 1.0}}), dict_delta<Int, TS<Float>>({{1, 2.0}}), dict_delta<Int, TS<Float>>({}, {1})))),
+        values<Bool>(false, none, true));
+}


### PR DESCRIPTION
## Summary

- compile hgraph.std as a real HGL standard-library module with len_ and is_empty implementations for strings, lists, sets, and maps
- install and export hgl::standard_library, including its generated registration descriptor, and exercise it from the installed-SDK consumer
- preserve source generic time-series parameters as TsVar during C++ schema emission while keeping scalar collection parameters as ScalarVar
- document the remaining production-operator, scheduling, rolling-window, and bundle-schema blockers explicitly

The generated code is clang-formatted, uses ordinary named static-node structs, and calls native free functions directly. It does not subclass operators. This slice intentionally proves the first two library migrations without replacing the production C++ operator registrations prematurely.

Stacked on #797. The backend-neutral hgspec prototype is tracked independently in #796.

## Validation

- focused HGL codegen and generated-runtime tests passed
- fresh native acceptance build: 1,801 tests passed
- Python 3.12 ABI3 wheel installed under Python 3.14: 3,323 passed, 10 skipped

Closes no issue.