### PR TITLE
fix(hgl): keep candidate constraints on implementations

### DIFF
--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Keep implementation-only constraints on `impl fn`: the executable HGL
+  operator contracts no longer expose their candidates' native delegation
+  requirements, and the guides distinguish public semantic constraints from
+  algorithm dependencies.
 - Use `#` for line comments and `/* ... */` for block comments, freeing `//`
   as the floor-division symbol backed by the fixed `floordiv_` operator.
 - Add module-level `cpp include <header>` and `cpp include "header"` declarations

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -360,7 +360,11 @@ compatible specialization of the contract and may itself be generic. Its body
 is checked with the operator requirements in scope and classified through the
 ordinary composition-versus-runtime rules. Candidate-specific requirements may
 further restrict an implementation; dispatch applies the conjunction of the
-mapped contract and candidate requirements.
+mapped contract and candidate requirements. Candidate requirements remain
+local to that implementation. A dependency introduced by its algorithm, such
+as using `add_` to implement `double`, must not be promoted to the operator
+contract merely to make the body type-check; another implementation may use a
+different operation.
 
 A generic `impl fn` is a hidden implementation template rather than a runtime
 candidate with unresolved source generics. A module requests concrete

--- a/language/docs/design/operators.md
+++ b/language/docs/design/operators.md
@@ -15,6 +15,9 @@ current symbol set, including floor division, are implemented. HGL comments use
   The initial vocabulary is `associative`, `commutative`, and `identity`.
 - Result types and lifting are signature information, not algebraic properties.
   Division need not be closed over its input type.
+- Put only semantic, public constraints on an `operator`. A dependency needed
+  by one candidate's chosen algorithm belongs on that `impl fn`; it neither
+  constrains sibling implementations nor becomes part of the operator API.
 - No inverse declarations, group/field hierarchy, automatic reduction detection,
   or loop-to-map/reduce conversion in this iteration.
 - Missing metadata means **no guarantee**. A declaration is not a proof of a
@@ -165,8 +168,10 @@ scalar operation. See the [paired HGL/C++ examples](../developer-guide/operator-
 The executable [operator module](../../stdlib/hgl/hgraph/operators.hgl) declares
 the 16 arithmetic/comparison/Boolean hooks (including floor division),
 delegates implementations to production native candidates, and materializes
-the supported primitive combinations. Its `hgraph.operators.*` identities are
-parallel migration contracts, not replacements for the native system identities.
+the supported primitive combinations. The native-call requirements therefore
+belong to those delegating `impl fn` candidates, not the public contracts. Its
+`hgraph.operators.*` identities are parallel migration contracts, not
+replacements for the native system identities.
 The existing `getitem_`/`getattr_` projections are not redeclared as scalar binary
 arithmetic. Broader temporal, collection, and downstream scalar domains remain
 in the native registry until their HGL materializations are covered.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -188,7 +188,9 @@ it evaluates concretely or follows from those premises. Conjunction requires
 both goals, disjunction requires either goal, a disjunctive premise must imply
 the goal on every branch, and a narrower closed set implies a wider one. This
 is compile-time implication only; no requirement becomes a per-tick runtime
-test.
+test. The mapped contract requirement and candidate requirement remain
+separate IR records: their conjunction controls that candidate, but the
+candidate record never strengthens the public operator or any sibling.
 
 Every source type occurrence records its containing declaration until
 canonicalization. Typed HIR uses that ownership to validate a constrained

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -934,6 +934,10 @@ checked, and an implementation may add stricter candidate requirements. Its
 effective dispatch constraint is the conjunction of the mapped operator and
 candidate constraints. The body still passes through ordinary function
 classification and may lower to either graph composition or one runtime node.
+An implementation requirement is not copied back to the operator contract or
+to sibling candidates. A requirement needed only by the candidate's chosen
+algorithm belongs on `impl fn`; put it on `operator` only when every
+implementation and caller must observe it as part of the public abstraction.
 Several `impl fn` declarations may share a name; each is a separate candidate
 of the same operator. A non-generic `impl fn` contributes a public candidate
 directly. A generic `impl fn` contributes only candidates requested by an

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -274,18 +274,34 @@ protocol. It declares a call shape and generic relationships but has no body:
 operator combine<T>(lhs: T, rhs: T) -> T
 ```
 
-An operator may carry requirements as part of its public contract:
+An operator may carry requirements when they are part of its public contract:
 
 ```hgl
-operator double<U>(value: U) -> U
-requires add_(U, U) -> U
+operator choose_number<U>(lhs: U, rhs: U) -> U
+requires U in {f64, i64}
 ```
 
 Every implementation is checked with the operator requirements in scope and
 may add stricter candidate requirements. At dispatch, the effective constraint
 is the operator requirement combined with the candidate requirement. A
 candidate does not need to repeat the public constraint merely to use its
-guarantees in the body.
+guarantees in the body. Requirements introduced only because of an algorithm
+belong to that implementation, not the operator. For example, an
+addition-based implementation of `double` is:
+
+```hgl
+operator double<U>(value: U) -> U
+
+impl fn double<U>(value: U) -> U
+requires add_(U, U) -> U
+=> value + value
+```
+
+The contract does not require addition. A different candidate can implement
+the same operation using multiplication, for example
+`impl fn double(value: f64) -> f64 => value * 2.0`. These are alternative
+implementation strategies; their implementation-only constraints do not
+restrict one another or become part of the public operator contract.
 
 An operator is public by definition; there is no `export operator` form.
 

--- a/language/docs/user-guide/language-tour.md
+++ b/language/docs/user-guide/language-tour.md
@@ -133,20 +133,22 @@ requires U in {f64, i64}
 impl fn choose_number<U>(lhs: U, rhs: U) -> U => lhs
 
 operator double<U>(value: U) -> U
-requires add_(U, U) -> U
 
-impl fn double<U>(value: U) -> U => value + value
+impl fn double<U>(value: U) -> U
+requires add_(U, U) -> U
+=> value + value
 ```
 
 Repeating `U` requires the arguments and result to share one canonical source
-type. The first contract restricts that type to `f64` or `i64`. The second
-requires the system `add_` operator to accept two `U` values and produce `U`;
-its implementation may rely on that guarantee without repeating it. `hgl
-check` evaluates closed requirements during typed-HIR completion and asks the
-hgraph operator registry to decide native operator viability. Cases needing
-native nominal-struct metadata, arbitrary constant predicates, or source
-candidate ranking remain explicitly deferred or fail closed as described in
-the roadmap. Requirements are never tested per tick.
+type. The first contract restricts that type to `f64` or `i64` because that is
+part of its public meaning. `double` places the `add_` requirement on the
+addition-based implementation instead: another candidate may implement the
+same contract as `value * 2` without requiring addition. `hgl check` evaluates
+closed requirements during typed-HIR completion and asks the hgraph operator
+registry to decide native operator viability. Cases needing native
+nominal-struct metadata, arbitrary constant predicates, or source candidate
+ranking remain explicitly deferred or fail closed as described in the roadmap.
+Requirements are never tested per tick.
 
 ## Anonymous functions
 

--- a/language/generated/cpp/hgraph/operators.cpp
+++ b/language/generated/cpp/hgraph/operators.cpp
@@ -8,7 +8,7 @@ namespace hgraph_::operators_
 {
     namespace
     {
-        // operators.hgl:60
+        // operators.hgl:46
         struct add__impl_18__i64__i64__i64__m0
         {
             [[maybe_unused]] static constexpr auto       name = "hgraph.operators.add_#18@instantiate:0";
@@ -19,7 +19,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:60
+        // operators.hgl:46
         struct add__impl_18__i64__f64__f64__m1
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.add_#18@instantiate:1";
@@ -30,7 +30,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:60
+        // operators.hgl:46
         struct add__impl_18__f64__i64__f64__m2
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.add_#18@instantiate:2";
@@ -41,7 +41,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:60
+        // operators.hgl:46
         struct add__impl_18__f64__f64__f64__m3
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.add_#18@instantiate:3";
@@ -52,7 +52,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:63
+        // operators.hgl:49
         struct sub__impl_19__i64__i64__i64__m4
         {
             [[maybe_unused]] static constexpr auto       name = "hgraph.operators.sub_#19@instantiate:4";
@@ -63,7 +63,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:63
+        // operators.hgl:49
         struct sub__impl_19__i64__f64__f64__m5
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.sub_#19@instantiate:5";
@@ -74,7 +74,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:63
+        // operators.hgl:49
         struct sub__impl_19__f64__i64__f64__m6
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.sub_#19@instantiate:6";
@@ -85,7 +85,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:63
+        // operators.hgl:49
         struct sub__impl_19__f64__f64__f64__m7
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.sub_#19@instantiate:7";
@@ -96,7 +96,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:66
+        // operators.hgl:52
         struct mul__impl_20__i64__i64__i64__m8
         {
             [[maybe_unused]] static constexpr auto       name = "hgraph.operators.mul_#20@instantiate:8";
@@ -107,7 +107,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:66
+        // operators.hgl:52
         struct mul__impl_20__i64__f64__f64__m9
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.mul_#20@instantiate:9";
@@ -118,7 +118,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:66
+        // operators.hgl:52
         struct mul__impl_20__f64__i64__f64__m10
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.mul_#20@instantiate:10";
@@ -129,7 +129,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:66
+        // operators.hgl:52
         struct mul__impl_20__f64__f64__f64__m11
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.mul_#20@instantiate:11";
@@ -140,7 +140,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:69
+        // operators.hgl:55
         struct div__impl_21__i64__i64__f64__m12
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.div_#21@instantiate:12";
@@ -151,7 +151,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:69
+        // operators.hgl:55
         struct div__impl_21__i64__f64__f64__m13
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.div_#21@instantiate:13";
@@ -162,7 +162,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:69
+        // operators.hgl:55
         struct div__impl_21__f64__i64__f64__m14
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.div_#21@instantiate:14";
@@ -173,7 +173,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:69
+        // operators.hgl:55
         struct div__impl_21__f64__f64__f64__m15
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.div_#21@instantiate:15";
@@ -184,7 +184,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:72
+        // operators.hgl:58
         struct floordiv__impl_22__i64__i64__i64__m16
         {
             [[maybe_unused]] static constexpr auto       name = "hgraph.operators.floordiv_#22@instantiate:16";
@@ -195,7 +195,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:72
+        // operators.hgl:58
         struct floordiv__impl_22__i64__f64__f64__m17
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.floordiv_#22@instantiate:17";
@@ -206,7 +206,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:72
+        // operators.hgl:58
         struct floordiv__impl_22__f64__i64__f64__m18
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.floordiv_#22@instantiate:18";
@@ -217,7 +217,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:72
+        // operators.hgl:58
         struct floordiv__impl_22__f64__f64__f64__m19
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.floordiv_#22@instantiate:19";
@@ -228,7 +228,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:75
+        // operators.hgl:61
         struct mod__impl_23__i64__i64__i64__m20
         {
             [[maybe_unused]] static constexpr auto       name = "hgraph.operators.mod_#23@instantiate:20";
@@ -239,7 +239,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:75
+        // operators.hgl:61
         struct mod__impl_23__i64__f64__f64__m21
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.mod_#23@instantiate:21";
@@ -250,7 +250,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:75
+        // operators.hgl:61
         struct mod__impl_23__f64__i64__f64__m22
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.mod_#23@instantiate:22";
@@ -261,7 +261,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:75
+        // operators.hgl:61
         struct mod__impl_23__f64__f64__f64__m23
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.mod_#23@instantiate:23";
@@ -272,7 +272,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:78
+        // operators.hgl:64
         struct eq__impl_24__i64__i64__m24
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.eq_#24@instantiate:24";
@@ -283,7 +283,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:78
+        // operators.hgl:64
         struct eq__impl_24__f64__f64__m25
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.eq_#24@instantiate:25";
@@ -294,7 +294,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:78
+        // operators.hgl:64
         struct eq__impl_24__i64__f64__m26
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.eq_#24@instantiate:26";
@@ -305,7 +305,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:78
+        // operators.hgl:64
         struct eq__impl_24__f64__i64__m27
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.eq_#24@instantiate:27";
@@ -316,7 +316,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:78
+        // operators.hgl:64
         struct eq__impl_24__str__str__m28
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.eq_#24@instantiate:28";
@@ -327,7 +327,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:78
+        // operators.hgl:64
         struct eq__impl_24__bool__bool__m29
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.eq_#24@instantiate:29";
@@ -338,7 +338,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:81
+        // operators.hgl:67
         struct ne__impl_25__i64__i64__m30
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.ne_#25@instantiate:30";
@@ -349,7 +349,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:81
+        // operators.hgl:67
         struct ne__impl_25__f64__f64__m31
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.ne_#25@instantiate:31";
@@ -360,7 +360,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:81
+        // operators.hgl:67
         struct ne__impl_25__i64__f64__m32
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.ne_#25@instantiate:32";
@@ -371,7 +371,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:81
+        // operators.hgl:67
         struct ne__impl_25__f64__i64__m33
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.ne_#25@instantiate:33";
@@ -382,7 +382,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:81
+        // operators.hgl:67
         struct ne__impl_25__str__str__m34
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.ne_#25@instantiate:34";
@@ -393,7 +393,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:81
+        // operators.hgl:67
         struct ne__impl_25__bool__bool__m35
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.ne_#25@instantiate:35";
@@ -404,7 +404,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:84
+        // operators.hgl:70
         struct lt__impl_26__i64__i64__m36
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.lt_#26@instantiate:36";
@@ -415,7 +415,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:84
+        // operators.hgl:70
         struct lt__impl_26__f64__f64__m37
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.lt_#26@instantiate:37";
@@ -426,7 +426,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:84
+        // operators.hgl:70
         struct lt__impl_26__i64__f64__m38
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.lt_#26@instantiate:38";
@@ -437,7 +437,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:84
+        // operators.hgl:70
         struct lt__impl_26__f64__i64__m39
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.lt_#26@instantiate:39";
@@ -448,7 +448,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:84
+        // operators.hgl:70
         struct lt__impl_26__str__str__m40
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.lt_#26@instantiate:40";
@@ -459,7 +459,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:87
+        // operators.hgl:73
         struct le__impl_27__i64__i64__m41
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.le_#27@instantiate:41";
@@ -470,7 +470,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:87
+        // operators.hgl:73
         struct le__impl_27__f64__f64__m42
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.le_#27@instantiate:42";
@@ -481,7 +481,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:87
+        // operators.hgl:73
         struct le__impl_27__i64__f64__m43
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.le_#27@instantiate:43";
@@ -492,7 +492,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:87
+        // operators.hgl:73
         struct le__impl_27__f64__i64__m44
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.le_#27@instantiate:44";
@@ -503,7 +503,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:87
+        // operators.hgl:73
         struct le__impl_27__str__str__m45
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.le_#27@instantiate:45";
@@ -514,7 +514,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:90
+        // operators.hgl:76
         struct gt__impl_28__i64__i64__m46
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.gt_#28@instantiate:46";
@@ -525,7 +525,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:90
+        // operators.hgl:76
         struct gt__impl_28__f64__f64__m47
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.gt_#28@instantiate:47";
@@ -536,7 +536,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:90
+        // operators.hgl:76
         struct gt__impl_28__i64__f64__m48
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.gt_#28@instantiate:48";
@@ -547,7 +547,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:90
+        // operators.hgl:76
         struct gt__impl_28__f64__i64__m49
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.gt_#28@instantiate:49";
@@ -558,7 +558,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:90
+        // operators.hgl:76
         struct gt__impl_28__str__str__m50
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.gt_#28@instantiate:50";
@@ -569,7 +569,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:93
+        // operators.hgl:79
         struct ge__impl_29__i64__i64__m51
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.ge_#29@instantiate:51";
@@ -580,7 +580,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:93
+        // operators.hgl:79
         struct ge__impl_29__f64__f64__m52
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.ge_#29@instantiate:52";
@@ -591,7 +591,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:93
+        // operators.hgl:79
         struct ge__impl_29__i64__f64__m53
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.ge_#29@instantiate:53";
@@ -602,7 +602,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:93
+        // operators.hgl:79
         struct ge__impl_29__f64__i64__m54
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.ge_#29@instantiate:54";
@@ -613,7 +613,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:93
+        // operators.hgl:79
         struct ge__impl_29__str__str__m55
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.ge_#29@instantiate:55";
@@ -624,7 +624,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:96
+        // operators.hgl:82
         struct and__impl_30__bool__bool__m56
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.and_#30@instantiate:56";
@@ -635,7 +635,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:96
+        // operators.hgl:82
         struct and__impl_30__i64__i64__m57
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.and_#30@instantiate:57";
@@ -646,7 +646,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:96
+        // operators.hgl:82
         struct and__impl_30__f64__f64__m58
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.and_#30@instantiate:58";
@@ -657,7 +657,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:96
+        // operators.hgl:82
         struct and__impl_30__str__str__m59
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.and_#30@instantiate:59";
@@ -668,7 +668,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:96
+        // operators.hgl:82
         struct and__impl_30__i64__f64__m60
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.and_#30@instantiate:60";
@@ -679,7 +679,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:96
+        // operators.hgl:82
         struct and__impl_30__f64__i64__m61
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.and_#30@instantiate:61";
@@ -690,7 +690,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:99
+        // operators.hgl:85
         struct or__impl_31__bool__bool__m62
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.or_#31@instantiate:62";
@@ -701,7 +701,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:99
+        // operators.hgl:85
         struct or__impl_31__i64__i64__m63
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.or_#31@instantiate:63";
@@ -712,7 +712,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:99
+        // operators.hgl:85
         struct or__impl_31__f64__f64__m64
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.or_#31@instantiate:64";
@@ -723,7 +723,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:99
+        // operators.hgl:85
         struct or__impl_31__str__str__m65
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.or_#31@instantiate:65";
@@ -734,7 +734,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:99
+        // operators.hgl:85
         struct or__impl_31__i64__f64__m66
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.or_#31@instantiate:66";
@@ -745,7 +745,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:99
+        // operators.hgl:85
         struct or__impl_31__f64__i64__m67
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.or_#31@instantiate:67";
@@ -756,7 +756,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:102
+        // operators.hgl:88
         struct neg__impl_32__i64__i64__m68
         {
             [[maybe_unused]] static constexpr auto       name = "hgraph.operators.neg_#32@instantiate:68";
@@ -766,7 +766,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:102
+        // operators.hgl:88
         struct neg__impl_32__f64__f64__m69
         {
             [[maybe_unused]] static constexpr auto         name = "hgraph.operators.neg_#32@instantiate:69";
@@ -776,7 +776,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:105
+        // operators.hgl:91
         struct not__impl_33__bool__m70
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.not_#33@instantiate:70";
@@ -786,7 +786,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:105
+        // operators.hgl:91
         struct not__impl_33__i64__m71
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.not_#33@instantiate:71";
@@ -796,7 +796,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:105
+        // operators.hgl:91
         struct not__impl_33__f64__m72
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.not_#33@instantiate:72";
@@ -806,7 +806,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:105
+        // operators.hgl:91
         struct not__impl_33__str__m73
         {
             [[maybe_unused]] static constexpr auto        name = "hgraph.operators.not_#33@instantiate:73";
@@ -816,7 +816,7 @@ namespace hgraph_::operators_
             }
         };
 
-        // operators.hgl:60
+        // operators.hgl:46
         struct add__impl_18__str__str__str__m74
         {
             [[maybe_unused]] static constexpr auto       name = "hgraph.operators.add_#18@instantiate:74";

--- a/language/generated/cpp/hgraph/operators.h
+++ b/language/generated/cpp/hgraph/operators.h
@@ -21,52 +21,52 @@ namespace hgraph_::operators_
     /// Operator contracts for the module's public callables.
     namespace operators
     {
-        // operators.hgl:7
+        // operators.hgl:9
         using add_ = hgraph::Operator<"hgraph.operators.add_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                       hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TsVar<"O">>>;
-        // operators.hgl:12
+        // operators.hgl:13
         using sub_ = hgraph::Operator<"hgraph.operators.sub_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                       hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TsVar<"O">>>;
         // operators.hgl:15
         using mul_ = hgraph::Operator<"hgraph.operators.mul_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                       hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TsVar<"O">>>;
-        // operators.hgl:19
+        // operators.hgl:18
         using div_ = hgraph::Operator<"hgraph.operators.div_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                       hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TsVar<"O">>>;
-        // operators.hgl:22
+        // operators.hgl:20
         using floordiv_ = hgraph::Operator<"hgraph.operators.floordiv_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                            hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TsVar<"O">>>;
-        // operators.hgl:25
+        // operators.hgl:22
         using mod_ = hgraph::Operator<"hgraph.operators.mod_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                       hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TsVar<"O">>>;
-        // operators.hgl:28
+        // operators.hgl:24
         using eq_ = hgraph::Operator<"hgraph.operators.eq_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                      hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TS<hgraph::Bool>>>;
-        // operators.hgl:31
+        // operators.hgl:26
         using ne_ = hgraph::Operator<"hgraph.operators.ne_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                      hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TS<hgraph::Bool>>>;
-        // operators.hgl:34
+        // operators.hgl:28
         using lt_ = hgraph::Operator<"hgraph.operators.lt_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                      hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TS<hgraph::Bool>>>;
-        // operators.hgl:37
+        // operators.hgl:30
         using le_ = hgraph::Operator<"hgraph.operators.le_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                      hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TS<hgraph::Bool>>>;
-        // operators.hgl:40
+        // operators.hgl:32
         using gt_ = hgraph::Operator<"hgraph.operators.gt_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                      hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TS<hgraph::Bool>>>;
-        // operators.hgl:43
+        // operators.hgl:34
         using ge_ = hgraph::Operator<"hgraph.operators.ge_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                      hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TS<hgraph::Bool>>>;
-        // operators.hgl:46
+        // operators.hgl:36
         using and_ = hgraph::Operator<"hgraph.operators.and_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                       hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TS<hgraph::Bool>>>;
-        // operators.hgl:50
+        // operators.hgl:39
         using or_ = hgraph::Operator<"hgraph.operators.or_", hgraph::In<"lhs", hgraph::TsVar<"L">>,
                                      hgraph::In<"rhs", hgraph::TsVar<"R">>, hgraph::Out<hgraph::TS<hgraph::Bool>>>;
-        // operators.hgl:54
+        // operators.hgl:42
         using neg_ =
             hgraph::Operator<"hgraph.operators.neg_", hgraph::In<"ts", hgraph::TsVar<"T">>, hgraph::Out<hgraph::TsVar<"O">>>;
-        // operators.hgl:57
+        // operators.hgl:44
         using not_ =
             hgraph::Operator<"hgraph.operators.not_", hgraph::In<"ts", hgraph::TsVar<"T">>, hgraph::Out<hgraph::TS<hgraph::Bool>>>;
     }  // namespace operators

--- a/language/stdlib/hgl/hgraph/operators.hgl
+++ b/language/stdlib/hgl/hgraph/operators.hgl
@@ -1,61 +1,47 @@
 # Executable parallel HGL contracts over the production native operators.
 # These module-local contracts do not replace the fixed system identities.
+# Native delegation is an implementation choice, so its requirements belong
+# to the impl fn candidates rather than these public contracts.
 module hgraph.operators
 
 use hgraph.std as core
 
 operator add_<L, R, O>(lhs: L, rhs: R) -> O
-requires core::add_(L, R) -> O
 properties<str, str, str> { associative, identity = "" }
 properties<i64, i64, i64> { commutative, identity = 0 }
 
 operator sub_<L, R, O>(lhs: L, rhs: R) -> O
-requires core::sub_(L, R) -> O
 
 operator mul_<L, R, O>(lhs: L, rhs: R) -> O
-requires core::mul_(L, R) -> O
 properties<i64, i64, i64> { commutative, identity = 1 }
 
 operator div_<L, R, O>(lhs: L, rhs: R) -> O
-requires core::div_(L, R) -> O
 
 operator floordiv_<L, R, O>(lhs: L, rhs: R) -> O
-requires core::floordiv_(L, R) -> O
 
 operator mod_<L, R, O>(lhs: L, rhs: R) -> O
-requires core::mod_(L, R) -> O
 
 operator eq_<L, R>(lhs: L, rhs: R) -> bool
-requires core::eq_(L, R) -> bool
 
 operator ne_<L, R>(lhs: L, rhs: R) -> bool
-requires core::ne_(L, R) -> bool
 
 operator lt_<L, R>(lhs: L, rhs: R) -> bool
-requires core::lt_(L, R) -> bool
 
 operator le_<L, R>(lhs: L, rhs: R) -> bool
-requires core::le_(L, R) -> bool
 
 operator gt_<L, R>(lhs: L, rhs: R) -> bool
-requires core::gt_(L, R) -> bool
 
 operator ge_<L, R>(lhs: L, rhs: R) -> bool
-requires core::ge_(L, R) -> bool
 
 operator and_<L, R>(lhs: L, rhs: R) -> bool
-requires core::and_(L, R) -> bool
 properties<bool, bool> { associative, commutative, identity = true }
 
 operator or_<L, R>(lhs: L, rhs: R) -> bool
-requires core::or_(L, R) -> bool
 properties<bool, bool> { associative, commutative, identity = false }
 
 operator neg_<T, O>(ts: T) -> O
-requires core::neg_(T) -> O
 
 operator not_<T>(ts: T) -> bool
-requires core::not_(T) -> bool
 
 impl fn add_<L, R, O>(lhs: L, rhs: R) -> O
 requires core::add_(L, R) -> O => core::add_(lhs, rhs)

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -782,14 +782,18 @@ struct Swap<X, Y>: Pair<Y, X> {}
     CHECK(second.nominal_identity == "X");
 }
 
-TEST_CASE("hgraph IR preserves operator and implementation requirements", "[hgraph-ir][constraints][operators]") {
+TEST_CASE("hgraph IR keeps public and implementation requirements distinct", "[hgraph-ir][constraints][operators]") {
     Lowered lowered{R"(
 module checks.requirements
 
 operator ordered<T>(value: T) -> T
 requires T in {i64, f64}
 
-impl fn ordered<T>(value: T) -> T
+impl fn ordered<T>(value: T) -> T => value
+
+operator chosen<T>(value: T) -> T
+
+impl fn chosen<T>(value: T) -> T
 requires T in {i64, f64}
 => value
 )"};
@@ -797,10 +801,12 @@ requires T in {i64, f64}
     REQUIRE_FALSE(lowered.diagnostics.has_errors());
     REQUIRE(lowered.graph);
 
-    REQUIRE(lowered.graph->operators.size() == 1);
-    CHECK(lowered.graph->operators.front().requirements.valid());
-    REQUIRE(lowered.graph->callables.size() == 1);
-    CHECK(lowered.graph->callables.front().requirements.valid());
+    REQUIRE(lowered.graph->operators.size() == 2);
+    CHECK(lowered.graph->operators[0].requirements.valid());
+    CHECK_FALSE(lowered.graph->operators[1].requirements.valid());
+    REQUIRE(lowered.graph->callables.size() == 2);
+    CHECK_FALSE(lowered.graph->callables[0].requirements.valid());
+    CHECK(lowered.graph->callables[1].requirements.valid());
 }
 
 TEST_CASE("hgraph IR lowering rejects unresolved HIR", "[hgraph-ir][completion]") {

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -1194,17 +1194,19 @@ fn double<T>(value: T) -> T requires add_(T, T) -> T => value + value
     CHECK_FALSE(complete(local));
 }
 
-TEST_CASE("operator implementations inherit contract requirements", "[ir][typed][constraints][operators]") {
+TEST_CASE("implementation requirements provide body premises without constraining the operator",
+          "[ir][typed][constraints][operators]") {
     Lowered lowered{R"(
-module checks.inherited_operator_constraint
+module checks.implementation_constraint
 
 operator add<T>(lhs: T, rhs: T) -> T
 impl fn add(lhs: f64, rhs: f64) -> f64 => lhs + rhs
 
 operator double<T>(value: T) -> T
-requires add(T, T) -> T
 
-impl fn double(value: f64) -> f64 => value + value
+impl fn double(value: f64) -> f64
+requires add(f64, f64) -> f64
+=> value + value
 fn apply_double(value: f64) -> f64 => double(value)
 )"};
     require_clean(lowered);


### PR DESCRIPTION
## Summary

- keep public `operator` contracts free of requirements introduced only by one implementation strategy
- move native delegation requirements in the accepted HGL operator library onto their `impl fn` candidates
- document and test the separation between public contract requirements and candidate-local requirements
- refresh accepted generated C++ source locations

An operator can still carry a requirement when it is part of the public abstraction. For example, a numeric-domain restriction belongs on the operator; requiring `add_` solely because one `double` implementation uses `value + value` belongs on that implementation. A sibling implementation may use multiplication without inheriting the addition requirement.

## Validation

- `cmake --preset cpp --fresh -DHGRAPH_BUILD_LANGUAGE=ON`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2 --output-on-failure` (1822 passed)
- stable-ABI wheel built with Python 3.12, installed into a fresh Python 3.14 environment
- `python -m pytest python/tests -q -m "not wip"` (3421 passed, 10 skipped)
- `git clang-format --diff HEAD -- language/tests/hgraph_ir/lower_tests.cpp language/tests/ir/lower_tests.cpp`
- `git diff --check`