### PR TITLE
Keep the with_columns resolver variable off the public signature

### DIFF
--- a/docs/source/developer_guide/surface_triage.rst
+++ b/docs/source/developer_guide/surface_triage.rst
@@ -133,7 +133,10 @@ This is the actionable backlog, in the order a user is most likely to hit it.
        generated signature, and a second positional argument bound to it
        instead of raising.  The DEFAULT variable now rides the return
        annotation, as the released signature spells it and as the identical
-       ``to_json``/``from_json`` leak was fixed.
+       ``to_json``/``from_json`` leak was fixed.  The overload's carrier is
+       keyword-only, so the public signature and the overload agree: removing
+       the parameter from the signature alone left the positional binding
+       intact, because the signature is not what binds the call.
 
        One consequence in the original finding is **not** fixed and is not
        caused by the signature: a column legitimately named ``_tp_out`` is

--- a/docs/source/developer_guide/surface_triage.rst
+++ b/docs/source/developer_guide/surface_triage.rst
@@ -124,14 +124,25 @@ This is the actionable backlog, in the order a user is most likely to hit it.
      - Keyword calls work; ``DebugContext.print(label, ts, False)`` raises
        ``TypeError``.  The parameters are also invisible to help() and IDEs.
    * - ``with_columns`` (``hgraph.adaptors.data_frame`` and
-       ``...._data_frame_operators``)
+       ``...._data_frame_operators``) -- **fixed, issue #817**
      - ``(ts, **columns)``
-     - ``(ts, _tp_out=DEFAULT[ROW_1], **columns)``
-     - An internal resolver parameter sits in the public signature between
-       ``ts`` and the columns: a column named ``_tp_out`` cannot be passed, and
-       a second positional argument binds to it instead of raising.  The same
-       leak was removed from ``to_json``/``from_json`` and is pinned against
-       regression by ``test_surface_probe_reports_json_public_signature_drift``.
+     - was ``(ts, _tp_out=DEFAULT[ROW_1], **columns)``; now
+       ``(ts, **columns) -> DEFAULT[ROW_1]``
+     - An internal resolver parameter sat in the public signature between
+       ``ts`` and the columns, where it showed in ``help()`` and every
+       generated signature, and a second positional argument bound to it
+       instead of raising.  The DEFAULT variable now rides the return
+       annotation, as the released signature spells it and as the identical
+       ``to_json``/``from_json`` leak was fixed.
+
+       One consequence in the original finding is **not** fixed and is not
+       caused by the signature: a column legitimately named ``_tp_out`` is
+       still rejected, because the only overload accepting ``**columns`` is
+       the Python adapter and that adapter claims the name.  Mirroring
+       upstream needs a second overload with a mutually exclusive ``requires``
+       predicate; a prototype without one silently returned the unprojected
+       frame through a port declared for the projected schema, so it is
+       tracked separately rather than rushed.
    * - ``LOGGER.isEnabledFor``
      - ``isEnabledFor(level)``
      - nothing

--- a/python/hgraph/adaptors/data_frame/_data_frame_operators.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_operators.py
@@ -298,6 +298,16 @@ def _columns_output_type(mapping, _tp_out):
 
 @graph(overloads=with_columns, resolvers={ROW_1: _columns_output_type})
 def _with_columns_adapter(
-    ts: TS[Frame[ROW]], _tp_out: type[ROW_1] = AUTO_RESOLVE, **columns: TSB[TS_SCHEMA]
+    ts: TS[Frame[ROW]], *, _tp_out: type[ROW_1] = AUTO_RESOLVE, **columns: TSB[TS_SCHEMA]
 ) -> TS[Frame[ROW_1]]:
+    """The resolver carrier is KEYWORD-ONLY.
+
+    The public signature declares ``(ts, **columns)``, and the overload has to
+    agree: positional-or-keyword left a second positional argument binding to
+    the hidden resolver instead of being rejected, so
+    ``with_columns(ts, SomeRow, c=c)`` quietly projected where the released
+    signature has no such parameter to bind (issue #817). The keyword spelling
+    ``with_columns(ts, _tp_out=SomeRow, c=c)`` is this runtime's own and stays
+    supported.
+    """
     return with_columns[TS[Frame[_tp_out]]](ts, _pack_tsb(columns))

--- a/python/hgraph/adaptors/data_frame/_data_frame_operators.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_operators.py
@@ -258,11 +258,18 @@ def concat_frames(ts1, ts2):
 
 
 def _with_columns_signature(
-    ts: TS[Frame[ROW]], _tp_out: type[ROW_1] = DEFAULT[ROW_1], **columns: TSB[TS_SCHEMA],
-):
+    ts: TS[Frame[ROW]], **columns: TSB[TS_SCHEMA],
+) -> DEFAULT[ROW_1]:
     """The public ``with_columns`` shape: ``with_columns[Row](ts, **columns)``
     names the projected row schema through the DEFAULT variable (RFC 0033),
-    ``with_columns(ts, **columns)`` keeps the input's."""
+    ``with_columns(ts, **columns)`` keeps the input's.
+
+    The DEFAULT marker rides the RETURN annotation, as the released signature
+    spells it, rather than a ``_tp_out`` parameter. Carried as a parameter it
+    sat in the public signature between ``ts`` and ``**columns``, where it
+    showed in ``help()`` and every generated signature. ``to_json`` and
+    ``from_json`` had the same leak removed the same way; the resolver never
+    read the parameter, it reads the subscript."""
 
 
 with_columns = operator_function("with_columns", signature=_with_columns_signature)

--- a/python/tests/adaptors/data_frame/test_upstream_surface_parity.py
+++ b/python/tests/adaptors/data_frame/test_upstream_surface_parity.py
@@ -102,9 +102,10 @@ def test_native_operator_callables_expose_user_signatures():
         "concat": "(ts1, ts2)",
         # The released ``with_columns[Row](ts, **columns)`` spelling names the
         # projected row through the public signature's DEFAULT variable
-        # (RFC 0033), so the signature declares it rather than a name branch.
-        "with_columns": "(ts: TS[Frame['ROW']], _tp_out: type[~ROW_1] = DEFAULT[~ROW_1], "
-                        "**columns: TSB[TS_SCHEMA])",
+        # (RFC 0033). The variable rides the RETURN annotation, as the released
+        # signature spells it: carried as a ``_tp_out`` parameter it sat in the
+        # public signature between ``ts`` and ``**columns`` (issue #817).
+        "with_columns": "(ts: TS[Frame['ROW']], **columns: TSB[TS_SCHEMA]) -> DEFAULT[~ROW_1]",
     }
     assert {
         name: str(inspect.signature(getattr(df, name))) for name in expected
@@ -214,3 +215,50 @@ def test_with_columns_public_delegate():
     frame = pa.table({"k": ["a", "b"], "v": [1, 2]})
     (out,) = eval_node(g, ts=[frame], v=[9])
     assert out.column("v").to_pylist() == [9, 9]
+
+
+@dataclass(frozen=True)
+class ProjectedRow(CompoundScalar):
+    k: str
+    c: int
+
+
+def test_with_columns_does_not_expose_the_resolver_parameter():
+    """``_tp_out`` is an internal resolver name and must not be public.
+
+    Carried as a parameter it sat between ``ts`` and ``**columns``, showing in
+    ``help()`` and every generated signature (issue #817). The released
+    signature carries the DEFAULT variable on the return annotation, which is
+    also how the identical ``to_json``/``from_json`` leak was removed here.
+    """
+    from hgraph.adaptors.data_frame import with_columns
+
+    assert "_tp_out" not in inspect.signature(with_columns).parameters
+
+
+def test_with_columns_call_shapes_project_the_declared_row():
+    """Both released spellings keep working, and produce the right columns.
+
+    Asserting the OUTPUT COLUMNS matters: a wrong overload here returns the
+    unprojected frame through a correctly typed port, which no wiring check
+    would catch.
+    """
+    from hgraph.adaptors.data_frame import with_columns
+
+    frame = pa.table({"k": ["a", "b"], "v": [1, 2]})
+
+    @graph
+    def keeps_row(ts: TS[Frame[Row]], v: TS[int]) -> TS[Frame[Row]]:
+        return with_columns(ts, v=v)
+
+    @graph
+    def projects_by_subscript(ts: TS[Frame[Row]], c: TS[int]) -> TS[Frame[ProjectedRow]]:
+        return with_columns[ProjectedRow](ts, c=c)
+
+    (kept,) = eval_node(keeps_row, ts=[frame], v=[9])
+    assert kept.column_names == ["k", "v"]
+    assert kept.column("v").to_pylist() == [9, 9]
+
+    (projected,) = eval_node(projects_by_subscript, ts=[frame], c=[7])
+    assert projected.column_names == ["k", "c"]
+    assert projected.column("c").to_pylist() == [7, 7]

--- a/python/tests/adaptors/data_frame/test_upstream_surface_parity.py
+++ b/python/tests/adaptors/data_frame/test_upstream_surface_parity.py
@@ -262,3 +262,36 @@ def test_with_columns_call_shapes_project_the_declared_row():
     (projected,) = eval_node(projects_by_subscript, ts=[frame], c=[7])
     assert projected.column_names == ["k", "c"]
     assert projected.column("c").to_pylist() == [7, 7]
+
+
+def test_with_columns_rejects_a_positional_resolver_argument():
+    """The released signature has no second positional parameter to bind.
+
+    Removing ``_tp_out`` from the public signature was not enough on its own:
+    the overload still declared it positional-or-keyword, so
+    ``with_columns(ts, SomeRow, c=c)`` quietly projected instead of raising.
+    The carrier is keyword-only, so the public signature and the overload agree.
+    """
+    from hgraph.adaptors.data_frame import with_columns
+
+    @graph
+    def positional(ts: TS[Frame[Row]], c: TS[int]) -> TS[Frame[ProjectedRow]]:
+        return with_columns(ts, ProjectedRow, c=c)
+
+    frame = pa.table({"k": ["a"], "v": [1]})
+    with pytest.raises(Exception, match="with_columns"):
+        eval_node(positional, ts=[frame], c=[7])
+
+
+def test_with_columns_keeps_the_keyword_resolver_spelling():
+    """``_tp_out=`` is this runtime's own spelling and stays supported."""
+    from hgraph.adaptors.data_frame import with_columns
+
+    @graph
+    def keyword(ts: TS[Frame[Row]], c: TS[int]) -> TS[Frame[ProjectedRow]]:
+        return with_columns(ts, _tp_out=ProjectedRow, c=c)
+
+    frame = pa.table({"k": ["a"], "v": [1]})
+    (out,) = eval_node(keyword, ts=[frame], c=[7])
+    assert out.column_names == ["k", "c"]
+    assert out.column("c").to_pylist() == [7]


### PR DESCRIPTION
Closes #817. Decided **fix** on #810 item 3.3.

## The change

`with_columns` carried an internal resolver parameter in its public signature:

```
before  (ts: TS[Frame['ROW']], _tp_out: type[~ROW_1] = DEFAULT[~ROW_1], **columns: TSB[TS_SCHEMA])
after   (ts: TS[Frame['ROW']], **columns: TSB[TS_SCHEMA]) -> DEFAULT[~ROW_1]
```

`_tp_out` was load-bearing only as the carrier of the `DEFAULT` marker that
makes the subscript `with_columns[Row]` legal. The marker rides the **return
annotation** instead, which is how the released signature spells it and how the
identical `to_json`/`from_json` leak was already fixed here. The resolver never
read the parameter; it reads the subscript.

Verified equivalent to dispatch before changing it: same type variables, same
default variable, same resolution for a subscripted call, and both released
call shapes evaluate to the same frames.

## One consequence in the issue is not fixed, and is not caused by the signature

The issue said a column legitimately named `_tp_out` could not be passed. That
is true, and **removing the parameter does not fix it** — I checked before and
after and the rejection is identical.

A related claim in my first draft was also wrong, and the review caught it: I
said removing the parameter stopped a second positional argument binding to the
resolver. It did not, for the same reason — the curated signature is not what
binds the call. The adapter's carrier is now **keyword-only**, so the public
signature and the overload agree:

```
with_columns(ts, Projected, c=c)
  before  projects, binding Projected to the hidden resolver
  after   WiringError: no matching overload for operator 'with_columns'
```

`with_columns(ts, _tp_out=Projected, c=c)` is this runtime's own spelling and
stays supported. The only overload accepting `**columns`
is the Python adapter, and that adapter claims the name, so the overload set
blocks it.

Mirroring upstream needs a second overload without `_tp_out`. I prototyped it,
and it is not a drop-in:

* without a `requires` predicate it fixed the column **and silently broke both
  projecting forms** — `with_columns[Projected](...)` returned the
  *unprojected* frame through a port declared `TS[Frame[Projected]]`, a wrong
  value rather than a wiring error;
* with a naive predicate the column failed again.

It needs a mutually exclusive `requires` pair proven by a behavioural test. That
is tracked separately rather than rushed in here, because its failure mode is a
silently wrong frame.

The issue's stated acceptance criterion — both surface findings clear with no
`surface_known.json` entry — is met by this change alone.

## Testing

* A direct regression asserting `_tp_out` is absent from the public signature.
* Both released call shapes asserting their **output columns**, not just that
  wiring succeeded. That is the assertion the prototype failure above would
  have slipped past.
* The pinned signature in the upstream-parity test moves with it.
* Data-frame adaptor suite → 32 passed. Full Python suite → **3380 passed, 9
  skipped**.

`surface_triage.rst` records both halves: what is fixed, and what is not and
why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga

