### PR TITLE
Republish the complete state when a filtered keyed input reopens

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -518,13 +518,21 @@ model.
        portable. Keyed-map error capture is covered by the error-handling
        runtime and public ``eval_node`` tests.
        **Accepted filter correction:** when a keyed input reopens after being
-       filtered, hg_cpp reconciles the complete currently valid state. It
-       removes every formerly published key that is now absent or invalid and
-       does not republish unchanged values. Released hgraph 0.5.34 instead
-       republishes unchanged values and omits an invalidated key; its own test
-       marks that omission as a feature needing reconsideration. The corrected
-       behavior is pinned by ``test_filter_str_tsd`` in the ported Python and
-       native map suites.
+       filtered, hg_cpp removes every formerly published key that is now
+       absent **or invalid**. Released hgraph omits the invalidated key, and
+       its own test says why -- ``test_stream_operators.py`` on
+       ``release/0.5`` carries ``FIXME: Item that has gone invalid does not
+       show up in the removed items ever. This is a 'feature' but really
+       needs some re-thinking``. Ours is the correction, and it is the whole
+       of this deviation.
+
+       Reopen otherwise reconciles the **complete** live state, republishing
+       every currently valid key including ones whose value did not change
+       while the filter was shut -- which is what upstream does. Suppressing
+       those was a second, unjustified deviation bundled into this note; it
+       lost accumulated state and was removed (issue #812). Both halves are
+       pinned by ``test_filter_str_tsd`` in the ported Python and native map
+       suites.
    * - ``test_mesh.py``
      - 7
      - Named and anonymous meshes, dependency ordering/cycles, on-demand

--- a/include/hgraph/lib/std/operators/impl/stream_impl.h
+++ b/include/hgraph/lib/std/operators/impl/stream_impl.h
@@ -746,9 +746,20 @@ namespace hgraph::stdlib
                     {
                         // Full resync preserves structural child validity;
                         // the current-state policy owns each representation.
+                        //
+                        // sample_all republishes every live child, including
+                        // ones whose value did not change while the filter was
+                        // shut. That is upstream's copy_from_input, and it is
+                        // what makes a reopen hand the consumer the COMPLETE
+                        // state rather than only what moved (issue #812).
+                        // Suppressing the unchanged ones lost accumulated
+                        // state. The separate correction -- removing a key
+                        // that went invalid, which upstream's own test flags
+                        // as a defect -- is owned by the scope field and is
+                        // deliberately unaffected.
                         reconcile_current_state(
                             erased, ts.base(),
-                            TSCurrentReconcileOptions{TSCurrentReconcileScope::Full, false});
+                            TSCurrentReconcileOptions{TSCurrentReconcileScope::Full, true});
                     }
                 }
                 else if (ts.modified())

--- a/python/tests/ported/_operators/test_stream_operators.py
+++ b/python/tests/ported/_operators/test_stream_operators.py
@@ -566,7 +566,13 @@ def test_filter_str_tsd():
         {"1": 2, "3": 4, "5": 6, "7": 8, "9": 10},
         None,
         None,
-        {"1": REMOVE, "3": REMOVE},
+        # Reopen reconciles the COMPLETE live state, so 5/7/9 come back even
+        # though they did not change while the filter was shut (issue #812).
+        # Released hgraph traces {"5": 6, "7": 8, "9": 10, "3": REMOVE} here.
+        # The extra "1": REMOVE is the single deviation the parity matrix
+        # still records: upstream never removes a key that has gone invalid,
+        # and its own test marks that omission as needing re-thinking.
+        {"1": REMOVE, "3": REMOVE, "5": 6, "7": 8, "9": 10},
         None,
         None,
     ]

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -1075,7 +1075,15 @@ TEST_CASE("map_: EMPTY-REF child removals propagate through a filtered map")
                                                        {"7"s, 8}, {"9"s, 10}}),
                      none,
                      none,
-                     dict_delta<Str, TS<Int>>({}, {"1"s, "3"s}),
+                     // Reopen hands back the COMPLETE live state: 5/7/9 are
+                     // republished though they did not change while shut
+                     // (issue #812). Released hgraph traces exactly
+                     // {5: 6, 7: 8, 9: 10, 3: REMOVE} here. The extra "1" in
+                     // removed is the one deviation this note still covers --
+                     // upstream never removes a key that went invalid, and
+                     // its own test calls that a feature needing re-thinking.
+                     dict_delta<Str, TS<Int>>({{"5"s, 6}, {"7"s, 8}, {"9"s, 10}},
+                                              {"1"s, "3"s}),
                      none,
                      none));
 }

