### PR TITLE
Keep a container's delta for a child whose reference emptied

### DIFF
--- a/docs/source/developer_guide/data_structures/linking_strategies.rst
+++ b/docs/source/developer_guide/data_structures/linking_strategies.rst
@@ -469,6 +469,21 @@ keeps its storage alive until erase. No key/value snapshot or retired-entry
 allocation is required. The borrowed handle is considered only while the
 link's modification time matches the structural transition time.
 
+**A container's delta capture must carry such a child.** The rule above makes
+an emptied ``TSS`` or ``TSD`` invalid *and* newsworthy at the same time, so a
+``TSD``, ``TSL`` or ``TSB`` walking its modified children cannot read
+``!valid()`` as "no news" -- doing so dropped the removals of a child whose
+reference emptied, and the parent published nothing where released hgraph
+published the removals (issue #815, reported against ``route_by_index``,
+though the operator itself was correct and the same hole sat on ``if_``).
+
+Which kinds this applies to is a property of the representation, not of the
+caller, so it is answered by the ``captures_while_invalid`` slot on
+``TSCurrentStateOps`` beside the ``delta_is_observable`` that already states
+the same rule for the parent's own delta. It is true for the set and dict
+policies alone: every other kind has no value once invalid, and the window
+policy's capture throws on a removal-only tick.
+
 - ``TSInputView::delta_value()``: when the position's LINK was modified
   after the target's own last tick (a from-REF retarget bound an
   already-valid output), the delta IS the current value — the target's

--- a/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
@@ -479,9 +479,14 @@ the explicit ``require_live`` API throws
 The three sub-tables and the Python-authoring family each answer one
 concern:
 
-- ``TSCurrentStateOps`` — record/replay reconciliation: eight per-kind
+- ``TSCurrentStateOps`` — record/replay reconciliation: nine per-kind
   singleton tables selected once at factory time
-  (``src/hgraph/types/time_series/ts_delta.cpp``).
+  (``src/hgraph/types/time_series/ts_delta.cpp``). Beside the function
+  pointers it carries one predicate, ``captures_while_invalid``, true for the
+  set and dict policies alone: an emptied keyed collection is invalid and
+  still owes the removals its link holds, so a container walking its modified
+  children must ask the child's representation rather than read ``!valid()``
+  as "no news" (see :doc:`../linking_strategies`, keyed structural unbind).
 - ``PythonTSDataOps`` (a type-layer struct the bridge instantiates) —
   delta conversion and node-result application per family; a strategy
   records its ``python_family`` and the bridge's

--- a/include/hgraph/types/time_series/ts_data/current_state_ops.h
+++ b/include/hgraph/types/time_series/ts_data/current_state_ops.h
@@ -65,6 +65,23 @@ namespace hgraph
         void (*reconcile_data_impl)(const TSOutputView &target,
                                     const TSDataView &source,
                                     TSCurrentReconcileOptions options);
+        /**
+         * True when ``capture_current_delta_impl`` is defined for an INVALID
+         * input of this kind, and the delta it produces can still be
+         * observable.
+         *
+         * A keyed collection that loses its reference is invalid but not
+         * silent: its link holds the removals for every key it had published
+         * (``linking_strategies.rst``, keyed structural unbind), and
+         * ``delta_is_observable_impl`` already says so. Every other kind has
+         * no value to capture once invalid, and the window policy's capture
+         * throws outright on a removal-only tick, so a container walking its
+         * children must ask before it captures.
+         *
+         * Lives here rather than as a ``TSTypeKind`` switch at each caller:
+         * the answer is a property of the representation (CLAUDE.md 3(ii)).
+         */
+        bool captures_while_invalid;
     };
 
     namespace ts_current_state_detail

--- a/python/tests/ported/_operators/test_control_operators.py
+++ b/python/tests/ported/_operators/test_control_operators.py
@@ -211,6 +211,52 @@ def test_route_by_index():
     assert eval_node(g, [1, 2, 0, 4], ["1", "2", "2", "2"]) == [{1: "1"}, {2: "2"}, {0: "2"}, None]
 
 
