### PR TITLE
Make frame schemas compare on their fields, not their names

### DIFF
--- a/include/hgraph/types/metadata/type_registry.h
+++ b/include/hgraph/types/metadata/type_registry.h
@@ -723,6 +723,12 @@ namespace hgraph
         InternTable<const ValueTypeMetaData *, ValueTypeMetaData> nullable_tuple_cache_;
         InternTable<const ValueTypeMetaData *, ValueTypeMetaData> series_cache_;
         InternTable<MapKey, ValueTypeMetaData, MapKeyHash> frame_cache_;
+        /** The un-typed ``frame`` scalar, cached for LOCK-FREE reads.
+            ``value_is_a`` runs without the registry lock, so it cannot call
+            ``is_frame`` (which takes it) to recognise the top of the frame
+            family. Published by ``frame()``; null until a frame is built,
+            which is exactly when no frame can be compared anyway. */
+        std::atomic<const ValueTypeMetaData *> frame_base_{nullptr};
         InternTable<const ValueTypeMetaData *, ValueTypeMetaData> mutable_set_cache_;
         InternTable<MapKey, ValueTypeMetaData, MapKeyHash> map_cache_;
         InternTable<MapKey, ValueTypeMetaData, MapKeyHash> mutable_map_cache_;

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -35,6 +35,16 @@ def _is_injectable_annotation(annotation):
 _FRAME_TS_PATTERN = None
 
 
+def _is_erased_frame_ts(handle):
+    """The un-typed ``frame`` scalar: a frame port carrying no column schema."""
+    if handle is None or not handle.is_ts:
+        return False
+    try:
+        return _hgraph.ts_value_vt(handle) == _hgraph.value_type("frame")
+    except TypeError:
+        return False
+
+
 def _is_frame_ts(handle):
     """Is this a frame-valued time series -- typed or erased?
 
@@ -73,7 +83,16 @@ def _output_check_deferred(declared, actual):
     * **Erased python values.** A ``TS[Any]`` result reaching a typed
       declaration is the opaque-python counterpart of the same problem.
     """
-    if _is_frame_ts(declared) and _is_frame_ts(actual):
+    # Only the ERASED frame remains deferred. `convert[TS[Frame]]` does not yet
+    # take its row schema from the source, so it yields a `TS[frame]` whose
+    # columns appear at runtime -- nothing at wiring can judge it against a
+    # typed declaration. Tracked as the remaining follow-up.
+    #
+    # The other two frame cases are gone, fixed in shared C++ where BOTH
+    # frontends reach them: a named bundle and its structural twin are now the
+    # same type (nominal_is_a), and the un-typed `frame` is the top of the
+    # frame family (value_is_a).
+    if _is_erased_frame_ts(actual) and _is_frame_ts(declared):
         return True
     try:
         # Only a scalar TS declaration: an erased payload says nothing about the