--- a/tools/parity/corpus/filter-tsd-reopen-republishes-unchanged.json
+++ b/tools/parity/corpus/filter-tsd-reopen-republishes-unchanged.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "id": "filter-tsd-reopen-republishes-unchanged",
+  "description": "filter_ reopening over a TSD hands back the complete live state, including a key that did not change while the filter was shut.",
+  "template": "flow_control",
+  "inputs": {
+    "condition": [
+      true,
+      false,
+      null,
+      true
+    ],
+    "ts": [
+      {
+        "a": 1,
+        "b": 2
+      },
+      null,
+      {
+        "b": 20
+      },
+      null
+    ]
+  },
+  "parameters": {
+    "operation": "filter_",
+    "input_type": "tsd"
+  },
+  "features": [
+    "operation:filter_",
+    "shape:TSD",
+    "type:bool"
+  ],
+  "source_issue": "https://github.com/hhenson/hgraph/issues/812"
+}


### PR DESCRIPTION
Closes #812. Decided **fix** on #810 item 1.2.

Landing this as an explicit **half-reversal of a recorded accepted deviation**,
not as a bug fix, so it is visible in review.

## The recorded note bundled two deviations; only one is justified

`parity_matrix.rst` said hg_cpp "removes every formerly published key that is
now absent or invalid **and** does not republish unchanged values". Those are
two independent choices, and they have different standing:

**(a) We remove a key that has gone invalid; upstream never does. — KEEP.**
Upstream's own test carries the reason, on `release/0.5` at
`hgraph_unit_tests/_operators/test_stream_operators.py:552`:

> `FIXME: Item that has gone invalid does not show up in the renmoved items ever. This is a 'feature' but really needs some re-thinking`

Ours is the correction. Untouched by this PR.

**(b) We suppressed unchanged values on reopen; upstream republishes them. — REVERSED.**
Upstream flagged nothing here. This is the half that lost accumulated state.

## The change is one argument

`filter_impl`'s reopen calls `reconcile_current_state(..., {Full, sample_all})`.
`sample_all` was `false`, which short-circuits every child whose value is
unchanged. It is now `true`, which is upstream's `copy_from_input`:

```python
@compute_node(overloads=filter_)
def filter_default(condition: TS[bool], ts: TIME_SERIES_TYPE, _output: TIME_SERIES_TYPE = None):
    if condition.value:
        if condition.modified:
            if _output.last_modified_time < ts.last_modified_time:
                _output.copy_from_input(ts)      # <-- whole value, every type
                return None
        if ts.modified:
            return ts.delta_value
```

Half (a) lives in the *scope* field of the same options struct, so the two are
genuinely independent and (a) is unaffected. `copy_from_input` is a whole-value
copy for **every** type, so this is right for scalars as well as containers.

## Blast radius: exactly one pinned expectation, as predicted

The full C++ suite moved **one** test — `map_: EMPTY-REF child removals
propagate through a filtered map`:

```
actual:   {removed: {1, 3}, modified: {5: 6, 7: 8, 9: 10}}
expected: {removed: {1, 3}, modified: {}}
```

and `test_filter_str_tsd` moves the same way. Both now read
`{"1": REMOVE, "3": REMOVE, "5": 6, "7": 8, "9": 10}`.

I ran the pinned graph under released 0.5.41 directly to get the target rather
than predicting it:

```
3 frozendict({'7': 8, '9': 10, '5': 6, '3': Sentinel(REMOVE)})
```

So the reference republishes 5/7/9 and does **not** emit `1: REMOVE`. Our new
expectation is that, plus the single retained half-(a) correction — which is
exactly what the rewritten parity-matrix note now claims, and nothing more.

## Verification

New parity recipe `filter-tsd-reopen-republishes-unchanged` isolates half (b)
alone (no invalid keys, so (a) cannot muddy it), replayed **A/B against two
candidate wheels**:

| | candidate trace at tick 3 | verdict |
|---|---|---|
| before | `{b: 20}` | **DIVERGED** |
| after | `{a: 1, b: 20}` | `difference: null` |

Reference is `{a: 1, b: 20}` in both runs. The missing `a` is precisely the
accumulated state this issue reports as lost.

Local gates: full `python/tests` green (3412 passed, 9 skipped); full C++ suite
green after the one expectation moved.

`known_divergences.json` carries no filter entry, so nothing to retire there —
this deviation lived only in the parity matrix, which is rewritten in the same
commit to cover half (a) only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
