### PR TITLE
Do not repeat a removal the previous switch branch already reported

### DIFF
--- a/python/tests/test_switch_tsd_delta.py
+++ b/python/tests/test_switch_tsd_delta.py
@@ -29,7 +29,8 @@ from frozendict import frozendict
 
 from hgraph import (
     TS, TSB, TSD, TimeSeriesSchema, combine, compute_node, const, dedup,
-    default, feedback, graph, if_then_else, lag, map_, no_key, sample, switch_,
+    REMOVE, convert, default, feedback, graph, if_then_else, lag, map_, no_key,
+    sample, switch_,
 )
 from hgraph.test import eval_node
 
@@ -260,3 +261,52 @@ def test_issue_40_feedback_preserves_no_key_map_after_if_then_else_rebind():
     )
 
     assert result == [-1.0, -1.0, 10.5, 10.5]
+
+
+def test_switch_branch_change_does_not_repeat_an_already_applied_removal():
+    """A branch change must not re-remove a key the previous tick retired.
+
+    The link synthesises the removals for a sampled rebind from the previous
+    target's slot store, and ``slot_published`` answers true for a stale
+    tombstone. Without the mirror of the added-side guard, a key retired in an
+    EARLIER cycle was reported a second time on the branch change (issue #814,
+    found by the declaration-shape fuzzer).
+    """
+
+    @graph
+    def _identity(a: TS[int]) -> TS[int]:
+        return a
+
+    @graph
+    def _direct(a: TS[int], b: TS[str]) -> TSD[str, TS[int]]:
+        return convert[TSD[str, TS[int]]](b, a)
+
+    @graph
+    def _projected(a: TS[int], b: TS[str]) -> TSD[str, TS[int]]:
+        return map_(_identity, convert[TSD[str, TS[int]]](b, a))
+
+    @graph
+    def g(selector: TS[str], value: TS[int], key: TS[str]) -> TSD[str, TS[int]]:
+        return switch_(selector, {"direct": _direct, "projected": _projected}, value, key)
+
+    # 'c' is retired at tick 2, one cycle before the branch change.
+    assert eval_node(g, ["direct", None, "projected"], [1, 2, 3], ["c", "b", "b"]) == [
+        frozendict({"c": 1}),
+        frozendict({"b": 2, "c": REMOVE}),
+        frozendict({"b": 3}),
+    ]
+
+    # The mirror: 'd' is retired IN the branch-change cycle, so it is still
+    # owed and must be reported exactly once.
+    assert eval_node(g, ["direct", None, "projected"], [1, 2, 3], ["c", "d", "b"]) == [
+        frozendict({"c": 1}),
+        frozendict({"d": 2, "c": REMOVE}),
+        frozendict({"b": 3, "d": REMOVE}),
+    ]
+
+    # And a key the new branch re-adds is not removed at all.
+    assert eval_node(g, ["direct", None, "projected"], [1, 2, 3], ["c", "b", "c"]) == [
+        frozendict({"c": 1}),
+        frozendict({"b": 2, "c": REMOVE}),
+        frozendict({"c": 3, "b": REMOVE}),
+    ]

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
@@ -264,10 +264,24 @@ namespace hgraph::detail
                 return false;
             }
 
+            // Two slots look published to ``slot_published`` but owe the
+            // consumer nothing, and they are mirror images.
+            //
+            // Added during the transition cycle: never published, so it cannot
+            // be removed.
             const bool added_in_transition =
                 previous.modified(link->structural_transition_time()) &&
                 state->slot_access->slot_added(previous, slot);
