### PR TITLE
Declare exception's exc_info, and record the deprecated LOGGER aliases

### DIFF
--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -1444,10 +1444,17 @@ namespace hgraph::python_bridge
              "Log msg with severity ERROR through the native run logger.")
         .def("exception",
              [](const PyLogger &self, nb::handle message, nb::args args,
-                nb::kwargs kwargs) {
+                nb::object exc_info, nb::kwargs kwargs) {
+                 // Declared rather than absorbed into **kwargs so it is visible
+                 // to help(), IDEs and the surface audit, which is the whole of
+                 // the released difference -- the emit path already honoured it
+                 // (#810 item 3.4). Kept as an object so logging's tuple and
+                 // exception spellings keep working beside the bool.
+                 kwargs["exc_info"] = std::move(exc_info);
                  py_logger_emit(self, 4, message, args, kwargs, true);
              },
-             nb::arg("msg"), nb::arg("args"), nb::arg("kwargs"),
+             nb::arg("msg"), nb::arg("args"), nb::arg("exc_info") = true,
+             nb::arg("kwargs"),
              "Log msg with severity ERROR and current exception information.")
         .def("critical",
              [](const PyLogger &self, nb::handle message, nb::args args,

--- a/python/tests/test_logger_level_queries.py
+++ b/python/tests/test_logger_level_queries.py
@@ -76,6 +76,51 @@ def test_get_effective_level_uses_the_python_scale():
     ), f"{seen[0]} is not a standard Python logging level"
 
 
+def test_exception_declares_exc_info():
+    """``exc_info`` was honoured but absorbed into ``**kwargs``, so it was
+    invisible to help(), IDEs and the surface audit (#810 item 3.4).
+
+    It stays an object rather than a bool because logging accepts the
+    ``(type, value, tb)`` tuple and an exception instance beside ``True``.
+
+    Read through the audit's own ``_documented_signature`` -- ``inspect``
+    cannot introspect a nanobind method, so the audit parses the declaration
+    line out of ``__doc__``. Asserting on the same source is what makes this
+    test track the finding rather than approximate it.
+    """
+    from tools.parity.surface import _documented_signature
+
+    parameters = _documented_signature(LOGGER.exception)
+    assert parameters is not None, "exception's doc line did not parse"
+    exc_info = next(p for p in parameters if p["name"] == "exc_info")
+    assert exc_info["kind"] == "KEYWORD_ONLY"
+    assert exc_info["default"] == "True"
+
+
+@sink_node
+def _log_caught_exception(ts: TS[int], exc_info: bool, logger: LOGGER = None):
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        logger.exception("caught", exc_info=exc_info)
+
+
+@pytest.mark.parametrize("exc_info, traceback_expected", [(True, True), (False, False)])
+def test_exception_honours_exc_info(caplog, exc_info, traceback_expected):
+    """Declaring the parameter must not change what it does."""
+
+    @graph
+    def g(ts: TS[int]):
+        _log_caught_exception(ts, exc_info)
+
+    with caplog.at_level(logging.ERROR, logger="hgraph"):
+        eval_node(g, [1])
+
+    text = caplog.text
+    assert "caught" in text
+    assert ("ValueError: boom" in text) is traceback_expected
+
+
 def test_setlevel_and_deprecated_aliases_stay_absent():
     """Pinned so a later 'completeness' change has to argue with a test.
 

--- a/tools/parity/surface_known.json
+++ b/tools/parity/surface_known.json
@@ -3176,6 +3176,20 @@
     },
     {
       "module": "hgraph",
+      "name": "LOGGER.fatal",
+      "kind": "method-missing",
+      "side": "candidate",
+      "reason": "deliberately not implemented, ruling on #810 item 3.4: warn and fatal are deprecated aliases upstream (logging.Logger.warn has raised a DeprecationWarning since 3.3, and fatal is an undocumented alias for critical), so adding them here would import a deprecation rather than parity. The live spellings warning and critical are present. The rest of item 3.4 -- isEnabledFor, getEffectiveLevel (#839) and exception's exc_info -- is implemented"
+    },
+    {
+      "module": "hgraph",
+      "name": "LOGGER.warn",
+      "kind": "method-missing",
+      "side": "candidate",
+      "reason": "deliberately not implemented, ruling on #810 item 3.4: warn and fatal are deprecated aliases upstream (logging.Logger.warn has raised a DeprecationWarning since 3.3, and fatal is an undocumented alias for critical), so adding them here would import a deprecation rather than parity. The live spellings warning and critical are present. The rest of item 3.4 -- isEnabledFor, getEffectiveLevel (#839) and exception's exc_info -- is implemented"
+    },
+    {
+      "module": "hgraph",
       "name": "WiringGraphContext.add_built_service_impl",
       "kind": "method-missing",
       "side": "candidate",


### PR DESCRIPTION
Finishes **#810 item 3.4**. Your ruling was *"Don't do the depreciated methods.
do the suggested adds"*. That item bundled five findings; #839 did two of the
adds (`isEnabledFor`, `getEffectiveLevel`) and neither half of the rest.

## `exception`'s `exc_info` — an add that never landed

The behaviour was already correct: `py_logger_emit` reads `exc_info` out of
`**kwargs` and defaults it true for `exception()`. The whole of the released
difference was that the parameter was **invisible** — absent from `help()`,
from IDEs, and from the audit's parameter list:

| | signature |
|---|---|
| reference | `(self, msg, *args, exc_info=True, **kwargs)` — `exc_info` KEYWORD_ONLY |
| candidate (was) | `(self, msg, *args, **kwargs)` |
| candidate (now) | `exception(self, msg: object, *args, exc_info: object = True, **kwargs) -> None` |

Kept as `nb::object` rather than `bool` so logging's `(type, value, tb)` tuple
and exception-instance spellings keep working beside `True`, and put straight
back into `kwargs` so the emit path is untouched.

This is the same class of change as `DebugContext.print` in #848: a parameter
that worked but could not be seen.

## `warn` / `fatal` — recorded, per the ruling

Deprecated aliases upstream (`logging.Logger.warn` has raised a
`DeprecationWarning` since 3.3; `fatal` is an undocumented alias for
`critical`), so implementing them imports a deprecation rather than parity.

They are now rules in `surface_known.json`. Without them they stay
**actionable** forever and the audit can never converge — a decision not to
implement still has to be recorded somewhere the audit reads.
`test_setlevel_and_deprecated_aliases_stay_absent` already pinned the code
side; this pins the audit side to agree with it.

The `surface_known.json` diff is 14 lines, purely additive — the new rules are
inserted next to the existing `LOGGER.*` ones rather than re-sorting the file.

## Verification

Surface audit on this branch: the three LOGGER findings are **gone**, leaving 4
— which are exactly #816's, fixed by #848.

Measured together rather than assumed: with #848 merged in locally, the audit
reports **0 actionable findings**. The two PRs are independent and can land in
either order; between them the audit converges.

The signature test reads through the audit's own `_documented_signature`, not
`inspect`, which cannot introspect a nanobind method — so it tracks the finding
rather than approximating it. The behavioural pair covers `exc_info=True` and
`exc_info=False`, because declaring a parameter must not change what it does.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
