### PR TITLE
Stop merge re-emitting when a removal leaves the value unchanged

### DIFF
--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -673,6 +673,21 @@ The following are intentional unless separately re-opened:
   which does **not** elide -- but that overload is not registered here at all,
   so there is no such path to diverge. If it is added, it needs its own
   implementation and must re-emit.
+
+  Extended 2026-09-10 (issue #823) to a **republication** -- an operator
+  re-publishing a value it did not compute. ``merge`` re-selects a source when
+  the selected one goes away, and if the re-selected value equals what merge
+  already published then nothing changed and nothing ticks. Released
+  ``merge_ts_scalar`` guards its own re-selection branch identically
+  (``if out is not None and out != _output.value``), so the ruling and upstream
+  parity agree here as well. The helper is ``stdlib::apply_if_changed``, beside
+  ``set_if_changed`` in the same header. It covers merge's **fallback path
+  only**: merge's modified path is unguarded in both runtimes, because an input
+  that ticked is news whatever value it carries.
+
+  This reaches ``merge`` over TSDs because both runtimes spell that
+  ``map_(merge, *tsl)``, so a removed key lands in the per-key fallback. Before
+  the fix, removing a key whose value the fallback already held re-emitted it.
 - **Reduce over partially-valid mapped keys** (issue #95; design record:
   :doc:`nested_graphs`): reduction is over currently-valid values. A keyed
   value can be invalid while its slot is live — a map child existing before

--- a/include/hgraph/lib/std/operators/impl/control_impl.h
+++ b/include/hgraph/lib/std/operators/impl/control_impl.h
@@ -4,6 +4,7 @@
 #include <hgraph/lib/std/operators/control.h>
 #include <hgraph/lib/std/operators/impl/higher_order_impl.h>
 #include <hgraph/lib/std/operators/impl/collection_impl.h>
+#include <hgraph/lib/std/operators/impl/output_elision.h>
 #include <hgraph/types/operator_type_resolution.h>
 #include <hgraph/types/subgraph_wiring.h>
 #include <hgraph/runtime/race_tsd_node.h>
@@ -79,12 +80,18 @@ namespace hgraph::stdlib
                     return;
                 }
 
+                // Nothing ticked: a source went away and we re-select. The
+                // re-selected value is a republication rather than a result,
+                // so an unchanged one is not an event -- released
+                // merge_ts_scalar guards its own re-selection the same way
+                // (`out != _output.value`). Without this, removing a key whose
+                // value the fallback already holds re-emits (issue #823).
                 if (current == 0 && !lhs.valid())
                 {
                     if (rhs.valid())
                     {
                         selected.set(Int{1});
-                        out.apply(rhs.value());
+                        apply_if_changed(out, rhs.value());
                     }
                     else { selected.set(Int{-1}); }
                     return;
@@ -94,7 +101,7 @@ namespace hgraph::stdlib
                     if (lhs.valid())
                     {
                         selected.set(Int{0});
-                        out.apply(lhs.value());
+                        apply_if_changed(out, lhs.value());
                     }
                     else { selected.set(Int{-1}); }
                     return;
@@ -105,12 +112,12 @@ namespace hgraph::stdlib
                     if (lhs.valid())
                     {
                         selected.set(Int{0});
-                        out.apply(lhs.value());
+                        apply_if_changed(out, lhs.value());
                     }
                     else if (rhs.valid())
                     {
                         selected.set(Int{1});
-                        out.apply(rhs.value());
+                        apply_if_changed(out, rhs.value());
                     }
                 }
             }

--- a/include/hgraph/lib/std/operators/impl/output_elision.h
+++ b/include/hgraph/lib/std/operators/impl/output_elision.h
@@ -28,6 +28,23 @@ namespace hgraph::stdlib
     {
         if (!out.valid() || out.value().template checked_as<T>() != value) { out.set(value); }
     }
