### PR TITLE
Make log_ emit: attach the stdout handler and stamp the engine time

### DIFF
--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -756,6 +756,14 @@ Platform notes
   forwards to ``GraphConfiguration.graph_logger``. Use ``caplog`` for mixed
   native/Python graph logs. ``_hgraph.reset_logger()`` remains only for tests
   that exercise the process-default C++ logger directly.
+- **Where ``log_`` records go**: ``GraphConfiguration`` resolves the ``hgraph``
+  logger and, when ``hasHandlers()`` is false, attaches a stdout handler and
+  sets DEBUG. Without it a ``logging.Logger`` drops everything below WARNING
+  and ``log_`` is a silent no-op, which it was until issue #813. The test is
+  ``hasHandlers()`` rather than ``handlers``, so an application that
+  configured logging through the root keeps its own destination and gets no
+  duplicate; released hgraph tests ``handlers`` and would duplicate there.
+  ``eval_node`` passes the same logger, having previously passed none.
 - **Windows DLLs**: there is no rpath on Windows; the build copies Arrow (and
   pyarrow-support) DLLs beside the extension so ``import _hgraph`` works
   before ``pyarrow`` is imported (``python/CMakeLists.txt``).
@@ -773,7 +781,7 @@ Symptom                                               Intentional cause
 Leak reports for registries / records at exit         Immortality rule: registries outlive everything.
 ``nb::set_leak_warnings(false)``                      Same — silences the intentional immortal records.
 Operator missing from ``dir(hgraph)``                 PEP 562 lazy surface; it appears on first access.
-Missing Python graph ``log_`` output                  Capture/configure ``GraphConfiguration.graph_logger``.
+``log_`` output goes to stdout by default              ``GraphConfiguration`` installs a stdout handler when nothing else would receive the records.
 Python node gets ``None`` for an input                Unwired optional input: the null-source contract.
 ``frozenset`` set-delta replaced the whole TSS        Full-value vs ``_SetDelta`` class-identity shaping.
 Ugly ``__pyop__…_1f3a`` registry names                Durable registration IDs isolate overload families.

--- a/include/hgraph/lib/std/operators/impl/io_impl.h
+++ b/include/hgraph/lib/std/operators/impl/io_impl.h
@@ -2,12 +2,14 @@
 #define HGRAPH_LIB_STD_OPERATORS_IMPL_IO_IMPL_H
 
 #include <hgraph/lib/std/operators/io.h>        // debug_print / null_sink / record / replay / log_
+#include <hgraph/runtime/evaluation_clock.h>
 #include <hgraph/runtime/logger.h>
 #include <hgraph/types/operator_dispatch.h>
 #include <hgraph/types/primitive_types.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/static_schema.h>
 
+#include <fmt/chrono.h>
 #include <fmt/core.h>
 
 #include <optional>
@@ -112,13 +114,23 @@ namespace hgraph::stdlib
     /** ``__log_sink``: formats the packed arguments and logs through the
         LOGGER injectable. Native levels use the spdlog 0..5 scale; Python's
         standard 10..50 levels are normalized onto the same scale. */
+    namespace io_impl_detail
+    {
+        /** The engine time as released hgraph renders it in a log record:
+            ``1970-01-01 00:00:00.000001``, microsecond precision, no zone. */
+        [[nodiscard]] inline Str format_engine_time(DateTime when)
+        {
+            return fmt::format("{:%Y-%m-%d %H:%M:%S}", when);
+        }
+    }  // namespace io_impl_detail
+
     struct log_sink_impl
     {
         static constexpr auto name = "log_sink";
 
         static void eval(In<"fmt", TS<Str>> format, In<"args", TsVar<"A">, InputValidity::Unchecked> args,
                          Scalar<"level", Int> level, Scalar<"sample_count", Int> sample_count,
-                         State<Int> ticks, LoggerView log)
+                         State<Int> ticks, LoggerView log, EvaluationClockView clock)
         {
             const Int seen = ticks.get() + 1;
             ticks.set(seen);
@@ -129,7 +141,15 @@ namespace hgraph::stdlib
                                                   ? raw_level / 10
                                                   : raw_level);
             if (!log.should_log(lvl)) { return; }
-            log.log(lvl, io_impl_detail::format_bundle(format.value(), args.base()));
+            // Released hgraph's sink is
+            // ``logger.log(level, "[%s] %s", ts.last_modified_time, ts.value)``
+            // (_impl/_operators/_graph_operators.py). The engine time is part
+            // of the record, not of the handler's format: a simulation log is
+            // unreadable without the tick it belongs to, and wall-clock
+            // timestamps from the handler are not that. The node runs only on
+            // a tick, so the evaluation time is the message's modified time.
+            log.log(lvl, fmt::format("[{}] {}", io_impl_detail::format_engine_time(clock.evaluation_time()),
+                                     io_impl_detail::format_bundle(format.value(), args.base())));
         }
     };
 

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -143,26 +143,37 @@ class GraphConfiguration:
 
 
 def _default_graph_logger():
-    """The ``hgraph`` logger, with a stdout handler when it has none.
+    """The ``hgraph`` logger, with a stdout handler when nothing would receive
+    its records.
 
-    ``log_`` exists to produce output, and a ``logging.Logger`` with no handler
-    produces none below WARNING, so without this the operator is a silent
-    no-op. Released hgraph attaches the same handler from the same layer, its
-    own ``GraphConfiguration`` default (``_runtime/_graph_runner.py``
-    ``_default_logger``), which settles where this belongs: configuration, not
-    the runtime. An embedding application that configures its own logging is
-    not overridden -- the handler is attached only to a logger this default
-    created, and only when that logger has none.
+    ``log_`` exists to produce output, and a ``logging.Logger`` whose chain has
+    no handler produces none below WARNING, so without this the operator is a
+    silent no-op. Released hgraph attaches the same handler from the same
+    layer, its own ``GraphConfiguration`` default
+    (``_runtime/_graph_runner.py`` ``_default_logger``), which settles where
+    this belongs: configuration, not the runtime.
+
+    The test is ``hasHandlers()``, not ``handlers``, and that is deliberately
+    stricter than the released implementation. An application that configured
+    logging through the ROOT logger -- ``basicConfig()``, ``dictConfig()`` --
+    has an effective destination for these records while ``hgraph`` itself
+    carries no handler. Adding one there would emit every record twice, once
+    to stdout and once to the application's own handler, and leak graph
+    records into a destination the application did not choose for them.
+
+    Nothing is overridden either way: the handler is attached only when no
+    destination exists, and only to a logger this default resolved.
     """
     logger = logging.getLogger("hgraph")
-    if not logger.handlers:
+    if not logger.hasHandlers():
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(
             logging.Formatter("%(asctime)s [%(name)s][%(levelname)s] %(message)s"))
         logger.addHandler(handler)
         # A bare logger inherits the root's WARNING, which drops log_'s INFO
         # records before any handler sees them. The released implementation
-        # sets DEBUG here for the same reason.
+        # sets DEBUG here for the same reason. Left alone when the application
+        # supplied the destination: its level is its choice.
         logger.setLevel(logging.DEBUG)
     return logger
 

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -3,6 +3,7 @@ eval_node test harness."""
 import functools
 import inspect
 import logging
+import sys
 import time
 from datetime import timedelta
 
@@ -117,7 +118,8 @@ class GraphConfiguration:
         self.life_cycle_observers = tuple(life_cycle_observers)
         self.trace_wiring = trace_wiring
         self.wiring_observers = tuple(wiring_observers)
-        self.graph_logger = graph_logger or logging.getLogger("hgraph")
+        self.graph_logger = (
+            graph_logger if graph_logger is not None else _default_graph_logger())
         self.trace_back_depth = trace_back_depth
         self.capture_values = capture_values
         self.default_log_level = default_log_level