-            return state->slot_access->slot_published(previous, slot) && !added_in_transition;
+            // Removed BEFORE the transition cycle: already reported, so it
+            // must not be removed twice. ``slot_published`` answers true for a
+            // stale tombstone, and the removed set is per-cycle, so a slot
+            // that reads removed while the previous target did tick in the
+            // transition cycle was retired in that cycle and is still owed.
+            const bool removed_before_transition =
+                !previous.modified(link->structural_transition_time()) &&
+                state->slot_access->slot_removed(previous, slot);
+            return state->slot_access->slot_published(previous, slot) && !added_in_transition &&
+                   !removed_before_transition;
         }
 
         [[nodiscard]] bool target_link_previous_contains_published(const void *context,

--- a/tests/cpp/test_switch.cpp
+++ b/tests/cpp/test_switch.cpp
@@ -631,6 +631,55 @@ namespace
                                      std::move(builder), inputs, Value{}));
     }
 
+    using RetiredKeyDict = TSD<Str, TS<Int>>;
+
+    /** Branches for the stale-tombstone case (issue #814): both produce the
+        same TSD, one directly and one through a map_, so a branch change is a
+        sampled structural rebind of a keyed output. */
+    struct RetiredKeyDirect
+    {
+        static constexpr auto name = "retired_key_direct";
+
+        static Port<RetiredKeyDict> compose(Wiring &w, Port<TS<Int>> value, Port<TS<Str>> key)
+        {
+            return wire<stdlib::convert, RetiredKeyDict>(w, key, value).as<RetiredKeyDict>();
+        }
+    };
+
+    struct RetiredKeyIdentity
+    {
+        static constexpr auto name = "retired_key_identity";
+
+        static Port<TS<Int>> compose(Wiring &, Port<TS<Int>> a) { return a; }
+    };
+
+    struct RetiredKeyProjected
+    {
+        static constexpr auto name = "retired_key_projected";
+
+        static Port<RetiredKeyDict> compose(Wiring &w, Port<TS<Int>> value, Port<TS<Str>> key)
+        {
+            auto direct = wire<stdlib::convert, RetiredKeyDict>(w, key, value).as<RetiredKeyDict>();
+            return wire<stdlib::map_>(w, fn<RetiredKeyIdentity>(), direct).as<RetiredKeyDict>();
+        }
+    };
+
+    struct RetiredKeySwitchGraph
+    {
+        static constexpr auto name = "retired_key_switch_graph";
+
+        static Port<RetiredKeyDict> compose(Wiring &w, Port<TS<Str>> selector, Port<TS<Int>> value,
+                                            Port<TS<Str>> key)
+        {
+            return wire<stdlib::switch_>(
+                       w, selector,
+                       stdlib::switch_cases({{Value{Str{"direct"}}, fn<RetiredKeyDirect>()},
+                                             {Value{Str{"projected"}}, fn<RetiredKeyProjected>()}}),
+                       value, key)
+                .as<RetiredKeyDict>();
+        }
+    };
+
     using Issue38Dict = TSD<Str, TS<Int>>;
     using Issue38Position =
         TSB<"Issue38Position", Field<"units", Issue38Dict>, Field<"unit_values", Issue38Dict>>;
@@ -912,6 +961,39 @@ TEST_CASE("switch_: a direct structural branch samples held list values on activ
                                list_delta<TS<Int>>({20, -20}),
                                list_delta<TS<Int>>({1, 2}),
                                list_delta<TS<Int>>({40, -40})));