+def test_route_by_index_records_the_emptied_arm_through_the_whole_tsl():
+    """A container delta must carry a child whose reference emptied.
+
+    ``route_by_index`` itself was never wrong: recorded on its own, the arm
+    routed away from reports its removals. What dropped them was the TSL's
+    delta capture, which read the invalid child as "no news" and skipped it,
+    so the whole-TSL recording published nothing for that arm (issue #815).
+    """
+
+    @graph
+    def whole(index: TS[int], ts: TSD[str, TS[int]]) -> TSL[TSD[str, TS[int]], Size[2]]:
+        return route_by_index[SIZE : Size[2]](index, ts)
+
+    @graph
+    def arm_only(index: TS[int], ts: TSD[str, TS[int]]) -> TSD[str, TS[int]]:
+        return route_by_index[SIZE : Size[2]](index, ts)[0]
+
+    inputs = ([0, 1], [{"a": 1}, {"b": 2}])
+
+    # The arm on its own always agreed with released hgraph.
+    assert eval_node(arm_only, *inputs) == [{"a": 1}, {"a": REMOVE}]
+    # The whole TSL must report the same removal for arm 0.
+    assert eval_node(whole, *inputs) == [
+        {0: {"a": 1}},
+        {0: {"a": REMOVE}, 1: {"a": 1, "b": 2}},
+    ]
+
+
+def test_if_records_the_emptied_arm_through_the_whole_bundle():
+    """The same hole on the TSB path, which looked clean only because the
+    existing coverage records one arm at a time."""
+
+    class _Arms(TimeSeriesSchema):
+        true: TSD[str, TS[int]]
+        false: TSD[str, TS[int]]
+
+    @graph
+    def whole(condition: TS[bool], ts: TSD[str, TS[int]]) -> TSB[_Arms]:
+        routed = if_(condition, ts)
+        return combine[TSB[_Arms]](true=routed.true, false=routed.false)
+
+    result = eval_node(whole, [True, False], [{"a": 1}, {"b": 2}])
+    assert result[1]["true"] == {"a": REMOVE}
+    assert result[1]["false"] == {"a": 1, "b": 2}
+
+
 def test_merge():
     assert eval_node(
         merge,

--- a/src/hgraph/types/time_series/ts_delta.cpp
+++ b/src/hgraph/types/time_series/ts_delta.cpp
@@ -1109,6 +1109,7 @@ namespace hgraph
                 &observable_atomic,
                 &reconcile_atomic_impl<TSInputView>,
                 &reconcile_atomic_impl<TSDataView>,
+                /* captures_while_invalid: */ false,   // an atomic input has no value to capture once invalid
             };
             return ops;
         }
@@ -1123,6 +1124,7 @@ namespace hgraph
                 &observable_atomic,
                 &reconcile_atomic_impl<TSInputView>,
                 &reconcile_atomic_impl<TSDataView>,
+                /* captures_while_invalid: */ false,   // a signal carries no value at all
             };
             return ops;
         }
@@ -1137,6 +1139,7 @@ namespace hgraph
                 &observable_atomic,
                 &reconcile_atomic_impl<TSInputView>,
                 &reconcile_atomic_impl<TSDataView>,
+                /* captures_while_invalid: */ false,   // an unbound reference has nothing to capture
             };
             return ops;
         }
@@ -1151,6 +1154,7 @@ namespace hgraph
                 &observable_window,
                 &reconcile_atomic_impl<TSInputView>,
                 &reconcile_atomic_impl<TSDataView>,
+                /* captures_while_invalid: */ false,   // capture_delta_tsw throws on a removal-only tick
             };
             return ops;
         }
@@ -1165,6 +1169,7 @@ namespace hgraph
                 &observable_set,
                 &reconcile_set_impl<TSInputView>,
                 &reconcile_set_impl<TSDataView>,
+                /* captures_while_invalid: */ true,   // an emptied TSS still owes the removals its link holds
             };
             return ops;
         }
@@ -1179,6 +1184,7 @@ namespace hgraph
                 &observable_dict,
                 &reconcile_dict_impl<TSInputView>,
                 &reconcile_dict_impl<TSDataView>,
+                /* captures_while_invalid: */ true,   // an emptied TSD still owes the removals its link holds
             };
             return ops;
         }
@@ -1193,6 +1199,7 @@ namespace hgraph
                 &observable_list,
                 &reconcile_indexed_impl<TSInputView>,
                 &reconcile_indexed_impl<TSDataView>,
+                /* captures_while_invalid: */ false,   // a truncation is reported through the list's own delta, not a child capture
             };
             return ops;
         }
@@ -1207,6 +1214,7 @@ namespace hgraph
                 &observable_bundle,
                 &reconcile_indexed_impl<TSInputView>,
                 &reconcile_indexed_impl<TSDataView>,
+                /* captures_while_invalid: */ false,   // a bundle's own capture already walks its children
             };
             return ops;
         }
@@ -1224,6 +1232,7 @@ namespace hgraph
                 &missing_observable_delta,
                 &missing_reconcile_input,
                 &missing_reconcile_data,
+                /* captures_while_invalid: */ false,   // no representation
             };
             return ops;
         }
@@ -1342,6 +1351,27 @@ namespace hgraph
             return bundle.build();
         }
 
