### PR TITLE
Elide an unchanged date component from day_of_month, month_of_year and year

### DIFF
--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -654,6 +654,16 @@ The following are intentional unless separately re-opened:
   TSS/TSD delta that nets to no change does not tick. Explicit writes are
   unaffected and match upstream exactly: a python node returning the same
   scalar each evaluation ticks each time, as do repeated TSD entry writes.
+
+  Extended 2026-09-09 (issue #822) to a projection of a scalar value, where
+  the argument runs the other way. ``day_of_month``, ``month_of_year`` and
+  ``year`` re-ticked an unchanged component while **released hgraph elided**
+  it, because released hgraph spells each of them ``explode(ts)[n]`` over an
+  explode that publishes only the components that changed. So here the ruling
+  and upstream parity agree, and this runtime was on the wrong side of both.
+  The shared helper is ``stdlib::set_if_changed``
+  (``operators/impl/output_elision.h``); an operator opts in, and only where
+  it projects part of a larger value.
 - **Reduce over partially-valid mapped keys** (issue #95; design record:
   :doc:`nested_graphs`): reduction is over currently-valid values. A keyed
   value can be invalid while its slot is live — a map child existing before

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -664,6 +664,15 @@ The following are intentional unless separately re-opened:
   The shared helper is ``stdlib::set_if_changed``
   (``operators/impl/output_elision.h``); an operator opts in, and only where
   it projects part of a larger value.
+
+  ``day`` and ``month`` are this runtime's own names for the ``day_of_month``
+  and ``month_of_year`` implementations and elide with them. Neither name
+  exists in released hgraph, so no parity constraint applies to it; what would
+  be incoherent is one spelling of a single implementation ticking where the
+  other does not. Upstream's attribute spelling is ``getattr_(ts, "day")``,
+  which does **not** elide -- but that overload is not registered here at all,
+  so there is no such path to diverge. If it is added, it needs its own
+  implementation and must re-emit.
 - **Reduce over partially-valid mapped keys** (issue #95; design record:
   :doc:`nested_graphs`): reduction is over currently-valid values. A keyed
   value can be invalid while its slot is live — a map child existing before

--- a/include/hgraph/lib/std/operators/impl/container_impl.h
+++ b/include/hgraph/lib/std/operators/impl/container_impl.h
@@ -5,6 +5,7 @@
 #include <hgraph/lib/std/operators/conversion.h>
 #include <hgraph/lib/std/value_util.h>
 #include <hgraph/lib/std/operators/impl/collection_input_semantics.h>
+#include <hgraph/lib/std/operators/impl/output_elision.h>
 #include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/operator_dispatch.h>
 #include <hgraph/types/operator_type_resolution.h>
@@ -89,12 +90,10 @@ normalize_item_index(Int index, std::size_t size, std::string_view subject) {
   return static_cast<std::size_t>(normalized);
 }
 
-template <typename T>
-void set_if_changed(const Out<TS<T>> &out, const T &value) {
-  if (!out.valid() || out.value().template checked_as<T>() != value) {
-    out.set(value);
-  }
-}
+// The no-change elision helper now lives beside the ruling it implements, so
+// the temporal component accessors can apply the same rule without a second
+// copy. The call sites below are unchanged.
+using stdlib::set_if_changed;
 
 [[nodiscard]] inline const TSValueTypeMetaData *
 direct_tsb_schema(const WiringArg &arg) noexcept {

--- a/include/hgraph/lib/std/operators/impl/output_elision.h
+++ b/include/hgraph/lib/std/operators/impl/output_elision.h
@@ -1,0 +1,33 @@
+#ifndef HGRAPH_LIB_STD_OPERATORS_IMPL_OUTPUT_ELISION_H
+#define HGRAPH_LIB_STD_OPERATORS_IMPL_OUTPUT_ELISION_H
+
+#include <hgraph/types/static_node.h>
+#include <hgraph/types/static_schema.h>
+
+namespace hgraph::stdlib
+{
+    /**
+     * Publish ``value`` only when it differs from what the output already
+     * holds.
+     *
+     * An operator opts in, and most should not. ``out.set`` always ticks, and
+     * that is right for an operator whose result is its own value: a
+     * recomputed value is news even when it is equal, and comparing costs a
+     * read the operator would otherwise not make. Explicit writes tick
+     * unconditionally by ruling (roadmap.rst, 2026-07-17).
+     *
+     * Reach for this where the operator PROJECTS part of a larger value, so an
+     * unchanged projection is genuinely not an event: a collection's size
+     * across a replaced element, a date's month across two days of the same
+     * month. Both directions of the parity argument land here -- the
+     * no-change-means-no-tick ruling covers the collection cases, and the
+     * released implementation elides the date components by building them on
+     * an ``explode`` that publishes only what changed.
+     */
+    template <typename T> void set_if_changed(const Out<TS<T>> &out, const T &value)
+    {
+        if (!out.valid() || out.value().template checked_as<T>() != value) { out.set(value); }
+    }
+}  // namespace hgraph::stdlib
+
+#endif  // HGRAPH_LIB_STD_OPERATORS_IMPL_OUTPUT_ELISION_H

--- a/include/hgraph/lib/std/operators/impl/temporal_impl.h
+++ b/include/hgraph/lib/std/operators/impl/temporal_impl.h
@@ -2,6 +2,7 @@
 #define HGRAPH_LIB_STD_OPERATORS_IMPL_TEMPORAL_IMPL_H
 
 #include <hgraph/lib/std/operators/temporal.h>
+#include <hgraph/lib/std/operators/impl/output_elision.h>
 
 #include <fmt/format.h>
 #include <hgraph/runtime/node_scheduler.h>
@@ -22,7 +23,11 @@ namespace hgraph::stdlib
     {
         static void eval(In<"ts", TS<Date>> ts, Out<TS<Int>> out)
         {
-            out.set(static_cast<Int>(static_cast<unsigned>(ts.value().day())));
+            // Released hgraph spells this ``explode(ts)[2]`` over an explode
+            // that publishes only the components that changed, so an unchanged
+            // day is not an event there. Elide it here too: this runtime's
+            // own no-change ruling (2026-07-17, roadmap.rst) says the same.
+            set_if_changed(out, static_cast<Int>(static_cast<unsigned>(ts.value().day())));
         }
     };
 
@@ -657,7 +662,11 @@ namespace hgraph::stdlib
     {
         static void eval(In<"ts", TS<Date>> ts, Out<TS<Int>> out)
         {
-            out.set(static_cast<Int>(static_cast<unsigned>(ts.value().month())));
+            // Released hgraph spells this ``explode(ts)[1]`` over an explode
+            // that publishes only the components that changed, so an unchanged
+            // month is not an event there. Elide it here too: this runtime's
+            // own no-change ruling (2026-07-17, roadmap.rst) says the same.
+            set_if_changed(out, static_cast<Int>(static_cast<unsigned>(ts.value().month())));
         }
     };
 
@@ -665,7 +674,11 @@ namespace hgraph::stdlib
     {
         static void eval(In<"ts", TS<Date>> ts, Out<TS<Int>> out)
         {
-            out.set(static_cast<Int>(static_cast<int>(ts.value().year())));
+            // Released hgraph spells this ``explode(ts)[0]`` over an explode
+            // that publishes only the components that changed, so an unchanged
+            // year is not an event there. Elide it here too: this runtime's
+            // own no-change ruling (2026-07-17, roadmap.rst) says the same.
+            set_if_changed(out, static_cast<Int>(static_cast<int>(ts.value().year())));
         }
     };
 
@@ -674,13 +687,16 @@ namespace hgraph::stdlib
         static void eval(In<"ts", TS<Date>> ts, Out<TSL<TS<Int>, 3>> out)
         {
             const Date value = ts.value();
-            set_if_changed(out, 0, static_cast<Int>(static_cast<int>(value.year())));
-            set_if_changed(out, 1, static_cast<Int>(static_cast<unsigned>(value.month())));
-            set_if_changed(out, 2, static_cast<Int>(static_cast<unsigned>(value.day())));
+            set_child_if_changed(out, 0, static_cast<Int>(static_cast<int>(value.year())));
+            set_child_if_changed(out, 1, static_cast<Int>(static_cast<unsigned>(value.month())));
+            set_child_if_changed(out, 2, static_cast<Int>(static_cast<unsigned>(value.day())));
         }
 
       private:
-        static void set_if_changed(const Out<TSL<TS<Int>, 3>> &out, std::size_t index, Int value)
+        /** The same rule as ``set_if_changed`` at a TSL child, which is where
+            the three component accessors above get their behaviour from in the
+            released implementation. */
+        static void set_child_if_changed(const Out<TSL<TS<Int>, 3>> &out, std::size_t index, Int value)
         {
             auto child = out[index];
             if (!child.valid() || child.value().template checked_as<Int>() != value) { child.set(value); }

--- a/python/tests/ported/_operators/test_date_operators.py
+++ b/python/tests/ported/_operators/test_date_operators.py
@@ -1,7 +1,9 @@
 from datetime import date, time, datetime, timezone
 from zoneinfo import ZoneInfo
 
-from hgraph import default, explode, graph, TS
+from hgraph import (
+    TS, day, day_of_month, default, explode, graph, month, month_of_year, year,
+)
 from hgraph.test import eval_node
 
 
@@ -93,3 +95,34 @@ def test_add_date_time_tz_tzname():
                'SAST',
            ]
 
+
+
+def test_date_components_elide_an_unchanged_value():
+    """Released hgraph spells these ``explode(ts)[n]`` over an explode that
+    publishes only what changed, so an unchanged component is not an event
+    there (issue #822). Verified against 0.5.41: ``day_of_month`` over these
+    dates gives ``[21, None, 22]`` and ``month_of_year`` gives ``[1, 2, None]``.
+    """
+    dates = [date(2024, 1, 21), date(2024, 2, 21), date(2024, 2, 22)]
+
+    assert eval_node(day_of_month, dates) == [21, None, 22]
+    assert eval_node(month_of_year, dates) == [1, 2, None]
+    assert eval_node(year, dates) == [2024, None, None]
+
+    # explode, which the released implementation projects these from, agreed
+    # already and must keep agreeing.
+    assert eval_node(explode, dates) == [{0: 2024, 1: 1, 2: 21}, {1: 2}, {2: 22}]
+
+
+def test_date_attribute_aliases_follow_their_component_operator():
+    """``day`` and ``month`` are this runtime's names for the same
+    implementations, so they elide identically.
+
+    Neither exists in released hgraph, so no parity constraint applies to the
+    names themselves; what would be incoherent is one spelling of a single
+    implementation ticking where the other does not.
+    """
+    dates = [date(2024, 1, 21), date(2024, 2, 21), date(2024, 2, 22)]
+
+    assert eval_node(day, dates) == eval_node(day_of_month, dates)
+    assert eval_node(month, dates) == eval_node(month_of_year, dates)

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -3501,6 +3501,30 @@ TEST_CASE("std operators: date component operators extract day month year and ex
                                list_delta<TS<Int>>({{0, 2025}})));
 }
 
+TEST_CASE("std operators: date component operators elide an unchanged component")
+{
+    stdlib::register_standard_operators();
+
+    // Released hgraph spells each of these ``explode(ts)[n]`` over an explode
+    // that publishes only the components that changed, so a date moving from
+    // 2024-01-21 to 2024-02-21 is not a day event. This runtime's own
+    // no-change ruling (2026-07-17, roadmap.rst) says the same, and these
+    // three were the only operators found on the wrong side of it.
+    const auto dates = [] {
+        return values<Date>(ymd(2024, 1, 21), ymd(2024, 2, 21), ymd(2024, 2, 22));
+    };
+    CHECK_OUTPUT(eval_node<stdlib::day_of_month>(dates()), values<Int>(21, none, 22));
+    CHECK_OUTPUT(eval_node<stdlib::month_of_year>(dates()), values<Int>(1, 2, none));
+    CHECK_OUTPUT(eval_node<stdlib::year>(dates()), values<Int>(2024, none, none));
+
+    // explode, which the released implementation projects these from, already
+    // agreed and must keep agreeing.
+    CHECK_OUTPUT(eval_node<stdlib::explode>(dates()),
+                 values<Value>(list_delta<TS<Int>>({{0, 2024}, {1, 1}, {2, 21}}),
+                               list_delta<TS<Int>>({{1, 2}}),
+                               list_delta<TS<Int>>({{2, 22}})));
+}
+
 TEST_CASE("std operators: time-series property operators report valid modified and last-modified")
 {
     stdlib::register_standard_operators();


### PR DESCRIPTION
Closes #822. Decided **fix** on #810 item 6.3.

## What diverged

Over the dates `2024-01-21`, `2024-02-21`, `2024-02-22`:

| | `day_of_month` |
|---|---|
| reference 0.5.41 | `[21, null, 22]` |
| before this PR | `[21, 21, 22]` |

`month_of_year` and `year` behave identically. This runtime re-ticked a
component that had not changed.

## Why upstream elides, which is not a rule stated anywhere

Worth recording, because I could not have guessed it and it changes what the
right fix is. Released hgraph does not implement these three as compute nodes
at all. It implements them as **graphs over `explode`**
(`_impl/_operators/_date_operators.py:28`):

```python
@graph(overloads=day_of_month)
def day_of_month_impl(ts: TS[date]) -> TS[int]:
    return explode(ts)[2]
```

and its `explode` compares against its own previous output, publishing only the
components that changed. So upstream's elision is a consequence of that
composition, not a declared contract for the accessors.

This runtime implements each accessor directly. Its own `explode` already
carried the same comparison — which is why `explode` **agreed** with upstream
while all three projections of it did not.

## Both arguments point the same way

Matching upstream says elide. So does this runtime's own
no-change-means-no-tick ruling (2026-07-17), which until now was scoped to
values derived from a *collection*. `roadmap.rst` records the extension, and
records the part that makes this entry unusual: every other case in that family
is one where **we** elide and upstream re-ticks. Here upstream is the eliding
side and we were on the wrong side of our own ruling.

## One helper, not a third copy

The comparison was already written twice — generically over a scalar output in
`container_impl.h`, and again privately for a TSL child inside
`explode_date_impl`. Rather than add a third, it moves to
`operators/impl/output_elision.h` as `stdlib::set_if_changed`, carrying the
guidance that an operator opts in and only where it **projects part of a larger
value**. Most operators should keep ticking unconditionally: a recomputed value
is news even when equal, and comparing costs a read.

`container_impl.h`'s thirteen call sites are unchanged (a using-declaration).
`explode`'s private helper keeps its TSL-child shape under the clearer name
`set_child_if_changed`.

## Scope

Only these three accessors diverged, and only these three exist upstream as
projections of `explode`. The other component accessors this runtime adds
(`hour`, `minute`, `weekday` and friends) have no upstream counterpart and so
no parity constraint; I have deliberately left them ticking unconditionally
rather than change behaviour no evidence asks me to change.

## Testing

* New case pinning all three accessors over a date whose day, then month, then
  year hold steady in turn, plus `explode` over the same dates so the operator
  they are projections of keeps agreeing.
* Full C++ suite → **1727 cases, 257496 assertions, all passed**.
* The corpus recipe needs the `temporal_component` template from #808 and
  follows on the coverage lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
