### PR TITLE
Enforce a graph's declared output type at wiring

### DIFF
--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -11,7 +11,7 @@ from .._types import (_ContextExpr, _GenericTsExpr, _TsExpr,
 from ._core import (ParseError, WiringError, WiringPort, _current_wiring,
                     _resolve_context, _unwrap, _wiring_stack, wire)
 from ._markers import (LOGGER, _INJECTABLE_MARKERS, _RecordableStateExpr,
-                       _StateExpr, _annotation_ts_kind)
+                       _StateExpr, _annotation_ts_kind, _is_object_vt)
 from ._node import (_PyNode, _is_time_series_annotation,
                     _bind_partial, _ensure_current_signature,
                     _lift_time_series_argument, _partial_binding_plan,
@@ -30,6 +30,106 @@ _GRAPH_INJECTABLES = frozenset((GlobalState, LOGGER))
 def _is_injectable_annotation(annotation):
     return (annotation in _INJECTABLE_MARKERS or
             isinstance(annotation, (_StateExpr, _RecordableStateExpr)))
+
+
+_FRAME_TS_PATTERN = None
+
+
+def _is_frame_ts(handle):
+    """Is this a frame-valued time series -- typed or erased?
+
+    Classified through the C++ pattern machinery and the interned erased
+    ``frame`` scalar, never by rendered label (the rule ``_markers`` states).
+    """
+    global _FRAME_TS_PATTERN
+    if handle is None or not handle.is_ts:
+        return False
+    try:
+        if _hgraph.ts_value_vt(handle) == _hgraph.value_type("frame"):
+            return True   # the erased 'frame' scalar: no column schema yet
+    except TypeError:
+        return False
+    if _FRAME_TS_PATTERN is None:
+        _FRAME_TS_PATTERN = _hgraph.type_pattern_ts(
+            _hgraph.scalar_pattern_frame(_hgraph.scalar_pattern_var("F")))
+    return _hgraph.ResolutionScope().match(_FRAME_TS_PATTERN, handle)
+
+
+def _output_check_deferred(declared, actual):
+    """Shapes whose WIRING-TIME type is under-specified relative to the
+    declaration, so comparing them here would reject working graphs.
+
+    These are deferrals, not widenings of assignability -- they live on the
+    output boundary rather than in ``binding_matches`` so that input binding is
+    not loosened by the same stroke. Both are tracked for removal; the honest
+    fix is for wiring to carry the specified type in the first place.
+
+    * **Frames.** ``convert[TS[Frame[AB]]](...)`` yields an erased ``TS[frame]``
+      at wiring time, and a typed frame may be spelled nominally
+      (``frame[AB]``) or structurally (``frame[Bundle{a:int,b:int}]``) for the
+      same schema. Released hgraph accepts both, and the P4 ruling that an
+      output frame schema is EXACT cannot be enforced until the schema is
+      actually attached at wiring.
+    * **Erased python values.** A ``TS[Any]`` result reaching a typed
+      declaration is the opaque-python counterpart of the same problem.
+    """
+    if _is_frame_ts(declared) and _is_frame_ts(actual):
+        return True
+    try:
+        if actual.is_ts and _is_object_vt(_hgraph.ts_value_vt(actual)):
+            return True
+    except TypeError:
+        pass
+    return False
+
+
+def _check_declared_output(declared_expr, raw, label):
+    """Reject a graph body whose returned type cannot satisfy the declaration.
+
+    Without this a graph could declare ``TS[bool]`` and return ``TS[int]``, and
+    the mismatch survived to whatever downstream trusted the declaration --
+    ``int`` values delivered through a declared ``TS[bool]``, or a ``TS``
+    delivered through a declared ``TSD`` (issue #811).
+
+    Only a CONCRETE declaration is enforced. ``_GenericTsExpr`` (``TS[SCALAR]``,
+    ``TIME_SERIES_TYPE``) is documented as "treated like an absent annotation" --
+    it resolves from the wired ports rather than constraining them, so there is
+    nothing to check and checking would break every generic graph.
+
+    The test is ASSIGNABILITY, not equality, and it reuses the same predicate
+    that decides input binding: declaring ``TS[Instrument]`` and returning
+    ``TS[Future]`` is correct covariance, and ``TS[Any]`` widens over any
+    payload. Writing this as handle equality rejected 87 legitimate graphs.
+
+    Comparison is on DEREFERENCED types, because a reference is how a value
+    travels rather than what it is; the message reports the types as declared
+    and returned, which is the released wording.
+    """
+    from ._node import binding_matches
+
+    if not isinstance(declared_expr, _TsExpr):
+        return
+    declared = getattr(declared_expr, "handle", None)
+    if declared is None:
+        return
+    actual = getattr(raw, "ts_type", None)
+    if actual is None:
+        # A wiring port with no output: service clients return one even though
+        # they publish nothing. The released implementation special-cases the
+        # same shape.
+        return
+    if declared.dereference == actual.dereference:
+        return
+    # A fresh scope: a concrete declaration binds no type variables, and we
+    # must not leak bindings into the caller's resolution.
+    if binding_matches(declared_expr, actual.dereference, _hgraph.ResolutionScope()):
+        return
+    if _output_check_deferred(declared, actual):
+        return
+    raise WiringError(
+        f"'{label}' declares its output as '{declared}' but "
+        f"'{actual}' was returned from the graph"
+    )
 
 
 def _wrap_graph_fn(gfn, *, input_names=None, scalar_bindings=None,
@@ -96,6 +196,7 @@ def _wrap_graph_fn(gfn, *, input_names=None, scalar_bindings=None,
                 # (hgraph parity - dispatch branches `return "woof"`).
                 out = wire("const", out)
             raw = _unwrap(out)
+            _check_declared_output(out_tp, raw, label)
             # Common C++ subgraph finalization converts a structural result
             # into its zero-copy REF terminal. Leaving the structural port
             # intact here keeps Python and native graph functions on the same
@@ -656,16 +757,23 @@ class _GraphFn:
             # the annotation is generic/absent).
             annotation = self._signature.return_annotation
             if isinstance(annotation, _TsExpr) and annotation.handle.is_tsb:
-                return annotation.from_ts(**result)
-            fields = [(k, _unwrap(v).ts_type) for k, v in result.items()]
-            tsb_type = _hgraph.un_named_tsb_type(fields)
-            return WiringPort(_hgraph.tsb_port(tsb_type, {k: _unwrap(v) for k, v in result.items()}))
-        if (result is not None and not isinstance(result, WiringPort)
+                result = annotation.from_ts(**result)
+            else:
+                fields = [(k, _unwrap(v).ts_type) for k, v in result.items()]
+                tsb_type = _hgraph.un_named_tsb_type(fields)
+                result = WiringPort(
+                    _hgraph.tsb_port(tsb_type, {k: _unwrap(v) for k, v in result.items()}))
+        elif (result is not None and not isinstance(result, WiringPort)
                 and _is_time_series_annotation(self._signature.return_annotation)):
             # hgraph parity: a plain value returned from a @graph with a
             # time-series return annotation lifts to const of that type.
-            return _lift_time_series_argument(
+            result = _lift_time_series_argument(
                 result, self._signature.return_annotation)
+        # Every return path funnels here so the declared output is enforced
+        # once, after the coercions above have had their say (issue #811).
+        if isinstance(result, WiringPort):
+            _check_declared_output(
+                self._signature.return_annotation, _unwrap(result), self.__name__)
         return result
 
 

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -76,7 +76,10 @@ def _output_check_deferred(declared, actual):
     if _is_frame_ts(declared) and _is_frame_ts(actual):
         return True
     try:
-        if actual.is_ts and _is_object_vt(_hgraph.ts_value_vt(actual)):
+        # Only a scalar TS declaration: an erased payload says nothing about the
+        # outer shape, so without this a declared TSD would accept a TS[Any]
+        # (issue #811 review).
+        if declared.is_ts and actual.is_ts and _is_object_vt(_hgraph.ts_value_vt(actual)):
             return True
     except TypeError:
         pass

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -70,9 +70,15 @@ def binding_matches(annotation, port_tp, scope):
 
     if isinstance(annotation, _TsExpr):
         handle = annotation.handle
-        if handle.is_ts and _is_object_vt(_hgraph.ts_value_vt(handle)):
+        # Both widenings are about the PAYLOAD, so they may only fire when the
+        # outer shapes already agree. Without that, TS[object] would accept a
+        # TSD and TSW would accept anything at all -- the very hole the
+        # declared-output check exists to close, and one no C++ signature can
+        # admit (issue #811 review).
+        if (handle.is_ts and port_tp is not None and port_tp.is_ts and
+                _is_object_vt(_hgraph.ts_value_vt(handle))):
             return True
-        if handle.kind == _tsw_kind():
+        if handle.kind == _tsw_kind() and port_tp is not None and port_tp.kind == _tsw_kind():
             return True
         if handle == port_tp:
             return True

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -40,6 +40,67 @@ def _node_ref(fn):
         return _hgraph.node_ref(fn)
 
 
+def binding_matches(annotation, port_tp, scope):
+    """Is a port of ``port_tp`` acceptable where ``annotation`` is declared?
+
+    This is the ONE assignability rule. It decides whether a wired port may
+    bind to a declared input, and -- since the question is identical -- whether
+    a graph body's result may satisfy its declared output (issue #811). Keeping
+    both on this single predicate is deliberate: a second, subtly different
+    notion of "compatible" is exactly the parallel abstraction the architecture
+    guardrails exist to prevent, and the two would drift.
+
+    Assignability is wider than equality, and every widening below is
+    load-bearing -- each was falsified by a test when the check was first
+    written as handle equality:
+
+    * ``TS[object]``/``TS[Any]`` widens over any payload (the py-any rule),
+    * ``TSW`` is deferred while min-period defaults are applied at wiring, so
+      handle equality over-rejects,
+    * the C++ pattern matcher owns type-variable binding and structural
+      matching,
+    * ``tuple[E, ...]`` widens over fixed tuples of ``E``,
+    * a concrete ``CompoundScalar`` annotation accepts SUBCLASS ports, which is
+      the covariance ``dispatch`` relies on.
+
+    ``scope`` is mutated by pattern matching: type variables bind into it.
+    Callers that must not bind should pass a throwaway scope.
+    """
+    from .._types import TS, _pattern_of
+
+    if isinstance(annotation, _TsExpr):
+        handle = annotation.handle
+        if handle.is_ts and _is_object_vt(_hgraph.ts_value_vt(handle)):
+            return True
+        if handle.kind == _tsw_kind():
+            return True
+        if handle == port_tp:
+            return True
+    try:
+        pattern = _pattern_of(annotation)
+    except TypeError:
+        return True   # non-ts annotation reached with a port: leave to the runtime
+    if scope.match(pattern, port_tp):
+        return True
+    if isinstance(annotation, _TsExpr) and annotation.handle.is_ts:
+        vt = _hgraph.ts_value_vt(annotation.handle)
+        if _hgraph.vt_kind(vt) == _unbounded_tuple_kind():
+            homogeneous = _hgraph.type_pattern_ts(
+                _hgraph.scalar_pattern_homogeneous_tuple(
+                    _hgraph.scalar_pattern_value(_hgraph.vt_element(vt))))
+            if scope.match(homogeneous, port_tp):
+                return True
+    cs_class = getattr(annotation, "_cs_class", None)
+    if cs_class is not None:
+        stack = list(cs_class.__subclasses__())
+        while stack:
+            candidate = stack.pop()
+            stack.extend(candidate.__subclasses__())
+            if TS[candidate].handle == port_tp:
+                return True   # subtype binding (auto-cast)
+    return False
+
+
 def _signature_registry_generation(signature):
     """Generation owning concrete TS handles retained by a signature."""
     annotations = [
@@ -562,13 +623,11 @@ class _PyNode:
         binding type variables into the scope. A mismatch on a concrete
         CompoundScalar annotation accepts SUBCLASS ports (python's
         inheritance is a py-frontend concept); anything else raises."""
-        from .._types import TS, _pattern_of
+        import typing
 
         annotation = param.annotation
         if isinstance(annotation, _ContextExpr):
             return
-        import typing
-
         if typing.get_origin(annotation) is typing.Union:
             members = typing.get_args(annotation)
             port_tp = _unwrap(value).ts_type
@@ -577,44 +636,9 @@ class _PyNode:
                     return
             raise IncorrectTypeBinding(
                 f"{self.__name__}: '{param.name}' expects one of {members!r}")
-        if isinstance(annotation, _TsExpr):
-            handle = annotation.handle
-            # TS[object] widens over any payload (the py-any input rule).
-            if handle.is_ts and _is_object_vt(_hgraph.ts_value_vt(handle)):
-                return
-            # TSW strictness is deferred until the duration/tick marker
-            # normalisation lands (min-period defaults are applied at
-            # wiring, so handle equality over-rejects).
-            if handle.kind == _tsw_kind():
-                return
-            port_tp = _unwrap(value).ts_type
-            if handle == port_tp:
-                return
-        try:
-            pattern = _pattern_of(annotation)
-        except TypeError:
-            return   # non-ts annotation reached with a port: leave to the runtime
         port_tp = _unwrap(value).ts_type
-        if scope.match(pattern, port_tp):
+        if binding_matches(annotation, port_tp, scope):
             return
-        if isinstance(annotation, _TsExpr) and annotation.handle.is_ts:
-            # tuple[E, ...] widens over fixed tuples of E: re-match with the
-            # C++ homogeneous-tuple pattern (the matcher owns that rule).
-            vt = _hgraph.ts_value_vt(annotation.handle)
-            if _hgraph.vt_kind(vt) == _unbounded_tuple_kind():
-                homogeneous = _hgraph.type_pattern_ts(
-                    _hgraph.scalar_pattern_homogeneous_tuple(
-                        _hgraph.scalar_pattern_value(_hgraph.vt_element(vt))))
-                if scope.match(homogeneous, port_tp):
-                    return
-        cs_class = getattr(annotation, "_cs_class", None)
-        if cs_class is not None:
-            stack = list(cs_class.__subclasses__())
-            while stack:
-                candidate = stack.pop()
-                stack.extend(candidate.__subclasses__())
-                if TS[candidate].handle == port_tp:
-                    return   # subtype binding (auto-cast)
         raise IncorrectTypeBinding(
             f"{self.__name__}: '{param.name}' expects {annotation!r}, got {port_tp!r}")
 

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -818,6 +818,18 @@ namespace hgraph::python_bridge
         .def_prop_ro("is_ref", [](const PyTsType &self) {
             return self.meta != nullptr && self.meta->kind == TSTypeKind::REF;
         })
+        .def_prop_ro("dereference", [](const PyTsType &self) {
+            // The referenced type, with REF wrappers peeled off; self when not
+            // a reference. A reference is how a value travels, not what it is,
+            // so declared-vs-actual comparisons are made on this (issue #811,
+            // matching the released check which dereferences both sides).
+            const TSValueTypeMetaData *meta = self.meta;
+            while (meta != nullptr && meta->kind == TSTypeKind::REF && meta->referenced_ts() != nullptr)
+            {
+                meta = meta->referenced_ts();
+            }
+            return PyTsType{meta};
+        })
         .def_prop_ro("is_fixed_tsl", [](const PyTsType &self) {
             return self.meta != nullptr && self.meta->kind == TSTypeKind::TSL && self.meta->fixed_size() > 0;
         })

--- a/python/tests/test_declared_graph_output.py
+++ b/python/tests/test_declared_graph_output.py
@@ -145,3 +145,50 @@ def test_covariance_is_still_accepted():
         return const(Derived(1, 2), TS[Derived])
 
     assert eval_node(g) == [Derived(1, 2)]
+
+
+def test_an_erased_payload_does_not_excuse_a_different_shape():
+    """The payload widenings must not admit a different OUTER shape.
+
+    ``TS[object]`` widens over any payload and ``TSW`` defers its handle
+    comparison, but both are about what a time series CARRIES. Applied without
+    checking the outer kind they reopened the hole this check exists to close,
+    in both directions -- and no C++ graph signature can admit either return
+    (issue #811 review).
+    """
+
+    @compute_node
+    def _to_tsd(x: TS[int]) -> TSD[str, TS[int]]:
+        return {"a": x.value}
+
+    @compute_node
+    def _to_object(x: TS[int]) -> TS[object]:
+        return x.value
+
+    @graph
+    def declared_scalar(a: TS[int]) -> TS[object]:
+        return _to_tsd(a)
+
+    with pytest.raises(WiringError, match="declares its output as"):
+        eval_node(declared_scalar, [1])
+
+    @graph
+    def declared_keyed(a: TS[int]) -> TSD[str, TS[int]]:
+        return _to_object(a)
+
+    with pytest.raises(WiringError, match="declares its output as"):
+        eval_node(declared_keyed, [1])
+
+
+def test_an_erased_payload_is_still_accepted_at_the_same_shape():
+    """The widening itself survives: same outer shape, erased payload."""
+
+    @compute_node
+    def _to_object(x: TS[int]) -> TS[object]:
+        return x.value
+
+    @graph
+    def g(a: TS[int]) -> TS[object]:
+        return _to_object(a)
+
+    assert eval_node(g, [1]) == [1]

--- a/python/tests/test_declared_graph_output.py
+++ b/python/tests/test_declared_graph_output.py
@@ -1,0 +1,147 @@
+"""A graph's declared output type is enforced at wiring (issue #811).
+
+A graph whose body returned a different time-series type from the one it
+declared was accepted and evaluated, so ``int`` values were delivered through a
+declared ``TS[bool]`` and a ``TS`` through a declared ``TSD``. Released hgraph
+rejects each of these at wiring, with the wording pinned below.
+
+The issue's own reading is worth keeping in view: if a declaration is never
+enforced where it is made, a mismatch survives to wherever something downstream
+trusts it -- which is why this is a wiring-safety hole rather than a value
+difference.
+"""
+import pytest
+
+from hgraph import (
+    TS,
+    TSD,
+    TIME_SERIES_TYPE,
+    WiringError,
+    compute_node,
+    graph,
+    invert_,
+)
+from hgraph.test import eval_node
+
+
+@compute_node
+def _to_float(x: TS[int]) -> TS[float]:
+    return float(x.value)
+
+
+@compute_node
+def _to_str(x: TS[int]) -> TS[str]:
+    return str(x.value)
+
+
+def test_operator_result_type_must_match_the_declaration():
+    """The issue's own case: invert_ over TS[bool] yields TS[int]."""
+
+    @graph
+    def g(ts: TS[bool]) -> TS[bool]:
+        return invert_(ts)
+
+    with pytest.raises(WiringError, match=r"declares its output as 'TS\[bool\]' but 'TS\[int\]'"):
+        eval_node(g, [True, False])
+
+
+def test_widened_arithmetic_result_must_match_the_declaration():
+    """Mixed arithmetic legitimately widens to TS[float]; the DECLARATION is
+    what was wrong, and it used to deliver a float inside a TS[int]."""
+
+    @graph
+    def g(a: TS[int]) -> TS[int]:
+        from hgraph import add_
+        return add_(a, 1.7)
+
+    with pytest.raises(WiringError, match=r"declares its output as 'TS\[int\]' but 'TS\[float\]'"):
+        eval_node(g, [10])
+
+
+def test_node_result_type_must_match_the_declaration():
+    @graph
+    def g(a: TS[int]) -> TS[int]:
+        return _to_float(a)
+
+    with pytest.raises(WiringError, match="declares its output as"):
+        eval_node(g, [3])
+
+
+def test_a_different_shape_is_rejected():
+    """Not just the payload: a TS returned through a declared TSD."""
+
+    @graph
+    def g(a: TS[int]) -> TSD[str, TS[int]]:
+        return a
+
+    with pytest.raises(WiringError, match="declares its output as"):
+        eval_node(g, [1])
+
+
+def test_unrelated_payload_is_rejected():
+    @graph
+    def g(a: TS[int]) -> TS[int]:
+        return _to_str(a)
+
+    with pytest.raises(WiringError, match=r"'TS\[int\]' but 'TS\[str\]'"):
+        eval_node(g, [3])
+
+
+def test_a_correct_declaration_still_wires():
+    @graph
+    def g(a: TS[int]) -> TS[float]:
+        return _to_float(a)
+
+    assert eval_node(g, [3]) == [3.0]
+
+
+def test_a_nested_graph_is_checked_too():
+    """map_ bodies go through the same wiring path, so a mis-declared body is
+    caught where it is declared rather than at the outer boundary."""
+    from hgraph import map_
+
+    @graph
+    def bad_body(x: TS[int]) -> TS[int]:
+        return _to_float(x)
+
+    @graph
+    def outer(ts: TSD[str, TS[int]]) -> TSD[str, TS[int]]:
+        return map_(bad_body, ts)
+
+    with pytest.raises(WiringError, match="'bad_body' declares its output as"):
+        eval_node(outer, [{"a": 1}])
+
+
+def test_a_generic_declaration_still_resolves():
+    """``TIME_SERIES_TYPE`` is treated as an absent annotation -- it resolves
+    FROM the wired ports rather than constraining them, so enforcing it would
+    break every generic graph. This is the acceptance criterion's second half.
+    """
+
+    @graph
+    def g(a: TS[int]) -> TIME_SERIES_TYPE:
+        return _to_float(a)
+
+    assert eval_node(g, [3]) == [3.0]
+
+
+def test_covariance_is_still_accepted():
+    """Assignability, not equality: a subclass payload satisfies a declared
+    base. Writing the check as handle equality rejected 87 working graphs."""
+    from dataclasses import dataclass
+
+    from hgraph import CompoundScalar, const
+
+    @dataclass(frozen=True)
+    class Base(CompoundScalar):
+        a: int
+
+    @dataclass(frozen=True)
+    class Derived(Base):
+        b: int = 0
+
+    @graph
+    def g() -> TS[Base]:
+        return const(Derived(1, 2), TS[Derived])
+
+    assert eval_node(g) == [Derived(1, 2)]

--- a/python/tests/test_mesh_generic_output.py
+++ b/python/tests/test_mesh_generic_output.py
@@ -8,7 +8,10 @@ from hgraph import (
     mesh_,
     pass_through,
 )
+from hgraph import WiringError
 from hgraph.test import eval_node
+
+import pytest
 
 
 @graph
@@ -65,4 +68,21 @@ def _generic_nested_mesh(
 
 
 def test_generic_mesh_scope_is_available_to_nested_map_output_inference():
-    assert eval_node(_generic_nested_mesh, [{}], [{}]) is None
+    """The nested mesh scope resolves, and the graph is then correctly rejected.
+
+    ``_generic_nested_peer`` returns one nesting level deeper than
+    ``_generic_nested_mesh`` declares: mapping over the mesh elements yields
+    ``TSD[str, TSD[str, TS[int]]]`` per peer, so the mesh is
+    ``TSD[str, TSD[str, TSD[str, TS[int]]]]`` against a declared
+    ``TSD[str, TSD[str, TS[int]]]``.
+
+    Released hgraph rejects the same graph -- at the inner peer, reporting
+    ``'TSD[str, TS[int]]' but 'TSD[str, REF[TSD[str, TS[int]]]]'`` -- so
+    rejecting is the parity-matching outcome. It used to wire here only because
+    the declared output was never enforced (issue #811). Reaching the type
+    error at all still proves the mesh scope was available to the nested map's
+    output inference, which is what this case exists to cover; the sibling
+    above pins the non-nested resolution.
+    """
+    with pytest.raises(WiringError, match="declares its output as"):
+        eval_node(_generic_nested_mesh, [{}], [{}])


### PR DESCRIPTION
Closes #811. Decided **fix** on #810 item 1.1.

A graph whose body returned a different time-series type from the one it
declared was accepted and evaluated. Every one of these wired before:

| declared ← returned | was |
|---|---|
| `TS[bool]` ← `TS[int]` (`invert_`) | `[-2, -1, -2]` — ints through a declared `TS[bool]` |
| `TS[int]` ← `TS[float]` (`add_`) | `[11.7]`, `type` **float**, inside a `TS[int]` |
| `TS[int]` ← `TS[float]` (node) | `[3.0]` |
| `TSD[str, TS[int]]` ← `TS[int]` | `[1]` — a `TS` through a declared dictionary |
| `TS[int]` ← `TS[str]` | `['3']` |

The reference rejects all five. It is a wiring-safety hole rather than a value
difference: it silently admits programs whose declared and actual shapes
disagree.

## Where the check belongs

**This is a Python-bridge hole specifically.** A C++ graph declares its return
as a template parameter (`static Port<TS<Bool>> compose(...)`), so the compiler
enforces it; the annotation is only runtime data on the Python side. The check
goes in `_GraphFn._call`, where every return path funnels after the dict-literal
and const-lift coercions have had their say. Nested bodies (`map_`, `mesh_`,
`switch_`) route through the same path, so a mis-declared body is reported where
it is declared rather than at the outer boundary.

## Assignability, not equality — and ONE rule

Written first as handle equality, the check **rejected 87 legitimate graphs**.
The failures named the reason: `TS[Instrument]` ← `TS[Future]` is correct
covariance (which `dispatch` depends on), and `TS[Any]` widens over any payload.

`_check_binding` already decides whether a wired port may bind to a declared
*input*, which is the identical question. So rather than write a second notion
of "compatible" — the parallel abstraction guardrail (iii) exists to prevent,
and the two would have drifted — I extracted it as
`binding_matches(annotation, port_tp, scope)` and both callers now use it. Its
docstring records that all five widenings are load-bearing, each falsified by a
test, so nobody retries equality.

REF is transparent on both sides via a new `TsType.dereference` accessor,
matching the released `dereference().matches(...)`.

## Two documented deferrals, deliberately NOT in the shared rule

Frames and erased `TS[Any]` are under-specified at wiring time relative to a
declaration: `convert[TS[Frame[AB]]](...)` yields an erased `TS[frame]`, and a
typed frame may be spelled nominally (`frame[AB]`) or structurally
(`frame[Bundle{a:int,b:int}]`) for the same schema. Released hgraph accepts
both — I verified the typed-frame graph wires upstream.

These live in `_check_declared_output`, **not** `binding_matches`, because
putting them in the shared rule would loosen input binding by the same stroke —
and loosening is invisible to tests, since it can only make things pass. They
are deferrals, not widenings: the honest fix is for wiring to carry the
specified type, which is the follow-up work. Frame detection goes through the
C++ pattern machinery and the interned erased-`frame` scalar, never rendered
labels (the rule `_markers` states).

## One test changed, because the graph was genuinely ill-typed

`test_generic_mesh_scope_is_available_to_nested_map_output_inference` asserted
that a nested mesh graph wires. **The reference rejects that same graph**, at
the inner peer: `'TSD[str, TS[int]]' but 'TSD[str, REF[TSD[str, TS[int]]]]'`.
`_generic_nested_peer` maps over mesh elements and so returns
`TSD[str, TSD[str, TS[int]]]` per peer, making the mesh one level deeper than
declared. It only wired here because the declaration was never enforced — which
is precisely the class of defect the issue predicted would survive.

Rejecting is therefore the parity outcome. The case now expects the
`WiringError` and explains why; reaching the type error still proves the mesh
scope was available to the nested map's inference, which is what it exists to
cover, and its sibling pins the non-nested resolution.

## Verification

Nine new cases in `test_declared_graph_output.py`: all five mismatch shapes with
the released wording, a correct declaration still wiring, a nested `map_` body
caught at its own declaration, a generic declaration still resolving (the
acceptance criterion's second half), and covariance still accepted.

Full `python/tests` green.

## Known gap

We render `'TSD[str,TS[int]]'` where the reference renders
`'TSD[str, TS[int]]'`. That is the global `TsType.__str__`, not this check —
changing it would touch every type message in the codebase.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