+}
+
+TEST_CASE("switch_: a branch change does not repeat an already-applied removal")
+{
+    using namespace hgraph;
+    using namespace hgraph::testing;
+    using namespace std::string_literals;
+
+    stdlib::register_standard_operators();
+
+    // The link synthesises a sampled rebind's removals from the previous
+    // target's slot store, and a stale tombstone still read as published, so a
+    // key retired in an EARLIER cycle was reported twice (issue #814).
+    const auto run = [](const char *k2, const char *k3) {
+        return eval_node<RetiredKeySwitchGraph>(
+            values<Str>(Str{"direct"}, none, Str{"projected"}),
+            values<Int>(1, 2, 3),
+            values<Str>(Str{"c"}, Str{k2}, Str{k3}));
+    };
+
+    // 'c' is retired at tick 2, one cycle before the branch change, so the
+    // change must not remove it again.
+    CHECK_OUTPUT(run("b", "b"),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"c"s, Int{1}}}),
+                               dict_delta<Str, TS<Int>>({{"b"s, Int{2}}}, {"c"s}),
+                               dict_delta<Str, TS<Int>>({{"b"s, Int{3}}})));
+
+    // The mirror: 'd' is retired IN the branch-change cycle, so it is still
+    // owed and must be reported exactly once.
+    CHECK_OUTPUT(run("d", "b"),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"c"s, Int{1}}}),
+                               dict_delta<Str, TS<Int>>({{"d"s, Int{2}}}, {"c"s}),
+                               dict_delta<Str, TS<Int>>({{"b"s, Int{3}}}, {"d"s})));
 }
 
 TEST_CASE("switch_: nested TSD update survives the feedback round-trip")


### PR DESCRIPTION
Closes #814. Decided **fix** on #810 item 1.4. Found by the declaration-shape
fuzzer added in #804.

## The defect

A `switch_` branch change republished the removal of a key the previous tick
had already retired.

| tick | reference 0.5.41 | before | after |
|---|---|---|---|
| 3 | `{'b': 3}` | `{'b': 3, 'c': REMOVE}` | `{'b': 3}` |

A consumer counting removals, or one treating the removal of an absent key as
an error, saw an event that had already happened.

## The new branch's output was never wrong

Worth stating, because it is where I would have looked first. A branch change
performs a **sampled rebind**, and the link synthesises that rebind's removals
from the *previous* target's slot store.
`target_link_previous_slot_was_published` decides which of those slots the
consumer has already seen, and `dict_access_slot_published` answers true for a
stale tombstone — so a key retired in an earlier cycle still counted as owed.

The predicate already carried the mirror of this rule on the **added** side: a
slot added during the transition cycle was never published, so it cannot be
removed. The removed side had no such clause. It has one now.

The clause is sound because the removed set is per-cycle: a slot that reads
removed *while the previous target did tick in the transition cycle* was retired
in that cycle and is still owed exactly once. Only a slot removed before it is
suppressed.

## How this was verified, and a trap worth knowing

**The local venv's prebuilt extension does not reproduce the defect.** It
reports the fixed answer with the fix stashed out of the tree, so it would have
signed off a no-op. I only caught it because the number looked too easy.

So the verification is an A/B between two candidate wheels built from this tree,
with and without the change, on the same recipe:

```
without: [{c: 1}, {b: 2, c: REMOVE}, {b: 3, c: REMOVE}]
with   : [{c: 1}, {b: 2, c: REMOVE}, {b: 3}]       == released hgraph
```

The new regression test **fails on the pre-fix wheel and passes on the post-fix
one**, which is the property that matters.

## Tests

One regression covering all three shapes:

* a key retired **before** the change — suppressed;
* a key retired **in** the change cycle — still reported, exactly once;
* a key the new branch re-adds — not reported at all.

All three match released hgraph exactly. Full C++ suite green at 1726 cases.

**Native coverage added after review.** My first attempt built the sampled
rebind by hand over two `TSOutput`s, which does not reproduce the defect — it
skips whatever the switch's own branch teardown sets up — and I wrongly
concluded a native test was not achievable. Wiring an actual `switch_` graph in
C++, as the review suggested, reproduces it exactly.

`tests/cpp/test_switch.cpp` now covers both shapes with two branches producing
the same `TSD<Str, TS<Int>>`, one through `convert` and one through a `map_`
over it. Confirmed to discriminate against `origin/main`'s
`target_link_ops.cpp`:

```
actual:   [..., {removed: {c, d}, modified: {b: 3}}]
expected: [..., {removed: {d},    modified: {b: 3}}]
2 assertions | 2 failed
```

Full C++ suite green at 1727 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga

