### PR TITLE
fix(hgl): recover handler selector semantics

### DIFF
--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -667,10 +667,37 @@ remaining predicate to a C++ `if` in source order. Later handlers observe state
 and output changes made by earlier handlers.
 
 `modified(a, b, ...)` is true when any listed input was modified, while
-`valid(a, b, ...)` is true only when every listed input is valid. Both require
-at least one argument. The compiler converts activation and validity predicates
-into hgraph input metadata whenever they are statically representable. Only
-residual conditions remain in the per-tick body.
+`valid(a, b, ...)` is true only when every listed input is valid. In a
+function-level `when` predicate, the empty forms select the complete temporal
+parameter list: `modified()` is the disjunction over that list and `valid()`
+is its top-level-valid conjunction. `const` parameters, state, injectables, and
+`out` are excluded.
+
+A handler that has no top-level `modified(...)` conjunction receives an
+implicit `modified()` selector. A handler with no top-level validity selector
+(`valid(...)` or `all_valid(...)`) receives an implicit `valid()` selector.
+Calls nested in a residual expression do not suppress the defaults. The
+canonical degenerate form is:
+
+```hgl
+when {
+    // Any temporal input activates this handler, after all are valid.
+}
+```
+
+It is equivalent to `when modified() && valid() { ... }`. The compiler
+converts activation predicates into hgraph input metadata when they are
+statically representable and retains admission and residual conditions in the
+ordered per-tick body. Empty selector calls outside a function-level `when`
+are rejected because this decision assigns them no meaning there. The behavior
+of a bare handler in a runtime function with no temporal parameters but an
+explicit scheduler remains a separate lifecycle decision.
+
+Because empty `modified()` and `valid()` mean the complete input list, they
+cannot also spell an explicitly empty activation or validity set. That source
+form remains open. It is required by scheduler-only handlers and native nodes
+that intentionally admit invalid inputs; the backend contract must keep its
+empty selector distinct from its default selector in the meantime.
 
 In a runtime function, `return value` writes the complete output and terminates
 the current evaluation. Reaching the end without a return or output mutation
@@ -729,16 +756,19 @@ modified(value)
 valid(value)
 modified(bid, ask)
 valid(bid, ask)