+
+    /**
+     * The same elision for an operator that republishes a whole value it did
+     * not compute -- ``merge`` re-selecting a source after the selected one
+     * went away.
+     *
+     * Same opt-in rule as ``set_if_changed``: this is for a republication, not
+     * a result. ``merge`` reaches for it on its FALLBACK path only, matching
+     * the released ``merge_ts_scalar``, whose re-selection branch ends
+     * ``if out is not None and out != _output.value``. Its modified path has
+     * no such guard and neither does ours, because an input that ticked is
+     * news whatever it carries.
+     */
+    template <typename TOut> void apply_if_changed(const TOut &out, const ValueView &value)
+    {
+        if (!out.valid() || out.value() != value) { out.apply(value); }
+    }
 }  // namespace hgraph::stdlib
 
 #endif  // HGRAPH_LIB_STD_OPERATORS_IMPL_OUTPUT_ELISION_H

--- a/python/tests/ported/_operators/test_control_operators.py
+++ b/python/tests/ported/_operators/test_control_operators.py
@@ -267,6 +267,32 @@ def test_merge():
     ) == [1, 2, 4, None, 6]
 
 
+def test_merge_does_not_reemit_when_a_removal_leaves_the_value_unchanged():
+    """A removal that re-selects the same value is not news (issue #823).
+
+    ``merge`` over TSDs is ``map_(merge, *tsl)`` in both runtimes, so a removed
+    key falls through to the per-key merge's fallback branch. Released
+    ``merge_ts_scalar`` guards that branch with ``out != _output.value``; we did
+    not, so removing a key whose value the fallback already held re-emitted it.
+    The no-change-means-no-tick ruling (roadmap.rst, 2026-07-17) says an
+    unchanged merged value must not tick.
+    """
+
+    @graph
+    def g(lhs: TSD[str, TS[int]], rhs: TSD[str, TS[int]]) -> TSD[str, TS[int]]:
+        return merge(lhs, rhs)
+
+    # "a" is removed from the leftmost input while the fallback holds the same
+    # value -- nothing changed, so nothing ticks. "b" differs in the fallback,
+    # which keeps the test honest: it proves the guard elides rather than
+    # suppressing the fallback outright.
+    assert eval_node(
+        g,
+        [{"a": 1, "b": 2}, None, {"a": REMOVE, "b": REMOVE}],
+        [{"a": 1, "b": 20}, None, None],
+    ) == [{"a": 1, "b": 2}, None, {"b": 20}]
+
+
 def test_merge_compound_scalars():
     @dataclass
     class SimpleCS(CompoundScalar):

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -1208,6 +1208,18 @@ namespace
         }
     };
 
+    /** merge over two TSDs: map_(merge, ...) per key in both runtimes. */
+    struct MergeTsdGraph
+    {
+        static constexpr auto name = "merge_tsd_graph";
+
+        static Port<TSD<Str, TS<Int>>> compose(Wiring &w, Port<TSD<Str, TS<Int>>> lhs,
+                                               Port<TSD<Str, TS<Int>>> rhs)
+        {
+            return wire<stdlib::merge>(w, lhs, rhs).as<TSD<Str, TS<Int>>>();
+        }
+    };
+
     struct IfTrueRouteGraph
     {
         static constexpr auto name = "if_true_route_graph";
@@ -3392,6 +3404,18 @@ TEST_CASE("std operators: control operators cover variadic booleans merge and se
                                           values<Int>(1, none, 4, none, none),
                                           values<Int>(none, 3, 5, none, none)),
                  values<Int>(1, 2, 4, none, 6));
+    // A removal that re-selects the SAME value is not news (issue #823).
+    // Released merge_ts_scalar guards its re-selection branch with
+    // `out != _output.value`; we did not, so "a" re-emitted. "b" differs in
+    // the fallback and still ticks, which proves the guard elides rather than
+    // suppressing the fallback outright.
+    CHECK_OUTPUT((eval_node<MergeTsdGraph>(
+                     values<Value>(dict_delta<Str, TS<Int>>({{Str{"a"}, 1}, {Str{"b"}, 2}}), none,
+                                   dict_delta<Str, TS<Int>>({}, {Str{"a"}, Str{"b"}})),
+                     values<Value>(dict_delta<Str, TS<Int>>({{Str{"a"}, 1}, {Str{"b"}, 20}})))),
+                 values<Value>(dict_delta<Str, TS<Int>>({{Str{"a"}, 1}, {Str{"b"}, 2}}), none,
+                               dict_delta<Str, TS<Int>>({{Str{"b"}, 20}})));
+
     CHECK_OUTPUT(eval_node<RaceGraph>(values<Int>(none, 1, 10, 11),
                                       values<Int>(2, 3, 4, 5)),
                  values<Int>(2, 3, 4, 5));

--- a/tools/parity/corpus/merge-tsd-removal-unchanged-no-retick.json
+++ b/tools/parity/corpus/merge-tsd-removal-unchanged-no-retick.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "id": "merge-tsd-removal-unchanged-no-retick",
+  "description": "A key removed from merge's leftmost TSD, where the fallback input already holds the same value, must not re-emit: the merged value has not changed.",
+  "template": "tsd_operator",
+  "inputs": {
+    "ts": [
+      {
+        "a": 1,
+        "b": 2
+      },
+      null,
+      {
+        "a": {
+          "$remove": true
+        },
+        "b": {
+          "$remove": true
+        }
+      }
+    ],
+    "other": [
+      {
+        "a": 1,
+        "b": 20
+      },
+      null,
+      null
+    ]
+  },
+  "parameters": {
+    "operation": "merge"
+  },
+  "features": [
+    "operation:merge",
+    "shape:TSD"
+  ],
+  "source_issue": "https://github.com/hhenson/hgraph/issues/823"
+}


### PR DESCRIPTION
Closes #823. Decided **fix** on #810 item 7.2 (N5 in PR #808 round 2), found by
the random operator-family strategies.

## What was wrong

`merge` re-selects a source when the selected one goes away, and applied the
re-selected value **unconditionally**. So removing a key whose value the
fallback input already held re-emitted that value, even though the merged value
had not changed.

## The reference draws the line in exactly one place

`merge_ts_scalar` on `release/0.5` guards its re-selection branch:

```python
if tsl.modified:
    return next(iter(tsl.modified_values())).value
else:
    # This implies a value has gone away ...
    ...
    if out is not None and out != _output.value:
        return out
```

The **modified** branch has no such guard — an input that ticked is news
whatever it carries. The **fallback** branch does. This PR mirrors both halves:
the new `stdlib::apply_if_changed` sits beside `set_if_changed` in
`output_elision.h` and is applied to the three fallback sites in `merge_binary`
only.

This reaches `merge` over TSDs because both runtimes spell that
`map_(merge, *tsl)`, so a removed key lands in the per-key fallback — which is
the shape the campaign found.

## Verification

**A/B against the same build**, not against a stale artifact. The new C++ case
fails on the unfixed tree:

```
actual:   [..., {removed: {}, modified: {a: 1, b: 20}}]
expected: [..., {removed: {}, modified: {b: 20}}]
```

and passes with the fix.

**New parity recipe** `merge-tsd-removal-unchanged-no-retick` replays clean —
candidate and released 0.5.41 both trace `[{a:1,b:2}, null, {b:20}]`,
`difference: null`.

**The existing ported `test_merge_tsd` is untouched by the guard**, and that is
the point: its removal re-selects a *different* value, so it still ticks. The
new cases deliberately pair an unchanged fallback (`a`) with a changed one
(`b`) so both directions are pinned by one assertion.

Local gates: full C++ suite and full `python/tests` green; stdlib suite 1680
assertions / 445 cases.

## Doc

`roadmap.rst` — the no-change-means-no-tick ruling extended to cover a
**republication** as well as a projection, with the upstream guard quoted and
the fallback-only scope stated.

## Noted, not changed

The reference picks its fallback by *most recently ticked still-valid input*;
our binary fold picks structurally. The two coincide for two inputs and may
differ for three or more. That is a separate question from this issue and I have
not touched it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