--- a/src/hgraph/types/metadata/type_registry.cpp
+++ b/src/hgraph/types/metadata/type_registry.cpp
@@ -406,7 +406,21 @@ namespace hgraph
         bool nominal_is_a(const ValueTypeMetaData *candidate, const ValueTypeMetaData *base) noexcept
         {
             if (candidate == base) { return candidate != nullptr; }
-            if (candidate == nullptr || base == nullptr || candidate->bundle_hierarchy == nullptr) { return false; }
+            if (candidate == nullptr || base == nullptr) { return false; }
+            // A named bundle and its canonical structural twin are the SAME
+            // type, in both directions: the fields drive correctness and the
+            // schema name is presentation. This is the same strategy the
+            // un-named bundle already encodes -- the structural form is the
+            // key, named variants are references to it -- reached here so that
+            // frame[AB] and frame[Bundle{a:int,b:int}] agree once covariant_pair
+            // has descended to their rows.
+            //
+            // Deliberately only a bundle against ITS OWN twin: two DIFFERENT
+            // named bundles keep nominal identity, exactly as
+            // value_schema_equivalent has it.
+            if (candidate->is_named_bundle() && candidate->wrapped_un_named == base) { return true; }
+            if (base->is_named_bundle() && base->wrapped_un_named == candidate) { return true; }
+            if (candidate->bundle_hierarchy == nullptr) { return false; }
             for (const auto &[ancestor, distance] : candidate->bundle_hierarchy->ancestors)
             {
                 if (ancestor == base) { return true; }
@@ -462,6 +476,15 @@ namespace hgraph
     {
         if (candidate == base) { return candidate != nullptr; }
         if (candidate == nullptr || base == nullptr) { return false; }
+        // The un-typed ``frame`` is the TOP of the frame family: declaring it
+        // accepts any frame, the way ``TS[object]`` accepts any payload.
+        // Deliberately one-directional -- a TYPED declaration is not satisfied
+        // by a frame whose row schema is unspecified.
+        if (candidate->has(ValueTypeFlags::Frame) &&
+            base == frame_base_.load(std::memory_order_relaxed))
+        {
+            return true;
+        }
         if (!covariant_pair(candidate, base)) { return false; }
         return nominal_is_a(candidate, base);
     }
@@ -1434,6 +1457,7 @@ namespace hgraph
         const std::lock_guard lock(mutex_);
         const ValueTypeMetaData *base = value_type("frame");
         if (base == nullptr) { throw std::logic_error("frame scalar is not registered"); }
+        frame_base_.store(base, std::memory_order_relaxed);
         if (column_schema == nullptr)
         {
             if (metadata_schema != nullptr)

--- a/src/hgraph/types/metadata/type_registry.cpp
+++ b/src/hgraph/types/metadata/type_registry.cpp
@@ -433,6 +433,12 @@ namespace hgraph
         {
             if (candidate == nullptr || base == nullptr) { return std::nullopt; }
             if (candidate == base) { return 0; }
+            // Mirrors nominal_is_a: a named bundle and its structural twin are
+            // the SAME type, so the distance is zero, not merely "related".
+            // value_is_a(c, b) holds exactly when this has a value, and the two
+            // must agree or overload ranking sees a match it cannot rank.
+            if (candidate->is_named_bundle() && candidate->wrapped_un_named == base) { return 0; }
+            if (base->is_named_bundle() && base->wrapped_un_named == candidate) { return 0; }
             if (candidate->bundle_hierarchy == nullptr) { return std::nullopt; }
             for (const auto &[ancestor, distance] : candidate->bundle_hierarchy->ancestors)
             {
@@ -495,6 +501,16 @@ namespace hgraph
     {
         if (candidate == nullptr || base == nullptr) { return std::nullopt; }
         if (candidate == base) { return 0; }
+        // Mirrors the un-typed-frame acceptance in value_is_a. ONE step, not
+        // zero: the bare frame is the top of the family, so a fallback
+        // TS<Frame> overload must rank WORSE than an exact TS<FrameOf<Row>>
+        // one. Lower rank wins, so an exact match keeps its 0 and the fallback
+        // no longer ties it.
+        if (candidate->has(ValueTypeFlags::Frame) &&
+            base == frame_base_.load(std::memory_order_relaxed))
+        {
+            return 1;
+        }
         if (!covariant_pair(candidate, base)) { return std::nullopt; }
         return nominal_distance(candidate, base);
     }

--- a/tests/cpp/test_operators.cpp
+++ b/tests/cpp/test_operators.cpp
@@ -504,6 +504,53 @@ TEST_CASE("operators: a nominal leaf overload beats inherited Bundle inputs")
     CHECK(registry.value_inheritance_distance(puppy, animal) == 2);
 }
 
+TEST_CASE("operators: frame acceptance and its ranking stay in step")
+{
+    // value_is_a and value_inheritance_distance advertise that
+    // "value_is_a(c, b) holds exactly when this has a value". Accepting a
+    // relation in one without ranking it in the other leaves overload
+    // resolution with a match it cannot rank, so the two move together.
+    auto       &registry = TypeRegistry::instance();
+    const auto *integer  = registry.value_type("int");
+    const auto *row      = registry.bundle(
+        "tests.operator.frame_fallback", "Row", {{"id", integer}}, {}, true);
+    const auto *typed_frame = registry.frame(row);
+    const auto *bare_frame  = registry.value_type("frame");
+
+    // The un-typed frame is the top of the family: accepted, and ranked as a
+    // step AWAY from an exact match rather than equal to one.
+    CHECK(registry.value_is_a(typed_frame, bare_frame));
+    const auto fallback_distance = registry.value_inheritance_distance(typed_frame, bare_frame);
+    REQUIRE(fallback_distance.has_value());
+    CHECK(*fallback_distance > 0);
+
+    // ... and an exact match still ranks zero, so it wins on distance.
+    CHECK(registry.value_inheritance_distance(typed_frame, typed_frame) == 0);
+
+    // Not symmetric: an un-specified frame does not satisfy a typed one, and
+    // an unrankable pair must report no distance rather than zero.
+    CHECK_FALSE(registry.value_is_a(bare_frame, typed_frame));
+    CHECK_FALSE(registry.value_inheritance_distance(bare_frame, typed_frame).has_value());
+}
+
+TEST_CASE("operators: a named bundle and its structural twin rank as one type")
+{
+    // The other half of the same invariant: nominal_is_a now equates a named
+    // bundle with its un-named structural twin, so the distance must be ZERO
+    // -- they are the same type, not merely related.
+    auto       &registry = TypeRegistry::instance();
+    const auto *integer  = registry.value_type("int");
+    const auto *named    = registry.bundle(
+        "tests.operator.twin", "Named", {{"id", integer}}, {}, true);
+    const auto *twin = named->wrapped_un_named;
+    REQUIRE(twin != nullptr);
+
+    CHECK(registry.value_is_a(named, twin));
+    CHECK(registry.value_is_a(twin, named));
+    CHECK(registry.value_inheritance_distance(named, twin) == 0);
+    CHECK(registry.value_inheritance_distance(twin, named) == 0);
+}
+
 TEST_CASE("operators: a narrower Frame row selects the nearest nominal overload")
 {
     auto &registry = TypeRegistry::instance();


### PR DESCRIPTION
Stacked on #867 — review that first; this fixes two of the three frame cases its
declared-output check surfaced.

Both land in **shared C++**, so both frontends get them: Python reaches them
through the relaxed pattern matcher, C++ through `input_accepts_output_schema`,
and both bottom out in `value_is_a`.

## (c) Nominal vs structural — the same frame, two spellings

`frame[AB]` and `frame[Bundle{a:int,b:int}]` are one frame (`AB` *is*
`{a:int,b:int}`) but compared as different types.

The un-named-bundle strategy already encodes the answer — the structural form is
the key, named variants are references to it via `wrapped_un_named` — and
`covariant_pair` already descends a Frame to its row. The only missing link was
`nominal_is_a`, which walks `bundle_hierarchy->ancestors` and never consulted
the twin.

A named bundle and its canonical structural twin are now the same type in
**both directions**: the fields drive correctness, the name is presentation.
Deliberately only a bundle against its **own** twin — two *different* named
bundles keep nominal identity, exactly as `value_schema_equivalent` already
has it.

## (b) The un-typed `frame` is the top of the family

Declaring `TS[Frame]` accepts any frame, the way `TS[object]` accepts any
payload. **One-directional by design**: a *typed* declaration is not satisfied
by a frame whose row is unspecified, which is the P4 ruling that an output
schema is exact.

Identifying the bare frame needs its pointer, and `value_is_a` runs lock-free
while `is_frame` takes the registry lock — so the base is cached as an atomic
published by `frame()`. Null until a frame is built, which is exactly when no
frame can be compared anyway.

## Measured one at a time, which was necessary

Two earlier attempts compiled, read correctly and **did nothing**:

* fixing `value_schema_equivalent` missed because neither frontend's wiring
  comparison reaches the value layer;
* guarding (b) on `ValueTypeFlags::Frame` missed because that flag is only ever
  added to *typed* frames, so the condition was never true for the bare one.

Only the unchanged failure count caught either. Both dead edits are excluded
here, along with a childless-`Frame`-pattern case that was likewise off every
live path — `_pattern_of(TS[Frame])` produces a `Concrete` pattern, not a
`Frame` one. (That last fact is what the follow-up below turns on.)

## Result

Frame-family failures **10 → 3**; full `python/tests` green at **3482**.

The declared-output deferral in #867 narrows to the single case left:
`convert[TS[Frame]]` does not yet take its row from the source, so it yields a
frame whose columns only appear at runtime and nothing at wiring can judge it.

## Follow-up, deliberately not here

Making `convert[TS[Frame]]` infer its row **cannot** be done with a resolver:
`bind_ts` throws on rebinding ("type variable resolved inconsistently") and
`TS[Frame]` already pins `__out__`. It needs `TS[Frame]` to mean "a frame whose
row is to be inferred" rather than "the erased frame type" — a semantic change
to a public annotation with reach beyond `convert`, so it lands on its own.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