+modified()
+valid()
 all_valid(book)
 last_modified(value)
 delta(value)
 ```
 
 The language does not expose `value.modified`, `value.valid`, or `value.value`.
-Like `key_set`, the metadata calls follow the phase of their containing
+Like `key_set`, non-empty metadata calls follow the phase of their containing
 function: in composition they wire hgraph's standard `valid`, `modified`, and
 `last_modified_time` operators and yield time series; `modified` and `valid`
-are evaluator-local metadata in runtime functions. The
+are evaluator-local metadata in runtime functions. Empty `modified()` and
+`valid()` have meaning only in a function-level `when` predicate. The
 compiler may consume them as activation and admission policy rather than
 materializing Boolean time series. `valid(value)` tests top-level endpoint
 validity; recursive child validity is a distinct operation named

--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -271,7 +271,7 @@ its runtime implementation:
 use hgraph.native as native
 
 impl fn len_<T, const size: i64>(value: list<T, size>) -> i64 {
-    when modified(value) && valid(value) {
+    when {
         return native::len(value)
     }
 }

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -165,6 +165,9 @@ surface.
   not classify the function by itself.
 - Runtime `when` predicates are decomposed into activation, validity admission,
   and residual per-evaluation logic where possible.
+- A handler with no modification selector defaults to any temporal input; one
+  with no validity selector defaults to all temporal inputs being top-level
+  valid. Bare `when { ... }` supplies both defaults.
 - State declarations aggregate into one recordable state value; grouped
   inject declarations map approved capabilities to native selectors.
 - `return value` is terminating output, while `inject out` enables persistent

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -911,9 +911,24 @@ fn combined_total(a: f64, b: f64) -> f64 {
 
 For all ordered `when` predicates, the runtime semantic pass derives:
 
-1. the union of activation dependencies derived from `modified(...)` terms;
-2. validity admission requirements common to every executable handler;
-3. ordered residual predicates that remain in the per-evaluation body.
+1. an implicit `modified()` term when a handler has no top-level modification
+   selector, selecting every temporal input;
+2. an implicit `valid()` term when a handler has no top-level validity
+   selector, requiring every temporal input to be top-level valid;
+3. the union of activation dependencies derived from explicit or implicit
+   `modified(...)` terms;
+4. validity admission requirements common to every executable handler; and
+5. ordered residual predicates that remain in the per-evaluation body.
+
+For a single handler, the source semantics are:
+
+| HGL handler | Handler activation | Handler validity admission |
+| --- | --- | --- |
+| `when { ... }` | any temporal input | every temporal input |
+| `when modified() && valid() { ... }` | any temporal input | every temporal input |
+| `when modified(a) { ... }` | `a` | every temporal input |
+| `when valid(a) { ... }` | any temporal input | `a` |
+| `when modified(a, b) && valid(a) { ... }` | `a` or `b` | `a` |
 
 An omitted `modified` term contributes every temporal parameter to that
 handler's activation set. An omitted `valid` term admits the handler only when
@@ -922,6 +937,11 @@ spell those same complete sets explicitly, and an omitted condition (`when
 { ... }`) applies both defaults. Lowering keeps the source condition optional;
 the runtime plan expands the defaults before it selects active inputs, checks
 validity dominance, and emits the handler guard.
+
+Only selectors found directly in the top-level `&&` conjunction suppress a
+default. A call beneath `||`, `!`, another call, or another residual expression
+remains part of that residual expression and does not silently replace the
+handler's missing activation or admission policy.
 
 For this example both inputs are active, but neither is globally
 required-valid: each handler can execute without the other input. Both inputs
@@ -1597,10 +1617,12 @@ expression is read from the syntax tree.
 - **Runtime-node structs.** A runtime function in the supported scalar subset
   is an empty static node struct in the generated header. Its `eval` signature
   carries typed `In`, `Scalar`, `RecordableState`, and `Out` selectors. The
-  union of `modified(...)` parameters selects active inputs; other temporal
-  inputs are passive. A function with `when` conservatively admits unchecked
-  inputs and retains its complete ordered predicates in `eval`. A function
-  without `when` uses ordinary active/valid input policy.
+  union of explicit or defaulted `modified(...)` parameters selects active
+  inputs. A missing selector or `modified()` selects all temporal inputs; other
+  inputs are passive. A function with `when` conservatively marks inputs
+  unchecked and enforces explicit or defaulted validity in its complete ordered
+  predicates in `eval`. A function without `when` uses ordinary active/valid
+  input policy.
 - **Bodies.** The same lowering the direct-wiring backend performs, printed:
   a constant expression folds into a C++ expression with the same rules
   (`/` on integers is a `Float` division, `Int` and `Float` mix to `Float`,
@@ -1624,7 +1646,9 @@ expression is read from the syntax tree.
 - **Runtime bodies.** Scalar payload expressions use the same checked type and
   widening rules, while `modified`, `valid`, and `all_valid` call selector
   metadata directly. `valid(a, b)` is an `&&` fold and `modified(a, b)` is
-  an `||` fold. Ordered `when` blocks become independent `if` statements.
+  an `||` fold. Within a handler, `modified()` and `valid()` fold over the
+  complete temporal parameter list and omitted selector categories default to
+  those empty forms. Ordered `when` blocks become independent `if` statements.
   `return value` sets the output and returns; assignment through `inject out`
   sets it and continues, so the final whole-output write wins. Scalar state
   fields form one named `TSB` behind `RecordableState`; `start` seeds only

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1077,6 +1077,14 @@ contribute safely to the node's activation policy.
 These are semantic restrictions rather than parser shortcuts so diagnostics
 can identify the misplaced or duplicate construct precisely.
 
+An omitted `when` expression is the canonical default handler. It is
+equivalent to writing `modified() && valid()`: any temporal parameter may
+activate the node, and every temporal parameter must be top-level valid before
+the handler is admitted. The empty calls are contextual handler-selector
+forms. Empty metadata calls outside a handler are rejected; they are not
+zero-argument graph-operator calls. The parser and both IR layers preserve an
+omitted condition, and the generated runtime backend expands the defaults.
+
 An inject declaration may span lines after `inject`; newlines around commas do
 not terminate it. Duplicate injectable names are rejected after name
 resolution.
@@ -1517,6 +1525,8 @@ modified(value)
 valid(value)
 modified(bid, ask)
 valid(bid, ask)
+modified()
+valid()
 all_valid(book)
 last_modified(value)
 delta(value)
@@ -1532,13 +1542,34 @@ meaning: `valid` and `modified` produce a `bool` time series and
 `last_modified` a `datetime` time series, with the multi-argument forms
 composing through the standard Boolean operators. In a runtime function,
 `modified` and `valid` inspect evaluator-local endpoint metadata rather than
-construct Boolean time series. Both require at least one
-argument and fold over their arguments with complementary rules:
+construct Boolean time series. Non-empty calls fold over their arguments with
+complementary rules:
 
 ```text
 modified(a, b, c) = modified(a) || modified(b) || modified(c)
 valid(a, b, c)    = valid(a) && valid(b) && valid(c)
 ```
+
+Within a function-level `when` predicate, `modified()` selects all temporal
+parameters and retains the ordinary disjunction, while `valid()` selects all
+temporal parameters and retains the ordinary conjunction. `const` parameters,
+state, injected capabilities, and `out` are not members of that implicit input
+list. Empty calls outside a `when` predicate are rejected until separate
+semantics are specified.
+
+The handler also supplies either selector when its top-level conjunction omits
+it. Thus `when modified(a) { ... }` implicitly requires `valid()`, and
+`when valid(a) { ... }` implicitly uses `modified()` for activation. A bare
+`when { ... }` supplies both. Calls nested under `||`, `!`, another call, or
+another residual expression do not suppress a missing top-level default. These
+defaults test endpoint validity only; recursive structural validity still
+requires `all_valid(value)`.
+
+The source spelling for an explicitly empty activation or validity selector is
+not yet defined. It cannot reuse `modified()` or `valid()`, because the empty
+argument list means all temporal parameters. The runtime representation must
+nevertheless preserve the difference between a default selector and an
+explicit empty selector.
 
 The compiler may consume these calls while deriving node input policies, so
 they need not remain as runtime calls in generated C++. `valid(value)` tests
@@ -1703,6 +1734,12 @@ and phase checking derive one safe node policy across the complete body:
   executable handler;
 - handler-specific activation, validity, and other predicates remain ordered
   runtime conditions.
+
+Before deriving that policy, each handler is normalized with its implicit
+selectors. A missing top-level `modified(...)` selector becomes `modified()`;
+a missing top-level validity selector (`valid(...)` or `all_valid(...)`)
+becomes `valid()`. Calls nested under `||`, `!`, or another residual expression
+do not suppress these defaults.
 
 A function classified as runtime by another node-only construct but containing
 no `when` uses hgraph's default policy: every ordinary temporal input is active

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -331,8 +331,14 @@ Runtime semantic tests additionally cover:
 
 - `modified(a, b)` activating when either input changes;
 - `valid(a, b)` requiring both inputs to be valid;
-- zero-argument `modified()` and `valid()` selecting all temporal inputs;
-- omitted activation and validity predicates, including compact `when {}`;
+- `modified()` selecting any temporal input and `valid()` requiring every
+  temporal input inside a `when` predicate;
+- omission of either selector category supplying its complete-input default;
+- bare `when { ... }` matching `when modified() && valid() { ... }`;
+- selector calls nested in residual Boolean expressions not suppressing a
+  missing top-level selector default;
+- diagnostics for empty selector calls outside a `when` predicate and for
+  empty `all_valid()`;
 - top-level `valid(value)` versus recursive `all_valid(value)` semantics;
 - statically admitted and unchecked-valid inputs;
 - flow-sensitive payload reads guarded by `valid(input)`;

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -451,6 +451,22 @@ It is equivalent to `when modified() && valid() { ... }`. Explicit arguments
 still narrow their respective predicate, so `when modified(a) && valid(a)`
 does not require `b` and does not activate for changes to `b`.
 
+| Handler | Activation | Validity admission |
+| --- | --- | --- |
+| `when { ... }` | Any temporal input | Every temporal input |
+| `when modified() && valid() { ... }` | Any temporal input | Every temporal input |
+| `when modified(a) { ... }` | `a` | Every temporal input |
+| `when valid(a) { ... }` | Any temporal input | `a` |
+| `when modified(a, b) && valid(a) { ... }` | `a` or `b` | `a` |
+
+These defaults apply to temporal function parameters, not `const` parameters,
+state, injectables, or `out`. `valid()` is not recursive for structural inputs;
+use `all_valid(value)` when every child must be valid. Empty selector calls are
+valid only in a function-level `when` predicate. There is not yet an agreed HGL
+spelling for “no input activation” or “no validity requirement”; those explicit
+empty policies are different from `modified()` and `valid()`, which select the
+complete temporal input list.
+
 `when` is a function-level handler rather than a nested control-flow form.
 Use `if valid(value) { ... }` inside a handler when only part of that handler
 needs a value. Validity guards follow normal left-to-right short-circuit order,

--- a/language/docs/user-guide/language-tour.md
+++ b/language/docs/user-guide/language-tour.md
@@ -189,6 +189,8 @@ modified(price)
 valid(price)
 modified(bid, ask)
 valid(bid, ask)
+modified()
+valid()
 all_valid(book)
 last_modified(price)
 delta(positions)
@@ -198,6 +200,11 @@ delta(positions)
 true only when every argument is valid. `valid(value)` tests the endpoint
 itself; use `all_valid(value)` when every child of a structural or collection
 endpoint must also be valid.
+
+Inside a function-level `when` header, empty calls select all temporal
+parameters. Omitting the modification or validity selector supplies that same
+default, so `when { ... }` means “any input modified and all inputs valid.”
+Empty selector calls outside `when` are rejected.
 
 The collection traversal surface uses `keys`, `values`, `elements`, and
 `items`. `values` projects values from keyed or named collections;

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -893,6 +893,8 @@ modified(value)
 valid(value)
 modified(bid, ask)
 valid(bid, ask)
+modified()
+valid()
 all_valid(book)
 last_modified(value)
 delta(value)
@@ -901,9 +903,19 @@ delta(value)
 Source does not expose `value.modified`, `value.valid`, or `value.value`.
 In a runtime `when` predicate, `modified(value)` and `valid(value)` inspect the
 input endpoint while ordinary expressions read its current payload. Both
-predicates accept one or more arguments: `modified(a, b, c)` is true when any
-argument was modified, while `valid(a, b, c)` is true only when every argument
-is valid. Calls without arguments are invalid.
+predicates accept one or more explicit arguments: `modified(a, b, c)` is true
+when any argument was modified, while `valid(a, b, c)` is true only when every
+argument is valid. In a function-level `when` predicate, an empty argument list
+selects all temporal parameters: `modified()` means any was modified and
+`valid()` means all are top-level valid. A handler that omits either selector
+receives the corresponding complete-input default; consequently
+`when { ... }` means any input may trigger once every input is valid. Empty
+selector calls outside `when` are invalid, and `all_valid` always requires an
+explicit argument.
+
+There is no source spelling yet for an explicitly empty activation or validity
+set. It cannot be `modified()` or `valid()`, because those calls select the
+complete temporal parameter list.
 
 For a structural or collection input, `valid(value)` tests the validity of the
 endpoint itself rather than recursively requiring every child to be valid.

--- a/language/examples/README.md
+++ b/language/examples/README.md
@@ -26,6 +26,11 @@ has no `test` block, the note below says which unit tests carry its behaviour.
   and incremental collection output. Tests: none in the file; native behaviour
   in `generated_example_tests.cpp`, and the `--dump-hir` /
   `--dump-hgraph-ir` CTest cases read this example.
+- [`when-defaults.hgl`](when-defaults.hgl) makes omitted and zero-argument
+  handler selectors executable: `when {}` matches
+  `when modified() && valid()`, while either omitted selector expands over all
+  temporal parameters. Tests: 3 `test` blocks under `hgl test`
+  (`hgraph_language_test_when-defaults`) plus focused generated-code checks.
 - [`collection-views.hgl`](collection-views.hgl) demonstrates dual-phase
   `key_set`, runtime `keys`/`values`/`elements`/`items`, built-in and inline
   predicates,

--- a/language/examples/when-defaults.hgl
+++ b/language/examples/when-defaults.hgl
@@ -1,0 +1,40 @@
+// Omitted and empty handler selectors have the same all-input defaults.
+
+module examples.when_defaults
+
+fn default_sum(a: f64, b: f64) -> f64 {
+    when {
+        return a + b
+    }
+}
+
+fn explicit_default_sum(a: f64, b: f64) -> f64 {
+    when modified() && valid() {
+        return a + b
+    }
+}
+
+fn on_a_when_all_valid(a: f64, b: f64) -> f64 {
+    when modified(a) {
+        return a + b
+    }
+}
+
+fn any_input_when_a_valid(a: f64, b: f64) -> f64 {
+    when valid(a) {
+        return a
+    }
+}
+
+test implicit_and_explicit_defaults_match {
+    assert eval(default_sum, a: [1.0, _, 3.0], b: [_, 10.0, 20.0]) == [_, 11.0, 23.0]
+    assert eval(explicit_default_sum, a: [1.0, _, 3.0], b: [_, 10.0, 20.0]) == [_, 11.0, 23.0]
+}
+
+test omitted_validity_uses_all_inputs {
+    assert eval(on_a_when_all_valid, a: [1.0, _, 3.0], b: [_, 10.0, 20.0]) == [_, _, 23.0]
+}
+
+test omitted_activation_uses_all_inputs {
+    assert eval(any_input_when_a_valid, a: [1.0, _, 3.0], b: [_, 10.0, 20.0]) == [1.0, 1.0, 3.0]
+}

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -163,6 +163,7 @@ namespace hgl::codegen
             std::vector<Value>                       params{};
             std::unordered_map<std::uint32_t, Value> planned_bindings{};
             bool                                     runtime{false};
+            bool                                     when_condition{false};
             bool                                     runtime_inputs_available{true};
             bool                                     output_available{false};
         };
@@ -600,13 +601,12 @@ namespace hgl::codegen
             [[nodiscard]] std::optional<std::int64_t> runtime_integer_constant(gir::ValueId id, gir::CallableId callable_id);
             [[nodiscard]] std::optional<std::string>  runtime_selector_key(gir::ValueId id, gir::CallableId callable_id);
             using RuntimeValidSet = std::unordered_set<std::string>;
-            [[nodiscard]] bool runtime_intrinsic_present(gir::ValueId id, gir::CallableId callable_id,
-                                                         std::string_view name);
-            void               add_all_runtime_parameters(gir::CallableId callable_id, RuntimeInfo &info);
+            [[nodiscard]] bool            runtime_top_level_selector_present(gir::ValueId id, gir::CallableId callable_id,
+                                                                             std::string_view name);
+            void                          add_all_runtime_parameters(gir::CallableId callable_id, RuntimeInfo &info);
             [[nodiscard]] RuntimeValidSet add_all_runtime_valid(gir::CallableId callable_id, RuntimeValidSet valid);
-            [[nodiscard]] std::string runtime_all_predicate(const Frame &frame, std::string_view method,
-                                                            std::string_view joiner);
-            void collect_runtime_activation(gir::ValueId id, gir::CallableId callable_id, RuntimeInfo &info);
+            [[nodiscard]] std::string runtime_all_predicate(const Frame &frame, std::string_view method, std::string_view joiner);
+            void                      collect_runtime_activation(gir::ValueId id, gir::CallableId callable_id, RuntimeInfo &info);
             void check_runtime_expr(gir::ValueId id, gir::CallableId callable_id, const RuntimeValidSet &valid);
             void check_runtime_selector(gir::ValueId id, gir::CallableId callable_id, const RuntimeValidSet &valid);
             [[nodiscard]] RuntimeValidSet runtime_true_valid(gir::ValueId id, gir::CallableId callable_id,
@@ -2721,11 +2721,12 @@ namespace hgl::codegen
             }
             if (name == "valid" || name == "modified" || name == "all_valid") {
                 if (call.arguments.empty()) {
-                    if (!frame.runtime) {
+                    if (name == "all_valid") { fail(Category::Type, range, "'all_valid' takes at least one argument"); }
+                    if (!frame.runtime || !frame.when_condition) {
                         fail(Category::Type, range,
-                             "zero-argument '" + name + "' is only available in a runtime 'when' condition");
+                             "zero-argument '" + name + "' is only available in a function-level 'when' condition");
                     }
-                    const std::string method = name == "modified" ? "modified()" : name == "all_valid" ? "all_valid()" : "valid()";
+                    const std::string method = name == "modified" ? "modified()" : "valid()";
                     return make_runtime(runtime_all_predicate(frame, method, name == "modified" ? " || " : " && "),
                                         scalar_type(hir::ScalarType::Bool), range);
                 }
@@ -3456,20 +3457,19 @@ namespace hgl::codegen
                         out.line("return;");
                     } else if constexpr (std::is_same_v<T, gir::Activation>) {
                         std::vector<std::string> conditions;
-                        const bool has_modified = node.condition.valid() &&
-                                                  runtime_intrinsic_present(node.condition, frame.fn, "modified");
-                        const bool has_valid = node.condition.valid() &&
-                                               (runtime_intrinsic_present(node.condition, frame.fn, "valid") ||
-                                                runtime_intrinsic_present(node.condition, frame.fn, "all_valid"));
-                        if (!has_modified) {
-                            conditions.push_back(runtime_all_predicate(frame, "modified()", " || "));
-                        }
+                        const bool               has_modified =
+                            node.condition.valid() && runtime_top_level_selector_present(node.condition, frame.fn, "modified");
+                        const bool has_valid =
+                            node.condition.valid() && (runtime_top_level_selector_present(node.condition, frame.fn, "valid") ||
+                                                       runtime_top_level_selector_present(node.condition, frame.fn, "all_valid"));
+                        if (!has_modified) { conditions.push_back(runtime_all_predicate(frame, "modified()", " || ")); }
                         if (!has_valid) { conditions.push_back(runtime_all_predicate(frame, "valid()", " && ")); }
                         if (node.condition.valid()) {
                             const gir::Value &condition_expression = planned_value(node.condition, statement.range);
-                            const Value       condition            = eval_planned_expr(node.condition, frame);
-                            if ((!condition.is_const() && !condition.is_runtime()) ||
-                                !condition.type.is(hir::ScalarType::Bool)) {
+                            frame.when_condition                   = true;
+                            const Value condition                  = eval_planned_expr(node.condition, frame);
+                            frame.when_condition                   = false;
+                            if ((!condition.is_const() && !condition.is_runtime()) || !condition.type.is(hir::ScalarType::Bool)) {
                                 fail(Category::Type, condition_expression.range, "a 'when' condition is a bool scalar");
                             }
                             conditions.push_back(condition.code);
@@ -3684,52 +3684,18 @@ namespace hgl::codegen
             return std::nullopt;
         }
 
-        bool Emitter::runtime_intrinsic_present(gir::ValueId id, gir::CallableId decl, std::string_view name) {
+        bool Emitter::runtime_top_level_selector_present(gir::ValueId id, gir::CallableId decl, std::string_view name) {
             if (!id.valid()) { return false; }
             const gir::Value &expression = planned_value(id, callable(decl).range);
-            return std::visit(
-                [&](const auto &node) -> bool {
-                    using T = std::decay_t<decltype(node)>;
-                    if constexpr (std::is_same_v<T, gir::Call>) {
-                        const gir::Value     &callee    = planned_value(node.callee, expression.range);
-                        const gir::Reference *reference = std::get_if<gir::Reference>(&callee.node);
-                        if (reference != nullptr && reference->kind == gir::ReferenceKind::Intrinsic &&
-                            reference->registry_name == name) {
-                            return true;
-                        }
-                        if (runtime_intrinsic_present(node.callee, decl, name)) { return true; }
-                        return std::ranges::any_of(node.arguments, [&](const gir::Argument &argument) {
-                            return runtime_intrinsic_present(argument.value, decl, name);
-                        });
-                    } else if constexpr (std::is_same_v<T, gir::Unary>) {
-                        return runtime_intrinsic_present(node.operand, decl, name);
-                    } else if constexpr (std::is_same_v<T, gir::Binary>) {
-                        return runtime_intrinsic_present(node.lhs, decl, name) ||
-                               runtime_intrinsic_present(node.rhs, decl, name);
-                    } else if constexpr (std::is_same_v<T, gir::Index>) {
-                        return runtime_intrinsic_present(node.target, decl, name) ||
-                               runtime_intrinsic_present(node.index, decl, name);
-                    } else if constexpr (std::is_same_v<T, gir::Field>) {
-                        return runtime_intrinsic_present(node.target, decl, name);
-                    } else if constexpr (std::is_same_v<T, gir::Sequence>) {
-                        return std::ranges::any_of(node.elements, [&](const gir::SequenceElement &element) {
-                            return (element.key.valid() && runtime_intrinsic_present(element.key, decl, name)) ||
-                                   runtime_intrinsic_present(element.value, decl, name);
-                        });
-                    } else if constexpr (std::is_same_v<T, gir::Tuple>) {
-                        return std::ranges::any_of(node.elements,
-                                                   [&](gir::ValueId value) { return runtime_intrinsic_present(value, decl, name); });
-                    } else if constexpr (std::is_same_v<T, gir::Conditional>) {
-                        return runtime_intrinsic_present(node.condition, decl, name) ||
-                               runtime_intrinsic_present(node.otherwise, decl, name);
-                    } else if constexpr (std::is_same_v<T, gir::HarnessEval> || std::is_same_v<T, gir::Construct>) {
-                        return std::ranges::any_of(node.arguments, [&](const gir::Argument &argument) {
-                            return runtime_intrinsic_present(argument.value, decl, name);
-                        });
-                    }
-                    return false;
-                },
-                expression.node);
+            if (const auto *call = std::get_if<gir::Call>(&expression.node)) {
+                const gir::Value     &callee    = planned_value(call->callee, expression.range);
+                const gir::Reference *reference = std::get_if<gir::Reference>(&callee.node);
+                return reference != nullptr && reference->kind == gir::ReferenceKind::Intrinsic && reference->registry_name == name;
+            }
+            const auto *binary = std::get_if<gir::Binary>(&expression.node);
+            return binary != nullptr && binary->op == ir::hir::BinaryOp::And &&
+                   (runtime_top_level_selector_present(binary->lhs, decl, name) ||
+                    runtime_top_level_selector_present(binary->rhs, decl, name));
         }
 
         void Emitter::add_all_runtime_parameters(gir::CallableId decl, RuntimeInfo &info) {
@@ -3966,9 +3932,9 @@ namespace hgl::codegen
                         if (node.init.valid()) { check_runtime_expr(node.init, decl, valid); }
                     } else if constexpr (std::is_same_v<T, gir::Activation>) {
                         if (!allow_when) { backend(statement.range, "a 'when' block must be at function top level"); }
-                        const bool has_valid = node.condition.valid() &&
-                                               (runtime_intrinsic_present(node.condition, decl, "valid") ||
-                                                runtime_intrinsic_present(node.condition, decl, "all_valid"));
+                        const bool has_valid =
+                            node.condition.valid() && (runtime_top_level_selector_present(node.condition, decl, "valid") ||
+                                                       runtime_top_level_selector_present(node.condition, decl, "all_valid"));
                         RuntimeValidSet body_valid = has_valid ? valid : add_all_runtime_valid(decl, valid);
                         if (node.condition.valid()) { body_valid = runtime_true_valid(node.condition, decl, body_valid); }
                         check_runtime_block(node.block, decl, body_valid);
@@ -4092,7 +4058,7 @@ namespace hgl::codegen
                             (node.kind == gir::LifecycleKind::Stop ? info.stop_blocks : info.start_blocks).push_back(node.block);
                         } else if constexpr (std::is_same_v<T, gir::Activation>) {
                             info.has_when = true;
-                            if (!node.condition.valid() || !runtime_intrinsic_present(node.condition, decl, "modified")) {
+                            if (!node.condition.valid() || !runtime_top_level_selector_present(node.condition, decl, "modified")) {
                                 add_all_runtime_parameters(decl, info);
                             } else {
                                 collect_runtime_activation(node.condition, decl, info);

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -475,12 +475,14 @@ namespace hgl::ir
 
             void check_declaration(DeclarationId id) {
                 if (!id.valid()) { return; }
-                const ConstraintId previous_requirements = active_requirements_;
-                const ConstraintId previous_inherited    = inherited_requirements_;
-                const NativePhase  previous_native_phase = active_native_phase_;
-                active_requirements_                     = {};
-                inherited_requirements_                  = {};
+                const ConstraintId previous_requirements   = active_requirements_;
+                const ConstraintId previous_inherited      = inherited_requirements_;
+                const NativePhase  previous_native_phase   = active_native_phase_;
+                const bool         previous_when_condition = active_when_condition_;
+                active_requirements_                       = {};
+                inherited_requirements_                    = {};
                 inherited_substitution_.reset();
+                active_when_condition_   = false;
                 Declaration &declaration = module_.declarations[id.value];
                 std::visit(
                     [&](auto &node) {
@@ -543,6 +545,7 @@ namespace hgl::ir
                 active_requirements_    = previous_requirements;
                 inherited_requirements_ = previous_inherited;
                 active_native_phase_    = previous_native_phase;
+                active_when_condition_  = previous_when_condition;
                 inherited_substitution_.reset();
             }
 
@@ -2281,8 +2284,11 @@ namespace hgl::ir
                 std::vector<ExprId> args;
                 for (const Argument &argument : call.arguments) { args.push_back(argument.value); }
                 if (name == "valid" || name == "modified" || name == "all_valid") {
-                    if (args.empty() && !runtime_owner(expression.owner)) {
-                        type_error(expression.range, "zero-argument '" + name + "' is only valid in a runtime function");
+                    if (args.empty() && name == "all_valid") {
+                        type_error(expression.range, "'all_valid' takes at least one argument");
+                    } else if (args.empty() && (!runtime_owner(expression.owner) || !active_when_condition_)) {
+                        type_error(expression.range,
+                                   "zero-argument '" + name + "' is only valid in a function-level 'when' condition");
                     }
                     for (ExprId argument : args) { (void)check_expr(argument); }
                     expression.type = scalar(ScalarType::Bool);
@@ -2444,7 +2450,10 @@ namespace hgl::ir
                             statement.effects    = module_.block(node.block).effects;
                         } else if constexpr (std::is_same_v<T, WhenStmt>) {
                             if (node.condition.valid()) {
-                                Expr &condition = check_expr(node.condition, scalar(ScalarType::Bool));
+                                const bool previous_when_condition = active_when_condition_;
+                                active_when_condition_             = true;
+                                Expr &condition                    = check_expr(node.condition, scalar(ScalarType::Bool));
+                                active_when_condition_             = previous_when_condition;
                                 require_assignable(scalar(ScalarType::Bool), condition, "when condition");
                                 statement.effects = condition.effects;
                             }
@@ -2567,6 +2576,7 @@ namespace hgl::ir
             std::unordered_set<std::uint64_t>          checked_type_applications_{};
             TypeId                                     void_type_{};
             NativePhase                                active_native_phase_{NativePhase::Wiring};
+            bool                                       active_when_condition_{false};
             ConstraintId                               active_requirements_{};
             ConstraintId                               inherited_requirements_{};
             std::optional<detail::GenericSubstitution> inherited_substitution_{};

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -172,6 +172,20 @@ unsupported, not added here as a supported loop contract.
 are also deferred. The proposed predicate-to-switch conversion is not an
 agreed contract and has no corpus example; further loop design is paused.
 
+## Runtime handler defaults
+
+[when-defaults.hgl](../examples/when-defaults.hgl) exercises the implemented
+relationship between explicit, empty, and omitted handler selectors.
+`modified()` means any temporal parameter was modified and `valid()` means
+every temporal parameter is top-level valid. Omitting either selector supplies
+that default, making `when { ... }` equivalent to
+`when modified() && valid() { ... }`.
+
+The example is checked, compiled as a scripted native module, and evaluated by
+`hgl test`. Focused emitter tests also prove that selectors nested in residual
+Boolean expressions do not suppress missing top-level defaults and that empty
+selector calls outside a handler fail closed.
+
 ## Compiler status
 
 The smallest temporal graph conditional—an explicit two-branch expression with

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -1989,6 +1989,61 @@ export fn default_activation(a: f64, b: f64) -> f64 {
     CHECK_FALSE(unit.diagnostics.has_errors());
 }
 
+TEST_CASE("emit-cpp recognizes only top-level handler selectors as explicit policy", "[codegen][runtime]") {
+    Unit       unit{R"(
+module t
+
+export fn residual(a: f64, b: f64) -> f64 {
+    when modified(a) || valid(a) {
+        return a + b
+    }
+}
+)"};
+    const auto emitted = unit.emit();
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE(emitted);
+
+    // Both selector calls are residual under `||`; neither suppresses the
+    // corresponding all-input default. The default activation also keeps both
+    // input selectors active in the generated node contract.
+    CHECK(contains(emitted->header, "(a.modified() || b.modified())"));
+    CHECK(contains(emitted->header, "(a.valid() && b.valid())"));
+    CHECK(contains(emitted->header, "((a.modified()) || (a.valid()))"));
+    CHECK_FALSE(contains(emitted->header, "hgraph::InputActivity::Passive"));
+    CHECK_FALSE(unit.diagnostics.has_errors());
+}
+
+TEST_CASE("empty runtime metadata calls are contextual handler selectors", "[codegen][runtime]") {
+    SECTION("modified and valid are rejected outside a when condition") {
+        Unit unit{R"(
+module t
+
+export fn invalid(value: f64) -> f64 {
+    inject out
+    if valid() || modified() {
+        out = value
+    }
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Type, "zero-argument 'valid' is only valid in a function-level 'when' condition"));
+        CHECK(unit.has(Category::Type, "zero-argument 'modified' is only valid in a function-level 'when' condition"));
+    }
+    SECTION("all_valid always names at least one endpoint") {
+        Unit unit{R"(
+module t
+
+export fn invalid(value: f64) -> f64 {
+    when modified(value) && all_valid() {
+        return value
+    }
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Type, "'all_valid' takes at least one argument"));
+    }
+}
+
 TEST_CASE("emit-cpp requires validity to dominate runtime payload reads", "[codegen][runtime]") {
     SECTION("a when and nested if establish validity for their bodies") {
         Unit unit{R"(


### PR DESCRIPTION
## Summary

- recover the agreed `when` activation and validity defaults across the language design, user, and developer documentation
- make zero-argument `modified()` and `valid()` contextual handler selectors and reject them elsewhere, while keeping `all_valid()` non-empty
- recognize only selectors in the top-level `&&` conjunction as explicit policy so residual expressions cannot accidentally suppress defaults
- add an executable `when-defaults.hgl` fixture and focused generated-code/diagnostic coverage

This PR is stacked on #798. It deliberately excludes the unresolved standard-library and design-input corpus; that material will be reconciled in a separate standalone PR after this resolved specification slice merges.

## Validation

- `hgl_codegen_tests '[codegen][runtime]'`: 82 assertions in 7 test cases
- `hgl test language/examples/when-defaults.hgl`: 3 tests, 0 failed
- fresh native C++ acceptance preset: 1745/1745 tests passed
- stable-ABI wheel installed into a fresh Python 3.14 environment: 3323 passed, 10 skipped