@@ -138,6 +140,31 @@ class GraphConfiguration:
             raise TypeError("GraphConfiguration.graph_logger must be a logging.Logger-like object")
         if self.logger_formatter is not None and not callable(self.logger_formatter):
             raise TypeError("GraphConfiguration.logger_formatter must be callable or None")
+
+
+def _default_graph_logger():
+    """The ``hgraph`` logger, with a stdout handler when it has none.
+
+    ``log_`` exists to produce output, and a ``logging.Logger`` with no handler
+    produces none below WARNING, so without this the operator is a silent
+    no-op. Released hgraph attaches the same handler from the same layer, its
+    own ``GraphConfiguration`` default (``_runtime/_graph_runner.py``
+    ``_default_logger``), which settles where this belongs: configuration, not
+    the runtime. An embedding application that configures its own logging is
+    not overridden -- the handler is attached only to a logger this default
+    created, and only when that logger has none.
+    """
+    logger = logging.getLogger("hgraph")
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(name)s][%(levelname)s] %(message)s"))
+        logger.addHandler(handler)
+        # A bare logger inherits the root's WARNING, which drops log_'s INFO
+        # records before any handler sees them. The released implementation
+        # sets DEBUG here for the same reason.
+        logger.setLevel(logging.DEBUG)
+    return logger
 
 
 def _make_evaluation_trace(trace):
@@ -825,6 +852,7 @@ def eval_node(node, *args, output_type=None, resolution_dict=None,
         if out is None:
             run = w.run(start_time=__start_time__, end_time=__end_time__,
                         realtime=realtime, trace=trace,
+                        logger=_default_graph_logger(),
                         observers=tuple(__observers__ or ()))
             return None
         # hgraph parity: a REF graph output records its DEREFERENCED values,
@@ -837,6 +865,7 @@ def eval_node(node, *args, output_type=None, resolution_dict=None,
         w.wire("__harness_record", (record_port, "eval_node::out"), record_kwargs)
         run = w.run(start_time=__start_time__, end_time=__end_time__,
                     realtime=realtime, trace=trace,
+                    logger=_default_graph_logger(),
                     observers=tuple(__observers__ or ()))
     finally:
         for line in w.wiring_trace_lines():

--- a/python/tests/test_graph_logging.py
+++ b/python/tests/test_graph_logging.py
@@ -27,10 +27,20 @@ def hgraph_logger_restored():
     logger.setLevel(level)
 
 
-def test_default_logger_gains_a_stdout_handler(hgraph_logger_restored):
+@pytest.fixture
+def root_logger_restored():
+    """Restore the root logger's handlers around a test."""
+    root = logging.getLogger()
+    handlers = list(root.handlers)
+    yield root
+    root.handlers = handlers
+
+
+def test_default_logger_gains_a_stdout_handler(hgraph_logger_restored, root_logger_restored):
     logger = hgraph_logger_restored
     logger.handlers = []
     logger.setLevel(logging.NOTSET)
+    root_logger_restored.handlers = []
 
     resolved = _default_graph_logger()
 
@@ -39,6 +49,29 @@ def test_default_logger_gains_a_stdout_handler(hgraph_logger_restored):
             if isinstance(h, logging.StreamHandler) and h.stream is sys.stdout]
     # A bare logger inherits the root's WARNING and would drop log_'s INFO.
     assert logger.level == logging.DEBUG
+
+
+def test_default_logger_defers_to_a_handler_on_the_root(
+    hgraph_logger_restored, root_logger_restored
+):
+    """An application that configured logging through the root already has a
+    destination for these records.
+
+    Adding one here would emit every record twice, once to stdout and once to
+    the application's own handler, and leak graph records into a destination it
+    did not choose for them. This is stricter than released hgraph, which tests
+    ``logger.handlers`` and would duplicate.
+    """
+    logger = hgraph_logger_restored
+    logger.handlers = []
+    logger.setLevel(logging.CRITICAL)
+    root_logger_restored.handlers = [logging.NullHandler()]
+
+    _default_graph_logger()
+
+    assert logger.handlers == []
+    # Its level is the application's choice too.
+    assert logger.level == logging.CRITICAL
 
 
 def test_default_logger_does_not_displace_an_existing_handler(hgraph_logger_restored):

--- a/python/tests/test_graph_logging.py
+++ b/python/tests/test_graph_logging.py
@@ -1,0 +1,94 @@
+"""``log_`` must actually produce output.
+
+The operator exists to emit, and a ``logging.Logger`` with no handler emits
+nothing below WARNING, so a missing handler makes it a silent no-op rather than
+a failure. Released hgraph attaches a stdout handler from its own
+``GraphConfiguration`` default, which is what these tests pin.
+"""
+import logging
+import sys
+
+import pytest
+
+import hgraph as hg
+from hgraph.test import eval_node
+
+from hgraph._wiring._runner import _default_graph_logger
+
+
+@pytest.fixture
+def hgraph_logger_restored():
+    """Restore the process-wide ``hgraph`` logger around a test."""
+    logger = logging.getLogger("hgraph")
+    handlers = list(logger.handlers)
+    level = logger.level
+    yield logger
+    logger.handlers = handlers
+    logger.setLevel(level)
+
+
+def test_default_logger_gains_a_stdout_handler(hgraph_logger_restored):
+    logger = hgraph_logger_restored
+    logger.handlers = []
+    logger.setLevel(logging.NOTSET)
+
+    resolved = _default_graph_logger()
+
+    assert resolved is logger
+    assert [h for h in logger.handlers
+            if isinstance(h, logging.StreamHandler) and h.stream is sys.stdout]
+    # A bare logger inherits the root's WARNING and would drop log_'s INFO.
+    assert logger.level == logging.DEBUG
+
+
+def test_default_logger_does_not_displace_an_existing_handler(hgraph_logger_restored):
+    logger = hgraph_logger_restored
+    existing = logging.NullHandler()
+    logger.handlers = [existing]
+    logger.setLevel(logging.CRITICAL)
+
+    _default_graph_logger()
+
+    # An application that configured its own logging keeps it, level included.
+    assert logger.handlers == [existing]
+    assert logger.level == logging.CRITICAL
+
+
+def test_log_emits_a_record_per_tick(caplog):
+    @hg.graph
+    def g(ts: hg.TS[int]) -> None:
+        hg.log_("v={}", ts)
+
+    with caplog.at_level(logging.INFO, logger="hgraph"):
+        eval_node(g, [1, 2, 3])
+
+    messages = [r.getMessage() for r in caplog.records if r.name.startswith("hgraph")]
+    assert [m for m in messages if m.endswith("v=1")]
+    assert [m for m in messages if m.endswith("v=2")]
+    assert [m for m in messages if m.endswith("v=3")]
+
+
+def test_log_record_carries_the_engine_time(caplog):
+    # Released hgraph logs "[%s] %s" % (last_modified_time, value): the tick a
+    # record belongs to is part of the record, not of the handler's format.
+    @hg.graph
+    def g(ts: hg.TS[int]) -> None:
+        hg.log_("v={}", ts)
+
+    with caplog.at_level(logging.INFO, logger="hgraph"):
+        eval_node(g, [1])
+
+    messages = [r.getMessage() for r in caplog.records if r.getMessage().endswith("v=1")]
+    assert messages, "log_ produced no record"
+    assert messages[0].startswith("[1970-01-01 00:00:00.000001] ")
+
+
+def test_log_respects_its_level(caplog):
+    @hg.graph
+    def g(ts: hg.TS[int]) -> None:
+        hg.log_("quiet={}", ts, level=logging.DEBUG)
+
+    with caplog.at_level(logging.INFO, logger="hgraph"):
+        eval_node(g, [1])
+
+    assert not [r for r in caplog.records if "quiet" in r.getMessage()]

--- a/tests/cpp/test_logger.cpp
+++ b/tests/cpp/test_logger.cpp
@@ -344,6 +344,22 @@ TEST_CASE("logger: the log_ operator formats and logs through the injectable")
     CHECK_THAT(captured.joined(), Catch::Matchers::ContainsSubstring("observed 42"));
 }
 
