### PR TITLE
test(web): drain buffered TLS records in H2 loopback

### DIFF
--- a/extensions/web/tests/test_h2_loopback.cpp
+++ b/extensions/web/tests/test_h2_loopback.cpp
@@ -353,7 +353,12 @@ private:
     boost::system::error_code ec;
     const std::size_t available = stream_.next_layer().available(ec);
     require(!ec, "raw client socket query failed: " + ec.message());
-    if (available == 0 && SSL_pending(stream_.native_handle()) == 0) {
+    // SSL_pending() sees only processed application bytes. OpenSSL may have
+    // already drained a complete later TLS record from the socket while
+    // leaving it unprocessed, in which case socket::available() and
+    // SSL_pending() are both zero and this polling client would never call
+    // SSL_read() again. SSL_has_pending() includes those buffered records.
+    if (available == 0 && SSL_has_pending(stream_.native_handle()) == 0) {
       return false;
     }
     std::array<char, 16 * 1024> buffer{};


### PR DESCRIPTION
## Summary

- fix the raw HTTP/2 loopback client polling gate used by the native web tests
- treat unprocessed TLS records already buffered by OpenSSL as readable input
- retain the existing timeout and PING round-trip synchronization

## Root cause

The native CI failure on the merged HGL change timed out waiting for the raw-client PING acknowledgement. The test gated `SSL_read()` on both socket availability and `SSL_pending()`. OpenSSL can already have drained a later complete TLS record from the socket without processing it; in that state both checks report zero, so the polling helper never reads again. `SSL_has_pending()` covers processed and unprocessed buffered records.

This changes only the test helper and does not lengthen the timeout.

## Validation

- HTTP/2 loopback executable passed once and 128 additional runs at four-way concurrency
- fresh native configure, clean build, and full CTest suite: 1,745 passed
- ABI3 wheel built with Python 3.12, installed with all test dependencies into a fresh Python 3.14 environment using a clean package cache
- full non-WIP Python compatibility suite: 3,323 passed, 10 skipped
- `git diff --check`