+        /** A child that reads invalid is not always silent: a keyed
+            collection that lost its reference still owes its consumer the
+            removals its link holds (``linking_strategies.rst``, keyed
+            structural unbind). Ask the child's own representation before
+            skipping it, rather than assuming invalid means no news. */
+        [[nodiscard]] bool child_delta_worth_capturing(const TSInputView &child)
+        {
+            if (child.valid()) { return true; }
+            // Reaching the policy is itself conditional. A child with no
+            // canonical type record cannot answer -- and an invalid child is
+            // exactly the case where the data view has no ops to fall back on,
+            // so current_state_ops_for_input would raise rather than reply.
+            // An unanswerable child keeps the previous behaviour and is
+            // skipped; only one that positively says it still owes removals is
+            // captured.
+            const auto type = child.type_ref();
+            if (!type) { return false; }
+            const auto *ops = type.as_role().ops_ref().current_state_ops;
+            return ops != nullptr && ops->captures_while_invalid;
+        }
+
         Value capture_delta_tsd(const TSInputView &in)
         {
             BundleBuilder bundle{canonical_delta_binding(in, "capture_delta")};
@@ -1366,7 +1396,7 @@ namespace hgraph
             MapBuilder modified{key_binding, delta_binding};
             for (const auto &[key, child] : dict.modified_items())
             {
-                if (!child.valid()) { continue; }   // empty-reference elements have no value
+                if (!child_delta_worth_capturing(child)) { continue; }
                 if (child.schema() != in.schema()->element_ts())
                 {
                     throw std::logic_error("capture_delta_tsd resolved the wrong child TS schema");
@@ -1411,7 +1441,7 @@ namespace hgraph
             const auto fill_modified = [&](MapBuilder &builder, ValueTypeRef key_binding) {
                 for (const auto &[index, child] : list.modified_items())
                 {
-                    if (!child.valid()) { continue; }   // empty-reference elements have no value
+                    if (!child_delta_worth_capturing(child)) { continue; }
                     const std::int64_t key = static_cast<std::int64_t>(index);
                     // The child's canonical delta is exactly the map's value schema, so a
                     // whole-value copy of the (owned, rebuilt) child delta is correct for
@@ -1462,10 +1492,7 @@ namespace hgraph
             for (std::size_t index = 0; index < bundle.size(); ++index)
             {
                 auto child = bundle.at(index);
-                // modified-but-INVALID children are skipped: a from-REF
-                // rebind marks the position modified, but an EMPTY reference
-                // leaves it unbound - there is no value to capture.
-                if (!child.modified() || !child.valid()) { continue; }
+                if (!child.modified() || !child_delta_worth_capturing(child)) { continue; }
                 Value child_delta = capture_delta(child);
                 builder.set(index, std::move(child_delta));
             }


### PR DESCRIPTION
Closes #815. Decided **fix** on #810 item 1.5.

## The issue title is wrong, and that is the useful part

`route_by_index` is **correct**. Recorded on its own, the arm routed away from
reports its removals and matches released hgraph exactly:

```
arm 0 alone   reference [{a: 1}, {a: REMOVE}]
              candidate [{a: 1}, {a: REMOVE}]     identical, before any fix
```

The divergence only appears when the whole TSL is recorded:

| tick 2 | value |
|---|---|
| reference | `{0: {a: REMOVE}, 1: {b: 2, a: 1}}` |
| before | `{1: {a: 1, b: 2}}` |
| after | `{0: {a: REMOVE}, 1: {a: 1, b: 2}}` |

So the operator was never the defect. The **container's delta capture** was.
And the same hole sits on the TSB path, where `if_` looked clean only because
the parity template records one arm at a time.

## The rule was already written, in the right place, and then ignored

`capture_delta_tsd`, `_tsl` and `_tsb` each skipped a modified child that read
`!valid()`, commented "empty-reference elements have no value". True of most
kinds. Wrong for the two that matter: `linking_strategies.rst` already states
that an emptied `TSS` or `TSD` is invalid **and** owes one modified cycle
carrying removals for every key it had published. The parent published nothing
where the child was still owed.

`delta_is_observable` already encodes exactly that rule for the parent's own
delta — "invalid, but the delta carries removals". Rather than hand-apply a
fourth copy of it, the decision moves to where the representation is:
`TSCurrentStateOps` gains `captures_while_invalid`, **true for the set and dict
policies alone**. Every other kind has no value once invalid, and the window
policy's capture throws outright on a removal-only tick — which is exactly why
the three callers must ask rather than assume.

## The first attempt was wrong, and the suite caught it

`current_state_ops_for_input` raises for an input with no canonical type
record, and an invalid child is precisely the case with no data-view ops to
fall back on. So my first guard raised where it should have replied, and the
reduce-with-race tests failed with `capture_delta requires a canonical input
type record`. The guard now reads the policy directly and treats an
unanswerable child as before — skipped.

## Verification

The local venv extension predates this change and cannot see it, so the
evidence is an A/B between two candidate wheels built from this tree. **Both
new tests fail on the pre-fix wheel and pass on the post-fix one.**

One full-suite run reported a failure in `test_race_tsd_of_bundles_all_free_bundles`.
It is flaky, not caused by this: two subsequent full runs pass, it passes in
isolation both with and without the change, and the venv extension the Python
suite loads does not contain the change at all.

* Full C++ suite → **1726 cases, 257492 assertions, passed**.
* Python suite → **3380 passed, 9 skipped**, twice.

## Still divergent, deliberately out of scope

A TSB delta materialises empty defaults for a field with no news, so the
whole-bundle recording of `if_` carries a spurious `'false': {}` at the first
tick where the reference has no `false` key at all. Separate defect, filed
separately, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