+TEST_CASE("logger: log_ stamps the record with the engine time")
+{
+    stdlib::register_standard_operators();
+    CapturedLog captured;
+
+    // Released hgraph's sink is
+    // ``logger.log(level, "[%s] %s", ts.last_modified_time, ts.value)``, so the
+    // tick the record belongs to is part of the record, not of the handler's
+    // format. A simulation log without it cannot be read against the trace, and
+    // the handler's wall clock is not the same thing.
+    CHECK_OUTPUT(eval_node<LogOperatorGraph>(values<Int>(1, 2)), values<Int>(1, 2));
+    const std::string all = captured.joined();
+    CHECK_THAT(all, Catch::Matchers::ContainsSubstring("[1970-01-01 00:00:00.000001] observed 1"));
+    CHECK_THAT(all, Catch::Matchers::ContainsSubstring("[1970-01-01 00:00:00.000002] observed 2"));
+}
+
 TEST_CASE("logger: log_ skips formatting when the level is filtered out")
 {
     stdlib::register_standard_operators();


### PR DESCRIPTION
Closes #813. Decided **fix** on #810 item 1.3.

## Two causes, one per layer

`log_` produced nothing at all — not stdout, not stderr, not at
file-descriptor level. Its only purpose is output, so it was a silent no-op.

**No handler, and no level.** The native sink already routed through the Python
`hgraph` logger (`make_python_run_logger` defaults to it), but nothing ever gave
that logger a handler, and a `logging.Logger` with no handler drops everything
below WARNING. It also inherits the root's WARNING, so `log_`'s INFO records
were dropped twice over.

**`eval_node` had no logger at all.** This is the part I would have missed by
reading only the issue. `eval_node` never builds a `GraphConfiguration`; it
calls `Wiring.run` directly and passed no logger, so the native side fell back
to a bare `getLogger("hgraph")`. Fixing the configuration default alone left
`eval_node` — and therefore the parity harness and most of the test suite —
still silent. Both of its `run` calls now pass the configured logger.

## The open question on the issue, answered by the reference

The issue asked whether the handler belongs to the runtime or to
`GraphConfiguration`. Released hgraph attaches a stdout `StreamHandler` and sets
DEBUG from its own `GraphConfiguration` default
(`_runtime/_graph_runner.py::_default_logger`). Configuration, not runtime.

`_default_graph_logger` does the same, and **only where the logger was
defaulted**. An application that passes its own `graph_logger`, or that has
already configured the `hgraph` logger, is left alone — level included. That is
one step stricter than the reference, which guards only on handlers.

## The record lost its tick

Released hgraph's sink is

```python
logger.log(level, "[%s] %s", ts.last_modified_time, ts.value)
```

so the engine time is part of the **record**, not of the handler's format. A
simulation log cannot be read against a trace without it, and the handler's
wall-clock timestamp is not the same thing. `log_sink_impl` now takes
`EvaluationClockView` and prefixes the evaluation time, which is the message's
modified time because the node runs only on a tick.

Before and after, over `[1, 2, 3]`:

```
(nothing)
2026-09-09 16:39:20,304 [hgraph.[].log_sink<2>][INFO] [1970-01-01 00:00:00.000001] v=1
```

## What is still different, deliberately

The logger's child name: ours `hgraph.[].log_sink<2>` against the reference's
`hgraph.eval_node_graph.g`. That is node-path naming, a much wider topic than
this operator, and I have left it alone rather than widen the change.

## Testing

* Five Python cases: the handler is attached, an existing handler is not
  displaced, a record appears per tick, the record carries the engine time, and
  a filtered level stays quiet.
* One C++ case pinning the prefix over two ticks.
* Full C++ suite → **1727 cases, 257495 assertions, passed**.
* Python suite → **3378 passed, 9 skipped**.
* End-to-end comparison against the reference posted below once the candidate
  wheel finishes rebuilding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
