### PR TITLE
feat(cpp): add functional collection output mutations

### DIFF
--- a/docs/source/user_guide/cpp/authoring_nodes.rst
+++ b/docs/source/user_guide/cpp/authoring_nodes.rst
@@ -730,6 +730,16 @@ conveniences.
        }
    };
 
+For code shared conceptually with HGL, include
+``<hgraph/types/time_series/output_mutation.h>`` and use the constrained free
+functions ``insert``, ``update``, ``upsert``, ``remove``, ``discard``,
+``invalidate``, and ``clear``. They preserve the member API above: the
+functions validate strict preconditions and then delegate to ``add``,
+``remove``, ``erase``, ``set``, child invalidation, or ``clear``. In
+particular, ``remove`` requires membership while ``discard`` tolerates an
+absent member or key, and ``invalidate(out, key)`` retains the dictionary key
+without using its create-on-access lookup.
+
 ``TSD`` replay/record uses the canonical
 ``Bundle{removed: Set<K>, modified: Map<K, delta(V)>}`` delta. Build expected
 test deltas with ``dict_delta<K, V>``; ``V`` can itself be any supported

--- a/extensions/web/tests/test_h2_loopback.cpp
+++ b/extensions/web/tests/test_h2_loopback.cpp
@@ -24,6 +24,8 @@
 // POSIX ssize_t name in the Windows SDK namespace.
 #define NGHTTP2_NO_SSIZE_T
 #endif
+#include <fmt/format.h>
+
 #include <nghttp2/nghttp2.h>
 
 #include <array>
@@ -189,6 +191,8 @@ public:
         [](nghttp2_session *, const nghttp2_frame *frame,
            void *user_data) -> int {
           auto &client = *static_cast<RawH2Client *>(user_data);
+          ++client.frames_in_;
+          client.last_frame_type_ = static_cast<int>(frame->hd.type);
           if (frame->hd.type == NGHTTP2_SETTINGS &&
               (frame->hd.flags & NGHTTP2_FLAG_ACK) == 0) {
             client.settings_seen_ = true;
@@ -299,8 +303,12 @@ public:
 
   template <typename Predicate>
   void pump_until(Predicate predicate, std::string_view failure) {
-    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    const auto started = std::chrono::steady_clock::now();
+    const auto deadline = started + 5s;
+    const std::size_t polls_at_entry = polls_;
+    const std::size_t bytes_at_entry = bytes_in_;
     while (std::chrono::steady_clock::now() < deadline) {
+      ++polls_;
       flush_output();
       bool progressed = false;
       while (read_input()) {
@@ -314,7 +322,51 @@ public:
         std::this_thread::sleep_for(1ms);
       }
     }
-    throw std::runtime_error(std::string{failure});
+    throw std::runtime_error(
+        std::string{failure} + " | " +
+        wait_diagnostics(started, polls_ - polls_at_entry, bytes_in_ - bytes_at_entry));
+  }
+
+  /** State that separates the two candidate causes of a pump_until timeout.
+   *
+   * Every previous fix here closed one plausible stall blind, and the bare
+   * failure string made each occurrence indistinguishable from the last. Read
+   * it as:
+   *
+   *   polls high, bytes_read 0, want_read=1   -> the client never saw bytes:
+   *                                              the peer did not send, or a
+   *                                              readiness signal is missing
+   *                                              again (the aaf874b01 class).
+   *   polls high, bytes_read > 0              -> bytes arrived and the
+   *                                              predicate still did not hold:
+   *                                              a protocol/ordering problem,
+   *                                              not a stalled reader.
+   *   polls low                               -> the loop itself was starved;
+   *                                              a wall-clock deadline on a
+   *                                              loaded machine.
+   *
+   * sock_available/ssl_pending are sampled AFTER the deadline: non-zero means
+   * readable data was sitting there while the loop gave up, which is the
+   * signature of a missed wakeup rather than a silent peer.
+   */
+  [[nodiscard]] std::string wait_diagnostics(
+      std::chrono::steady_clock::time_point started, std::size_t polls,
+      std::size_t bytes_read) {
+    boost::system::error_code ec;
+    const std::size_t available = stream_.next_layer().available(ec);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - started);
+    return fmt::format(
+        "elapsed={}ms polls={} read_calls={} bytes_read={} bytes_in_total={} "
+        "bytes_out_total={} frames_in={} last_frame_type={} "
+        "want_read={} want_write={} sock_available={}{} ssl_pending={} "
+        "settings_seen={} ping_acked={}",
+        elapsed.count(), polls, read_calls_, bytes_read, bytes_in_, bytes_out_,
+        frames_in_, last_frame_type_,
+        nghttp2_session_want_read(session_), nghttp2_session_want_write(session_),
+        available, ec ? "(query failed)" : "",
+        SSL_has_pending(stream_.native_handle()), settings_seen_,
+        ping_acknowledged_);
   }
 
 private:
@@ -346,6 +398,7 @@ private:
                   asio::buffer(bytes, static_cast<std::size_t>(length)), ec);
       stream_.next_layer().non_blocking(true);
       require(!ec, "raw client TLS write failed: " + ec.message());
+      bytes_out_ += static_cast<std::size_t>(length);
     }
   }
 
@@ -362,6 +415,7 @@ private:
       return false;
     }
     std::array<char, 16 * 1024> buffer{};
+    ++read_calls_;
     const std::size_t received = stream_.read_some(asio::buffer(buffer), ec);
     if (ec == asio::error::would_block || ec == asio::error::try_again) {
       return false;
@@ -371,6 +425,7 @@ private:
         session_, reinterpret_cast<const uint8_t *>(buffer.data()), received);
     require(processed >= 0 && static_cast<std::size_t>(processed) == received,
             "raw client rejected server HTTP/2 bytes");
+    bytes_in_ += received;
     return received != 0;
   }
 
@@ -381,6 +436,17 @@ private:
   std::map<std::int32_t, RawH2Stream> streams_{};
   bool settings_seen_{};
   bool ping_acknowledged_{};
+  // Failure-path diagnostics only. Every previous fix for this test
+  // (696b42eef, 23c62aecc, aaf874b01) closed one plausible stall and the
+  // timeout still reports a bare string, so each occurrence looks identical
+  // and distinguishes nothing. These separate "the client stopped reading"
+  // from "the server never answered" on the NEXT failure.
+  std::size_t polls_{};
+  std::size_t read_calls_{};
+  std::size_t bytes_in_{};
+  std::size_t bytes_out_{};
+  std::size_t frames_in_{};
+  int last_frame_type_{-1};
 };
 
 void test_rejected_stream_restores_connection_window(int port) {

--- a/extensions/web/tests/test_h2_loopback.cpp
+++ b/extensions/web/tests/test_h2_loopback.cpp
@@ -494,12 +494,15 @@ void test_rejected_stream_restores_connection_window(int port) {
   try {
     client.pump_until([&] { return client.stream(recovered).closed; },
                       "the connection window was not restored after discard");
-  } catch (const std::runtime_error &) {
+  } catch (const std::runtime_error &stall) {
+    // Bind and carry what() through: this is the very stall the pump
+    // diagnostics exist for, and replacing the message outright would discard
+    // them at the one call site most likely to hit it.
     throw std::runtime_error(
         "the recovery stream stalled (sent=" + std::to_string(recovery.offset) +
         ", window=" + std::to_string(client.connection_window()) +
         ", status=" + std::to_string(client.stream(recovered).status) +
-        ", body='" + client.stream(recovered).body + "')");
+        ", body='" + client.stream(recovered).body + "') | " + stall.what());
   }
   require(client.stream(recovered).error_code == NGHTTP2_NO_ERROR,
           "the recovery stream did not close cleanly");

--- a/include/hgraph/types/metadata/type_registry.h
+++ b/include/hgraph/types/metadata/type_registry.h
@@ -723,6 +723,12 @@ namespace hgraph
         InternTable<const ValueTypeMetaData *, ValueTypeMetaData> nullable_tuple_cache_;
         InternTable<const ValueTypeMetaData *, ValueTypeMetaData> series_cache_;
         InternTable<MapKey, ValueTypeMetaData, MapKeyHash> frame_cache_;
+        /** The un-typed ``frame`` scalar, cached for LOCK-FREE reads.
+            ``value_is_a`` runs without the registry lock, so it cannot call
+            ``is_frame`` (which takes it) to recognise the top of the frame
+            family. Published by ``frame()``; null until a frame is built,
+            which is exactly when no frame can be compared anyway. */
+        std::atomic<const ValueTypeMetaData *> frame_base_{nullptr};
         InternTable<const ValueTypeMetaData *, ValueTypeMetaData> mutable_set_cache_;
         InternTable<MapKey, ValueTypeMetaData, MapKeyHash> map_cache_;
         InternTable<MapKey, ValueTypeMetaData, MapKeyHash> mutable_map_cache_;

--- a/include/hgraph/types/time_series/output_mutation.h
+++ b/include/hgraph/types/time_series/output_mutation.h
@@ -1,0 +1,108 @@
+#ifndef HGRAPH_TYPES_TIME_SERIES_OUTPUT_MUTATION_H
+#define HGRAPH_TYPES_TIME_SERIES_OUTPUT_MUTATION_H
+
+#include <hgraph/types/static_node.h>
+
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+namespace hgraph
+{
+    namespace output_mutation_detail
+    {
+        template <typename TValue> [[nodiscard]] ValueView key_view(const Out<TSS<TValue>> &out, const TValue &value) {
+            return ValueView{out.data_view().layout().key_binding, std::addressof(value)};
+        }
+
+        template <typename TSchema, typename TValue>
+        concept settable_output = requires(const Out<TSchema> &out, TValue &&value) { out.set(std::forward<TValue>(value)); };
+    }  // namespace output_mutation_detail
+
+    /** Insert an absent member into a set output. */
+    template <typename TValue> void insert(const Out<TSS<TValue>> &out, const TValue &value) {
+        if (out.contains(output_mutation_detail::key_view(out, value))) {
+            throw std::invalid_argument("insert requires an absent TSS member");
+        }
+        if (!out.add(value)) { throw std::logic_error("TSS insert did not add the absent member"); }
+    }
+
+    /** Ensure that a member exists in a set output. */
+    template <typename TValue> void upsert(const Out<TSS<TValue>> &out, const TValue &value) {
+        if (!out.contains(output_mutation_detail::key_view(out, value))) { static_cast<void>(out.add(value)); }
+    }
+
+    /** Remove a present member from a set output. */
+    template <typename TValue> void remove(const Out<TSS<TValue>> &out, const TValue &value) {
+        if (!out.contains(output_mutation_detail::key_view(out, value))) {
+            throw std::out_of_range("remove requires a present TSS member");
+        }
+        if (!out.remove(value)) { throw std::logic_error("TSS remove did not remove the present member"); }
+    }
+
+    /** Remove a member from a set output if it exists. */
+    template <typename TValue> void discard(const Out<TSS<TValue>> &out, const TValue &value) {
+        if (out.contains(output_mutation_detail::key_view(out, value))) { static_cast<void>(out.remove(value)); }
+    }
+
+    /** Remove every member from a set output. */
+    template <typename TValue> void clear(const Out<TSS<TValue>> &out) {
+        if (!out.empty()) { out.clear(); }
+    }
+
+    /** Insert and initialize an absent dictionary child. */
+    template <typename TKey, typename TValueSchema, typename TValue>
+        requires output_mutation_detail::settable_output<TValueSchema, TValue>
+    void insert(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key, TValue &&value) {
+        if (out.contains(key)) { throw std::invalid_argument("insert requires an absent TSD key"); }
+
+        auto rollback = make_scope_exit<true>([&] { static_cast<void>(out.erase(key)); });
+        out[key].set(std::forward<TValue>(value));
+        rollback.release();
+    }
+
+    /** Update and tick an existing dictionary child. */
+    template <typename TKey, typename TValueSchema, typename TValue>
+        requires output_mutation_detail::settable_output<TValueSchema, TValue>
+    void update(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key, TValue &&value) {
+        if (!out.contains(key)) { throw std::out_of_range("update requires a present TSD key"); }
+        out.at_slot(out.find_slot(key)).set(std::forward<TValue>(value));
+    }
+
+    /** Insert or update a dictionary child. */
+    template <typename TKey, typename TValueSchema, typename TValue>
+        requires output_mutation_detail::settable_output<TValueSchema, TValue>
+    void upsert(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key, TValue &&value) {
+        const bool existed  = out.contains(key);
+        auto       rollback = make_scope_exit<true>([&] {
+            if (!existed) { static_cast<void>(out.erase(key)); }
+        });
+        out[key].set(std::forward<TValue>(value));
+        rollback.release();
+    }
+
+    /** Remove a present dictionary child. */
+    template <typename TKey, typename TValueSchema> void remove(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key) {
+        if (!out.contains(key)) { throw std::out_of_range("remove requires a present TSD key"); }
+        if (!out.erase(key)) { throw std::logic_error("TSD remove did not remove the present key"); }
+    }
+
+    /** Remove a dictionary child if it exists. */
+    template <typename TKey, typename TValueSchema> void discard(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key) {
+        if (out.contains(key)) { static_cast<void>(out.erase(key)); }
+    }
+
+    /** Invalidate an existing dictionary child without removing its key. */
+    template <typename TKey, typename TValueSchema> void invalidate(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key) {
+        if (!out.contains(key)) { throw std::out_of_range("invalidate requires a present TSD key"); }
+        auto child = out.at_slot(out.find_slot(key));
+        static_cast<void>(child.begin_mutation(child.evaluation_time()).invalidate());
+    }
+
+    /** Remove every child from a dictionary output. */
+    template <typename TKey, typename TValueSchema> void clear(const Out<TSD<TKey, TValueSchema>> &out) {
+        if (!out.empty()) { out.clear(); }
+    }
+}  // namespace hgraph
+
+#endif  // HGRAPH_TYPES_TIME_SERIES_OUTPUT_MUTATION_H

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -707,12 +707,16 @@ In a runtime function, `return value` writes the complete output and terminates
 the current evaluation. Reaching the end without a return or output mutation
 produces no output tick. With `inject out`, whole-output writes are
 last-write-wins; writes to distinct collection children accumulate into one
-delta, and repeated writes to one child use the last value.
+delta, and repeated writes to one child use the last value. Collection effects
+use the typed functional vocabulary `insert`, `update`, `upsert`, `remove`,
+`discard`, `invalidate`, `clear`, `push`, and `pop`; the first argument is the
+injected output. Strict operations inspect staged state, and removal remains
+distinct from child invalidation.
 
 A runtime function without `when` uses hgraph's default input activation and
-validity rules. Calls to scalar kernels, richer structural mutation, output
-access during lifecycle hooks, and exact conditional-expression spelling
-remain open.
+validity rules. Calls to scalar kernels, structural delta forwarding, output
+access during lifecycle hooks, and exact conditional-expression spelling remain
+open.
 
 The compiler must represent a function as unclassified until the explicit
 source rule is applied. Scripted and AOT modes must classify identically.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1036,6 +1036,22 @@ Collection projections lower to the typed output view's incremental mutation
 operations, preserving one combined delta for writes to distinct children.
 Reaching the end without a return or output mutation produces no output tick.
 
+The functional collection effects lower to constrained public C++ free
+functions with the same names. For example, `upsert(out, key, value)` becomes
+`hgraph::upsert(hgl_output, key, value)`. The façade delegates to the existing
+typed `Out`/View methods; it does not rename or redesign those raw C++ methods.
+Constraints reject a mismatched key or value, mutation through an input, a map
+operation on a set, and dynamic-size operations on a fixed list before a node
+can be instantiated.
+
+Map insertion and upsert must remove a newly created child if initializing its
+complete value throws. Keyed and indexed invalidation must use non-creating
+lookup. Unbounded-list `push` resizes then initializes the new trailing child
+with rollback to the previous size on failure; `pop` and `clear` lower to
+shrinking `resize`. The generated code relies on the runtime's delta
+normalization for last-write-wins and cancellation rather than reimplementing
+delta bookkeeping in the compiler.
+
 Runtime lowering must obey hgraph's native contracts:
 
 - generated node implementations are empty static structs;

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1840,8 +1840,37 @@ writes made by earlier blocks.
 
 `return value` is semantically equivalent to assigning the complete output and
 then returning. A bare `return` terminates evaluation after any preceding
-incremental output mutations. Detailed collection mutation operations remain
-part of structural-type design.
+incremental output mutations.
+
+Collection output mutations are function-shaped effects whose first argument
+must be the injected `out` binding:
+
+| Output | Operations |
+| --- | --- |
+| `set<T>` | `insert(out, value)`, `upsert(out, value)`, `remove(out, value)`, `discard(out, value)`, `clear(out)` |
+| `map<K, V>` | `insert(out, key, value)`, `update(out, key, value)`, `upsert(out, key, value)`, `remove(out, key)`, `discard(out, key)`, `invalidate(out, key)`, `clear(out)` |
+| `list<V, unbounded>` | `push(out, value)`, `pop(out)`, `invalidate(out, index)`, `clear(out)` |
+| `list<V, size>` | `invalidate(out, index)` |
+
+`insert`, `update`, `remove`, and `pop` are strict: their required absent,
+present, or non-empty precondition is checked against the staged state at the
+point of the call. `upsert` and `discard` are tolerant. Set `upsert` is an
+idempotent ensure-membership operation; a set has no `update` operation because
+there is no child payload to replace. Map and list `invalidate` preserve
+structure and invalidate an existing child without creating a key or growing a
+list.
+
+Within one evaluation, distinct child changes accumulate and repeated writes to
+one child use the last value. Insert followed by remove of a previously absent
+child cancels; remove followed by insert of a previously present child is a
+modification. Structural removal, child invalidation, and a value-level `null`
+are separate states. Projected children and collection ranges are borrowed for
+the evaluation and cannot escape it.
+
+These operations initially classify and execute only as runtime-node effects.
+Their function shape reserves the same names for a possible graph form, but a
+future graph overload would return a new collection rather than mutate its
+input and requires a separate semantic decision.
 
 Assigning `delta<S>(...)` to `out` performs the same sparse structural update
 and continues evaluation. Explicit `null` on an optional delta field requests

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -903,21 +903,48 @@ information required by the next evaluation. Use `state` when the function
 needs private information, when that information may change without producing
 an output tick, or when it differs from the output shape.
 
-Collection output supports incremental mutation:
+Collection outputs support typed functional mutations. The first argument is
+always the injected output:
 
 ```hgl
 fn latest_by_key(key: str, value: f64) -> map<str, f64> {
     inject out
 
     when modified(value) && valid(key, value) {
-        out[key] = value
+        upsert(out, key, value)
     }
 }
 ```
 
+Use `insert` when absence is required, `update` when presence is required, and
+`upsert` when either state is acceptable. Sets support `insert` and `upsert`;
+they do not need a separate `update` because membership has no child value.
+`remove` requires the member or key to exist, while `discard` silently does
+nothing when it is absent. `invalidate(out, key)` keeps a map key but
+invalidates its child, which is different from removing the key.
+
+An unbounded list is a stack-shaped mutable output:
+
+```hgl
+fn collect_values(value: i64) -> list<i64, unbounded> {
+    inject out
+
+    when {
+        push(out, value)
+    }
+}
+```
+
+`push` appends and initializes one trailing child. `pop` removes the trailing
+child and requires a non-empty list. `clear` is available for sets, maps, and
+unbounded lists. Indexed `invalidate(out, index)` preserves list length and
+never grows the list. Fixed lists do not support `push`, `pop`, or `clear`.
+
 Whole-output assignments are last-write-wins. Writes to different collection
 children accumulate into one output delta; repeated writes to the same child
-use the last value. `inject out` is invalid on an outputless function and `out`
+use the last value. Strict preconditions observe mutations already staged in
+the current evaluation. Removal, invalidation, and a scalar `null` value remain
+different effects. `inject out` is invalid on an outputless function and `out`
 is initially restricted to evaluation code rather than `start` or `stop`.
 
 Once some other node-only construct classifies a function as runtime, omitting

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -11,7 +11,7 @@ from .._types import (_ContextExpr, _GenericTsExpr, _TsExpr,
 from ._core import (ParseError, WiringError, WiringPort, _current_wiring,
                     _resolve_context, _unwrap, _wiring_stack, wire)
 from ._markers import (LOGGER, _INJECTABLE_MARKERS, _RecordableStateExpr,
-                       _StateExpr, _annotation_ts_kind)
+                       _StateExpr, _annotation_ts_kind, _is_object_vt)
 from ._node import (_PyNode, _is_time_series_annotation,
                     _bind_partial, _ensure_current_signature,
                     _lift_time_series_argument, _partial_binding_plan,
@@ -30,6 +30,106 @@ _GRAPH_INJECTABLES = frozenset((GlobalState, LOGGER))
 def _is_injectable_annotation(annotation):
     return (annotation in _INJECTABLE_MARKERS or
             isinstance(annotation, (_StateExpr, _RecordableStateExpr)))
+
+
+_FRAME_TS_PATTERN = None
+
+
+def _is_frame_ts(handle):
+    """Is this a frame-valued time series -- typed or erased?
+
+    Classified through the C++ pattern machinery and the interned erased
+    ``frame`` scalar, never by rendered label (the rule ``_markers`` states).
+    """
+    global _FRAME_TS_PATTERN
+    if handle is None or not handle.is_ts:
+        return False
+    try:
+        if _hgraph.ts_value_vt(handle) == _hgraph.value_type("frame"):
+            return True   # the erased 'frame' scalar: no column schema yet
+    except TypeError:
+        return False
+    if _FRAME_TS_PATTERN is None:
+        _FRAME_TS_PATTERN = _hgraph.type_pattern_ts(
+            _hgraph.scalar_pattern_frame(_hgraph.scalar_pattern_var("F")))
+    return _hgraph.ResolutionScope().match(_FRAME_TS_PATTERN, handle)
+
+
+def _output_check_deferred(declared, actual):
+    """Shapes whose WIRING-TIME type is under-specified relative to the
+    declaration, so comparing them here would reject working graphs.
+
+    These are deferrals, not widenings of assignability -- they live on the
+    output boundary rather than in ``binding_matches`` so that input binding is
+    not loosened by the same stroke. Both are tracked for removal; the honest
+    fix is for wiring to carry the specified type in the first place.
+
+    * **Frames.** ``convert[TS[Frame[AB]]](...)`` yields an erased ``TS[frame]``
+      at wiring time, and a typed frame may be spelled nominally
+      (``frame[AB]``) or structurally (``frame[Bundle{a:int,b:int}]``) for the
+      same schema. Released hgraph accepts both, and the P4 ruling that an
+      output frame schema is EXACT cannot be enforced until the schema is
+      actually attached at wiring.
+    * **Erased python values.** A ``TS[Any]`` result reaching a typed
+      declaration is the opaque-python counterpart of the same problem.
+    """
+    if _is_frame_ts(declared) and _is_frame_ts(actual):
+        return True
+    try:
+        if actual.is_ts and _is_object_vt(_hgraph.ts_value_vt(actual)):
+            return True
+    except TypeError:
+        pass
+    return False
+
+
+def _check_declared_output(declared_expr, raw, label):
+    """Reject a graph body whose returned type cannot satisfy the declaration.
+
+    Without this a graph could declare ``TS[bool]`` and return ``TS[int]``, and
+    the mismatch survived to whatever downstream trusted the declaration --
+    ``int`` values delivered through a declared ``TS[bool]``, or a ``TS``
+    delivered through a declared ``TSD`` (issue #811).
+
+    Only a CONCRETE declaration is enforced. ``_GenericTsExpr`` (``TS[SCALAR]``,
+    ``TIME_SERIES_TYPE``) is documented as "treated like an absent annotation" --
+    it resolves from the wired ports rather than constraining them, so there is
+    nothing to check and checking would break every generic graph.
+
+    The test is ASSIGNABILITY, not equality, and it reuses the same predicate
+    that decides input binding: declaring ``TS[Instrument]`` and returning
+    ``TS[Future]`` is correct covariance, and ``TS[Any]`` widens over any
+    payload. Writing this as handle equality rejected 87 legitimate graphs.
+
+    Comparison is on DEREFERENCED types, because a reference is how a value
+    travels rather than what it is; the message reports the types as declared
+    and returned, which is the released wording.
+    """
+    from ._node import binding_matches
+
+    if not isinstance(declared_expr, _TsExpr):
+        return
+    declared = getattr(declared_expr, "handle", None)
+    if declared is None:
+        return
+    actual = getattr(raw, "ts_type", None)
+    if actual is None:
+        # A wiring port with no output: service clients return one even though
+        # they publish nothing. The released implementation special-cases the
+        # same shape.
+        return
+    if declared.dereference == actual.dereference:
+        return
+    # A fresh scope: a concrete declaration binds no type variables, and we
+    # must not leak bindings into the caller's resolution.
+    if binding_matches(declared_expr, actual.dereference, _hgraph.ResolutionScope()):
+        return
+    if _output_check_deferred(declared, actual):
+        return
+    raise WiringError(
+        f"'{label}' declares its output as '{declared}' but "
+        f"'{actual}' was returned from the graph"
+    )
 
 
 def _wrap_graph_fn(gfn, *, input_names=None, scalar_bindings=None,
@@ -96,6 +196,7 @@ def _wrap_graph_fn(gfn, *, input_names=None, scalar_bindings=None,
                 # (hgraph parity - dispatch branches `return "woof"`).
                 out = wire("const", out)
             raw = _unwrap(out)
+            _check_declared_output(out_tp, raw, label)
             # Common C++ subgraph finalization converts a structural result
             # into its zero-copy REF terminal. Leaving the structural port
             # intact here keeps Python and native graph functions on the same
@@ -656,16 +757,23 @@ class _GraphFn:
             # the annotation is generic/absent).
             annotation = self._signature.return_annotation
             if isinstance(annotation, _TsExpr) and annotation.handle.is_tsb:
-                return annotation.from_ts(**result)
-            fields = [(k, _unwrap(v).ts_type) for k, v in result.items()]
-            tsb_type = _hgraph.un_named_tsb_type(fields)
-            return WiringPort(_hgraph.tsb_port(tsb_type, {k: _unwrap(v) for k, v in result.items()}))
-        if (result is not None and not isinstance(result, WiringPort)
+                result = annotation.from_ts(**result)
+            else:
+                fields = [(k, _unwrap(v).ts_type) for k, v in result.items()]
+                tsb_type = _hgraph.un_named_tsb_type(fields)
+                result = WiringPort(
+                    _hgraph.tsb_port(tsb_type, {k: _unwrap(v) for k, v in result.items()}))
+        elif (result is not None and not isinstance(result, WiringPort)
                 and _is_time_series_annotation(self._signature.return_annotation)):
             # hgraph parity: a plain value returned from a @graph with a
             # time-series return annotation lifts to const of that type.
-            return _lift_time_series_argument(
+            result = _lift_time_series_argument(
                 result, self._signature.return_annotation)
+        # Every return path funnels here so the declared output is enforced
+        # once, after the coercions above have had their say (issue #811).
+        if isinstance(result, WiringPort):
+            _check_declared_output(
+                self._signature.return_annotation, _unwrap(result), self.__name__)
         return result
 
 

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -76,7 +76,10 @@ def _output_check_deferred(declared, actual):
     if _is_frame_ts(declared) and _is_frame_ts(actual):
         return True
     try:
-        if actual.is_ts and _is_object_vt(_hgraph.ts_value_vt(actual)):
+        # Only a scalar TS declaration: an erased payload says nothing about the
+        # outer shape, so without this a declared TSD would accept a TS[Any]
+        # (issue #811 review).
+        if declared.is_ts and actual.is_ts and _is_object_vt(_hgraph.ts_value_vt(actual)):
             return True
     except TypeError:
         pass

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -35,6 +35,16 @@ def _is_injectable_annotation(annotation):
 _FRAME_TS_PATTERN = None
 
 
+def _is_erased_frame_ts(handle):
+    """The un-typed ``frame`` scalar: a frame port carrying no column schema."""
+    if handle is None or not handle.is_ts:
+        return False
+    try:
+        return _hgraph.ts_value_vt(handle) == _hgraph.value_type("frame")
+    except TypeError:
+        return False
+
+
 def _is_frame_ts(handle):
     """Is this a frame-valued time series -- typed or erased?
 
@@ -73,7 +83,16 @@ def _output_check_deferred(declared, actual):
     * **Erased python values.** A ``TS[Any]`` result reaching a typed
       declaration is the opaque-python counterpart of the same problem.
     """
-    if _is_frame_ts(declared) and _is_frame_ts(actual):
+    # Only the ERASED frame remains deferred. `convert[TS[Frame]]` does not yet
+    # take its row schema from the source, so it yields a `TS[frame]` whose
+    # columns appear at runtime -- nothing at wiring can judge it against a
+    # typed declaration. Tracked as the remaining follow-up.
+    #
+    # The other two frame cases are gone, fixed in shared C++ where BOTH
+    # frontends reach them: a named bundle and its structural twin are now the
+    # same type (nominal_is_a), and the un-typed `frame` is the top of the
+    # frame family (value_is_a).
+    if _is_erased_frame_ts(actual) and _is_frame_ts(declared):
         return True
     try:
         # Only a scalar TS declaration: an erased payload says nothing about the

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -70,9 +70,15 @@ def binding_matches(annotation, port_tp, scope):
 
     if isinstance(annotation, _TsExpr):
         handle = annotation.handle
-        if handle.is_ts and _is_object_vt(_hgraph.ts_value_vt(handle)):
+        # Both widenings are about the PAYLOAD, so they may only fire when the
+        # outer shapes already agree. Without that, TS[object] would accept a
+        # TSD and TSW would accept anything at all -- the very hole the
+        # declared-output check exists to close, and one no C++ signature can
+        # admit (issue #811 review).
+        if (handle.is_ts and port_tp is not None and port_tp.is_ts and
+                _is_object_vt(_hgraph.ts_value_vt(handle))):
             return True
-        if handle.kind == _tsw_kind():
+        if handle.kind == _tsw_kind() and port_tp is not None and port_tp.kind == _tsw_kind():
             return True
         if handle == port_tp:
             return True

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -40,6 +40,67 @@ def _node_ref(fn):
         return _hgraph.node_ref(fn)
 
 
+def binding_matches(annotation, port_tp, scope):
+    """Is a port of ``port_tp`` acceptable where ``annotation`` is declared?
+
+    This is the ONE assignability rule. It decides whether a wired port may
+    bind to a declared input, and -- since the question is identical -- whether
+    a graph body's result may satisfy its declared output (issue #811). Keeping
+    both on this single predicate is deliberate: a second, subtly different
+    notion of "compatible" is exactly the parallel abstraction the architecture
+    guardrails exist to prevent, and the two would drift.
+
+    Assignability is wider than equality, and every widening below is
+    load-bearing -- each was falsified by a test when the check was first
+    written as handle equality:
+
+    * ``TS[object]``/``TS[Any]`` widens over any payload (the py-any rule),
+    * ``TSW`` is deferred while min-period defaults are applied at wiring, so
+      handle equality over-rejects,
+    * the C++ pattern matcher owns type-variable binding and structural
+      matching,
+    * ``tuple[E, ...]`` widens over fixed tuples of ``E``,
+    * a concrete ``CompoundScalar`` annotation accepts SUBCLASS ports, which is
+      the covariance ``dispatch`` relies on.
+
+    ``scope`` is mutated by pattern matching: type variables bind into it.
+    Callers that must not bind should pass a throwaway scope.
+    """
+    from .._types import TS, _pattern_of
+
+    if isinstance(annotation, _TsExpr):
+        handle = annotation.handle
+        if handle.is_ts and _is_object_vt(_hgraph.ts_value_vt(handle)):
+            return True
+        if handle.kind == _tsw_kind():
+            return True
+        if handle == port_tp:
+            return True
+    try:
+        pattern = _pattern_of(annotation)
+    except TypeError:
+        return True   # non-ts annotation reached with a port: leave to the runtime
+    if scope.match(pattern, port_tp):
+        return True
+    if isinstance(annotation, _TsExpr) and annotation.handle.is_ts:
+        vt = _hgraph.ts_value_vt(annotation.handle)
+        if _hgraph.vt_kind(vt) == _unbounded_tuple_kind():
+            homogeneous = _hgraph.type_pattern_ts(
+                _hgraph.scalar_pattern_homogeneous_tuple(
+                    _hgraph.scalar_pattern_value(_hgraph.vt_element(vt))))
+            if scope.match(homogeneous, port_tp):
+                return True
+    cs_class = getattr(annotation, "_cs_class", None)
+    if cs_class is not None:
+        stack = list(cs_class.__subclasses__())
+        while stack:
+            candidate = stack.pop()
+            stack.extend(candidate.__subclasses__())
+            if TS[candidate].handle == port_tp:
+                return True   # subtype binding (auto-cast)
+    return False
+
+
 def _signature_registry_generation(signature):
     """Generation owning concrete TS handles retained by a signature."""
     annotations = [
@@ -562,13 +623,11 @@ class _PyNode:
         binding type variables into the scope. A mismatch on a concrete
         CompoundScalar annotation accepts SUBCLASS ports (python's
         inheritance is a py-frontend concept); anything else raises."""
-        from .._types import TS, _pattern_of
+        import typing
 
         annotation = param.annotation
         if isinstance(annotation, _ContextExpr):
             return
-        import typing
-
         if typing.get_origin(annotation) is typing.Union:
             members = typing.get_args(annotation)
             port_tp = _unwrap(value).ts_type
@@ -577,44 +636,9 @@ class _PyNode:
                     return
             raise IncorrectTypeBinding(
                 f"{self.__name__}: '{param.name}' expects one of {members!r}")
-        if isinstance(annotation, _TsExpr):
-            handle = annotation.handle
-            # TS[object] widens over any payload (the py-any input rule).
-            if handle.is_ts and _is_object_vt(_hgraph.ts_value_vt(handle)):
-                return
-            # TSW strictness is deferred until the duration/tick marker
-            # normalisation lands (min-period defaults are applied at
-            # wiring, so handle equality over-rejects).
-            if handle.kind == _tsw_kind():
-                return
-            port_tp = _unwrap(value).ts_type
-            if handle == port_tp:
-                return
-        try:
-            pattern = _pattern_of(annotation)
-        except TypeError:
-            return   # non-ts annotation reached with a port: leave to the runtime
         port_tp = _unwrap(value).ts_type
-        if scope.match(pattern, port_tp):
+        if binding_matches(annotation, port_tp, scope):
             return
-        if isinstance(annotation, _TsExpr) and annotation.handle.is_ts:
-            # tuple[E, ...] widens over fixed tuples of E: re-match with the
-            # C++ homogeneous-tuple pattern (the matcher owns that rule).
-            vt = _hgraph.ts_value_vt(annotation.handle)
-            if _hgraph.vt_kind(vt) == _unbounded_tuple_kind():
-                homogeneous = _hgraph.type_pattern_ts(
-                    _hgraph.scalar_pattern_homogeneous_tuple(
-                        _hgraph.scalar_pattern_value(_hgraph.vt_element(vt))))
-                if scope.match(homogeneous, port_tp):
-                    return
-        cs_class = getattr(annotation, "_cs_class", None)
-        if cs_class is not None:
-            stack = list(cs_class.__subclasses__())
-            while stack:
-                candidate = stack.pop()
-                stack.extend(candidate.__subclasses__())
-                if TS[candidate].handle == port_tp:
-                    return   # subtype binding (auto-cast)
         raise IncorrectTypeBinding(
             f"{self.__name__}: '{param.name}' expects {annotation!r}, got {port_tp!r}")
 

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -818,6 +818,18 @@ namespace hgraph::python_bridge
         .def_prop_ro("is_ref", [](const PyTsType &self) {
             return self.meta != nullptr && self.meta->kind == TSTypeKind::REF;
         })
+        .def_prop_ro("dereference", [](const PyTsType &self) {
+            // The referenced type, with REF wrappers peeled off; self when not
+            // a reference. A reference is how a value travels, not what it is,
+            // so declared-vs-actual comparisons are made on this (issue #811,
+            // matching the released check which dereferences both sides).
+            const TSValueTypeMetaData *meta = self.meta;
+            while (meta != nullptr && meta->kind == TSTypeKind::REF && meta->referenced_ts() != nullptr)
+            {
+                meta = meta->referenced_ts();
+            }
+            return PyTsType{meta};
+        })
         .def_prop_ro("is_fixed_tsl", [](const PyTsType &self) {
             return self.meta != nullptr && self.meta->kind == TSTypeKind::TSL && self.meta->fixed_size() > 0;
         })

--- a/python/tests/test_declared_graph_output.py
+++ b/python/tests/test_declared_graph_output.py
@@ -145,3 +145,50 @@ def test_covariance_is_still_accepted():
         return const(Derived(1, 2), TS[Derived])
 
     assert eval_node(g) == [Derived(1, 2)]
+
+
+def test_an_erased_payload_does_not_excuse_a_different_shape():
+    """The payload widenings must not admit a different OUTER shape.
+
+    ``TS[object]`` widens over any payload and ``TSW`` defers its handle
+    comparison, but both are about what a time series CARRIES. Applied without
+    checking the outer kind they reopened the hole this check exists to close,
+    in both directions -- and no C++ graph signature can admit either return
+    (issue #811 review).
+    """
+
+    @compute_node
+    def _to_tsd(x: TS[int]) -> TSD[str, TS[int]]:
+        return {"a": x.value}
+
+    @compute_node
+    def _to_object(x: TS[int]) -> TS[object]:
+        return x.value
+
+    @graph
+    def declared_scalar(a: TS[int]) -> TS[object]:
+        return _to_tsd(a)
+
+    with pytest.raises(WiringError, match="declares its output as"):
+        eval_node(declared_scalar, [1])
+
+    @graph
+    def declared_keyed(a: TS[int]) -> TSD[str, TS[int]]:
+        return _to_object(a)
+
+    with pytest.raises(WiringError, match="declares its output as"):
+        eval_node(declared_keyed, [1])
+
+
+def test_an_erased_payload_is_still_accepted_at_the_same_shape():
+    """The widening itself survives: same outer shape, erased payload."""
+
+    @compute_node
+    def _to_object(x: TS[int]) -> TS[object]:
+        return x.value
+
+    @graph
+    def g(a: TS[int]) -> TS[object]:
+        return _to_object(a)
+
+    assert eval_node(g, [1]) == [1]

--- a/python/tests/test_declared_graph_output.py
+++ b/python/tests/test_declared_graph_output.py
@@ -1,0 +1,147 @@
+"""A graph's declared output type is enforced at wiring (issue #811).
+
+A graph whose body returned a different time-series type from the one it
+declared was accepted and evaluated, so ``int`` values were delivered through a
+declared ``TS[bool]`` and a ``TS`` through a declared ``TSD``. Released hgraph
+rejects each of these at wiring, with the wording pinned below.
+
+The issue's own reading is worth keeping in view: if a declaration is never
+enforced where it is made, a mismatch survives to wherever something downstream
+trusts it -- which is why this is a wiring-safety hole rather than a value
+difference.
+"""
+import pytest
+
+from hgraph import (
+    TS,
+    TSD,
+    TIME_SERIES_TYPE,
+    WiringError,
+    compute_node,
+    graph,
+    invert_,
+)
+from hgraph.test import eval_node
+
+
+@compute_node
+def _to_float(x: TS[int]) -> TS[float]:
+    return float(x.value)
+
+
+@compute_node
+def _to_str(x: TS[int]) -> TS[str]:
+    return str(x.value)
+
+
+def test_operator_result_type_must_match_the_declaration():
+    """The issue's own case: invert_ over TS[bool] yields TS[int]."""
+
+    @graph
+    def g(ts: TS[bool]) -> TS[bool]:
+        return invert_(ts)
+
+    with pytest.raises(WiringError, match=r"declares its output as 'TS\[bool\]' but 'TS\[int\]'"):
+        eval_node(g, [True, False])
+
+
+def test_widened_arithmetic_result_must_match_the_declaration():
+    """Mixed arithmetic legitimately widens to TS[float]; the DECLARATION is
+    what was wrong, and it used to deliver a float inside a TS[int]."""
+
+    @graph
+    def g(a: TS[int]) -> TS[int]:
+        from hgraph import add_
+        return add_(a, 1.7)
+
+    with pytest.raises(WiringError, match=r"declares its output as 'TS\[int\]' but 'TS\[float\]'"):
+        eval_node(g, [10])
+
+
+def test_node_result_type_must_match_the_declaration():
+    @graph
+    def g(a: TS[int]) -> TS[int]:
+        return _to_float(a)
+
+    with pytest.raises(WiringError, match="declares its output as"):
+        eval_node(g, [3])
+
+
+def test_a_different_shape_is_rejected():
+    """Not just the payload: a TS returned through a declared TSD."""
+
+    @graph
+    def g(a: TS[int]) -> TSD[str, TS[int]]:
+        return a
+
+    with pytest.raises(WiringError, match="declares its output as"):
+        eval_node(g, [1])
+
+
+def test_unrelated_payload_is_rejected():
+    @graph
+    def g(a: TS[int]) -> TS[int]:
+        return _to_str(a)
+
+    with pytest.raises(WiringError, match=r"'TS\[int\]' but 'TS\[str\]'"):
+        eval_node(g, [3])
+
+
+def test_a_correct_declaration_still_wires():
+    @graph
+    def g(a: TS[int]) -> TS[float]:
+        return _to_float(a)
+
+    assert eval_node(g, [3]) == [3.0]
+
+
+def test_a_nested_graph_is_checked_too():
+    """map_ bodies go through the same wiring path, so a mis-declared body is
+    caught where it is declared rather than at the outer boundary."""
+    from hgraph import map_
+
+    @graph
+    def bad_body(x: TS[int]) -> TS[int]:
+        return _to_float(x)
+
+    @graph
+    def outer(ts: TSD[str, TS[int]]) -> TSD[str, TS[int]]:
+        return map_(bad_body, ts)
+
+    with pytest.raises(WiringError, match="'bad_body' declares its output as"):
+        eval_node(outer, [{"a": 1}])
+
+
+def test_a_generic_declaration_still_resolves():
+    """``TIME_SERIES_TYPE`` is treated as an absent annotation -- it resolves
+    FROM the wired ports rather than constraining them, so enforcing it would
+    break every generic graph. This is the acceptance criterion's second half.
+    """
+
+    @graph
+    def g(a: TS[int]) -> TIME_SERIES_TYPE:
+        return _to_float(a)
+
+    assert eval_node(g, [3]) == [3.0]
+
+
+def test_covariance_is_still_accepted():
+    """Assignability, not equality: a subclass payload satisfies a declared
+    base. Writing the check as handle equality rejected 87 working graphs."""
+    from dataclasses import dataclass
+
+    from hgraph import CompoundScalar, const
+
+    @dataclass(frozen=True)
+    class Base(CompoundScalar):
+        a: int
+
+    @dataclass(frozen=True)
+    class Derived(Base):
+        b: int = 0
+
+    @graph
+    def g() -> TS[Base]:
+        return const(Derived(1, 2), TS[Derived])
+
+    assert eval_node(g) == [Derived(1, 2)]

--- a/python/tests/test_mesh_generic_output.py
+++ b/python/tests/test_mesh_generic_output.py
@@ -8,7 +8,10 @@ from hgraph import (
     mesh_,
     pass_through,
 )
+from hgraph import WiringError
 from hgraph.test import eval_node
+
+import pytest
 
 
 @graph
@@ -65,4 +68,21 @@ def _generic_nested_mesh(
 
 
 def test_generic_mesh_scope_is_available_to_nested_map_output_inference():
-    assert eval_node(_generic_nested_mesh, [{}], [{}]) is None
+    """The nested mesh scope resolves, and the graph is then correctly rejected.
+
+    ``_generic_nested_peer`` returns one nesting level deeper than
+    ``_generic_nested_mesh`` declares: mapping over the mesh elements yields
+    ``TSD[str, TSD[str, TS[int]]]`` per peer, so the mesh is
+    ``TSD[str, TSD[str, TSD[str, TS[int]]]]`` against a declared
+    ``TSD[str, TSD[str, TS[int]]]``.
+
+    Released hgraph rejects the same graph -- at the inner peer, reporting
+    ``'TSD[str, TS[int]]' but 'TSD[str, REF[TSD[str, TS[int]]]]'`` -- so
+    rejecting is the parity-matching outcome. It used to wire here only because
+    the declared output was never enforced (issue #811). Reaching the type
+    error at all still proves the mesh scope was available to the nested map's
+    output inference, which is what this case exists to cover; the sibling
+    above pins the non-nested resolution.
+    """
+    with pytest.raises(WiringError, match="declares its output as"):
+        eval_node(_generic_nested_mesh, [{}], [{}])

--- a/src/hgraph/types/metadata/type_registry.cpp
+++ b/src/hgraph/types/metadata/type_registry.cpp
@@ -406,7 +406,21 @@ namespace hgraph
         bool nominal_is_a(const ValueTypeMetaData *candidate, const ValueTypeMetaData *base) noexcept
         {
             if (candidate == base) { return candidate != nullptr; }
-            if (candidate == nullptr || base == nullptr || candidate->bundle_hierarchy == nullptr) { return false; }
+            if (candidate == nullptr || base == nullptr) { return false; }
+            // A named bundle and its canonical structural twin are the SAME
+            // type, in both directions: the fields drive correctness and the
+            // schema name is presentation. This is the same strategy the
+            // un-named bundle already encodes -- the structural form is the
+            // key, named variants are references to it -- reached here so that
+            // frame[AB] and frame[Bundle{a:int,b:int}] agree once covariant_pair
+            // has descended to their rows.
+            //
+            // Deliberately only a bundle against ITS OWN twin: two DIFFERENT
+            // named bundles keep nominal identity, exactly as
+            // value_schema_equivalent has it.
+            if (candidate->is_named_bundle() && candidate->wrapped_un_named == base) { return true; }
+            if (base->is_named_bundle() && base->wrapped_un_named == candidate) { return true; }
+            if (candidate->bundle_hierarchy == nullptr) { return false; }
             for (const auto &[ancestor, distance] : candidate->bundle_hierarchy->ancestors)
             {
                 if (ancestor == base) { return true; }
@@ -462,6 +476,15 @@ namespace hgraph
     {
         if (candidate == base) { return candidate != nullptr; }
         if (candidate == nullptr || base == nullptr) { return false; }
+        // The un-typed ``frame`` is the TOP of the frame family: declaring it
+        // accepts any frame, the way ``TS[object]`` accepts any payload.
+        // Deliberately one-directional -- a TYPED declaration is not satisfied
+        // by a frame whose row schema is unspecified.
+        if (candidate->has(ValueTypeFlags::Frame) &&
+            base == frame_base_.load(std::memory_order_relaxed))
+        {
+            return true;
+        }
         if (!covariant_pair(candidate, base)) { return false; }
         return nominal_is_a(candidate, base);
     }
@@ -1434,6 +1457,7 @@ namespace hgraph
         const std::lock_guard lock(mutex_);
         const ValueTypeMetaData *base = value_type("frame");
         if (base == nullptr) { throw std::logic_error("frame scalar is not registered"); }
+        frame_base_.store(base, std::memory_order_relaxed);
         if (column_schema == nullptr)
         {
             if (metadata_schema != nullptr)

--- a/src/hgraph/types/metadata/type_registry.cpp
+++ b/src/hgraph/types/metadata/type_registry.cpp
@@ -433,6 +433,12 @@ namespace hgraph
         {
             if (candidate == nullptr || base == nullptr) { return std::nullopt; }
             if (candidate == base) { return 0; }
+            // Mirrors nominal_is_a: a named bundle and its structural twin are
+            // the SAME type, so the distance is zero, not merely "related".
+            // value_is_a(c, b) holds exactly when this has a value, and the two
+            // must agree or overload ranking sees a match it cannot rank.
+            if (candidate->is_named_bundle() && candidate->wrapped_un_named == base) { return 0; }
+            if (base->is_named_bundle() && base->wrapped_un_named == candidate) { return 0; }
             if (candidate->bundle_hierarchy == nullptr) { return std::nullopt; }
             for (const auto &[ancestor, distance] : candidate->bundle_hierarchy->ancestors)
             {
@@ -495,6 +501,16 @@ namespace hgraph
     {
         if (candidate == nullptr || base == nullptr) { return std::nullopt; }
         if (candidate == base) { return 0; }
+        // Mirrors the un-typed-frame acceptance in value_is_a. ONE step, not
+        // zero: the bare frame is the top of the family, so a fallback
+        // TS<Frame> overload must rank WORSE than an exact TS<FrameOf<Row>>
+        // one. Lower rank wins, so an exact match keeps its 0 and the fallback
+        // no longer ties it.
+        if (candidate->has(ValueTypeFlags::Frame) &&
+            base == frame_base_.load(std::memory_order_relaxed))
+        {
+            return 1;
+        }
         if (!covariant_pair(candidate, base)) { return std::nullopt; }
         return nominal_distance(candidate, base);
     }

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -224,6 +224,7 @@ hgraph_add_test_objects(hgraph_wiring_test_objects
     test_nested_wiring.cpp
     test_operator_calls.cpp
     test_operators.cpp
+    test_output_mutation.cpp
     test_race_semantics.cpp
     test_service_push_sources.cpp
     test_service_runtime.cpp

--- a/tests/cpp/header_compile_check.cpp
+++ b/tests/cpp/header_compile_check.cpp
@@ -30,6 +30,7 @@
 #include <hgraph/types/time_series/ts_data/types.h>
 #include <hgraph/types/time_series/ts_data/window_view.h>
 #include <hgraph/types/time_series/endpoint_schema.h>
+#include <hgraph/types/time_series/output_mutation.h>
 #include <hgraph/types/time_series/ts_input.h>
 #include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/type_pointer.h>

--- a/tests/cpp/test_operators.cpp
+++ b/tests/cpp/test_operators.cpp
@@ -504,6 +504,53 @@ TEST_CASE("operators: a nominal leaf overload beats inherited Bundle inputs")
     CHECK(registry.value_inheritance_distance(puppy, animal) == 2);
 }
 
+TEST_CASE("operators: frame acceptance and its ranking stay in step")
+{
+    // value_is_a and value_inheritance_distance advertise that
+    // "value_is_a(c, b) holds exactly when this has a value". Accepting a
+    // relation in one without ranking it in the other leaves overload
+    // resolution with a match it cannot rank, so the two move together.
+    auto       &registry = TypeRegistry::instance();
+    const auto *integer  = registry.value_type("int");
+    const auto *row      = registry.bundle(
+        "tests.operator.frame_fallback", "Row", {{"id", integer}}, {}, true);
+    const auto *typed_frame = registry.frame(row);
+    const auto *bare_frame  = registry.value_type("frame");
+
+    // The un-typed frame is the top of the family: accepted, and ranked as a
+    // step AWAY from an exact match rather than equal to one.
+    CHECK(registry.value_is_a(typed_frame, bare_frame));
+    const auto fallback_distance = registry.value_inheritance_distance(typed_frame, bare_frame);
+    REQUIRE(fallback_distance.has_value());
+    CHECK(*fallback_distance > 0);
+
+    // ... and an exact match still ranks zero, so it wins on distance.
+    CHECK(registry.value_inheritance_distance(typed_frame, typed_frame) == 0);
+
+    // Not symmetric: an un-specified frame does not satisfy a typed one, and
+    // an unrankable pair must report no distance rather than zero.
+    CHECK_FALSE(registry.value_is_a(bare_frame, typed_frame));
+    CHECK_FALSE(registry.value_inheritance_distance(bare_frame, typed_frame).has_value());
+}
+
+TEST_CASE("operators: a named bundle and its structural twin rank as one type")
+{
+    // The other half of the same invariant: nominal_is_a now equates a named
+    // bundle with its un-named structural twin, so the distance must be ZERO
+    // -- they are the same type, not merely related.
+    auto       &registry = TypeRegistry::instance();
+    const auto *integer  = registry.value_type("int");
+    const auto *named    = registry.bundle(
+        "tests.operator.twin", "Named", {{"id", integer}}, {}, true);
+    const auto *twin = named->wrapped_un_named;
+    REQUIRE(twin != nullptr);
+
+    CHECK(registry.value_is_a(named, twin));
+    CHECK(registry.value_is_a(twin, named));
+    CHECK(registry.value_inheritance_distance(named, twin) == 0);
+    CHECK(registry.value_inheritance_distance(twin, named) == 0);
+}
+
 TEST_CASE("operators: a narrower Frame row selects the nearest nominal overload")
 {
     auto &registry = TypeRegistry::instance();

--- a/tests/cpp/test_output_mutation.cpp
+++ b/tests/cpp/test_output_mutation.cpp
@@ -1,0 +1,128 @@
+#include <hgraph/lib/testing/check_output.h>
+#include <hgraph/lib/testing/eval_node.h>
+#include <hgraph/types/time_series/output_mutation.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <concepts>
+#include <stdexcept>
+
+namespace
+{
+    using namespace hgraph;
+    using namespace hgraph::testing;
+
+    template <typename TOut>
+    concept accepts_set_upsert = requires(const TOut &out) { hgraph::upsert(out, Int{1}); };
+
+    template <typename TOut>
+    concept accepts_dict_update = requires(const TOut &out) { hgraph::update(out, Str{"key"}, Int{1}); };
+
+    static_assert(accepts_set_upsert<Out<TSS<Int>>>);
+    static_assert(!accepts_set_upsert<Out<TS<Int>>>);
+    static_assert(accepts_dict_update<Out<TSD<Str, TS<Int>>>>);
+    static_assert(!accepts_dict_update<Out<TSS<Int>>>);
+    static_assert(!accepts_dict_update<Out<TSD<Str, TSS<Int>>>>);
+
+    struct FunctionalSetMutation
+    {
+        static constexpr auto name = "functional_set_mutation";
+
+        static void eval(In<"step", TS<Int>> step, Out<TSS<Int>> out) {
+            if (step.value() == 1) {
+                insert(out, Int{1});
+                upsert(out, Int{1});
+                upsert(out, Int{2});
+                REQUIRE_THROWS_AS(insert(out, Int{2}), std::invalid_argument);
+                discard(out, Int{99});
+            } else {
+                remove(out, Int{1});
+                REQUIRE_THROWS_AS(remove(out, Int{1}), std::out_of_range);
+                upsert(out, Int{3});
+                discard(out, Int{99});
+            }
+        }
+    };
+
+    struct FunctionalDictMutation
+    {
+        static constexpr auto name = "functional_dict_mutation";
+
+        static void eval(In<"step", TS<Int>> step, Out<TSD<Str, TS<Int>>> out) {
+            if (step.value() == 1) {
+                insert(out, Str{"a"}, Int{1});
+                upsert(out, Str{"b"}, Int{2});
+                REQUIRE_THROWS_AS(insert(out, Str{"a"}, Int{9}), std::invalid_argument);
+                REQUIRE_THROWS_AS(update(out, Str{"missing"}, Int{9}), std::out_of_range);
+                discard(out, Str{"missing"});
+            } else if (step.value() == 2) {
+                update(out, Str{"a"}, Int{3});
+                upsert(out, Str{"b"}, Int{4});
+                upsert(out, Str{"c"}, Int{5});
+                remove(out, Str{"a"});
+                REQUIRE_THROWS_AS(remove(out, Str{"a"}), std::out_of_range);
+            } else {
+                invalidate(out, Str{"b"});
+                REQUIRE(out.contains(Str{"b"}));
+                REQUIRE_FALSE(out.at_slot(out.find_slot(Str{"b"})).valid());
+                REQUIRE_THROWS_AS(invalidate(out, Str{"missing"}), std::out_of_range);
+                clear(out);
+            }
+        }
+    };
+
+    struct FunctionalSetNoOpMutation
+    {
+        static constexpr auto name = "functional_set_no_op_mutation";
+
+        static void eval(In<"step", TS<Int>> step, Out<TSS<Int>> out) {
+            if (step.value() == 1) {
+                upsert(out, Int{1});
+            } else if (step.value() == 2) {
+                upsert(out, Int{1});
+                discard(out, Int{99});
+            } else if (step.value() == 3) {
+                remove(out, Int{1});
+            } else {
+                discard(out, Int{99});
+                clear(out);
+            }
+        }
+    };
+
+    struct FunctionalDictNoOpMutation
+    {
+        static constexpr auto name = "functional_dict_no_op_mutation";
+
+        static void eval(In<"step", TS<Int>> step, Out<TSD<Str, TS<Int>>> out) {
+            if (step.value() == 1) {
+                upsert(out, Str{"a"}, Int{1});
+            } else if (step.value() == 2) {
+                discard(out, Str{"missing"});
+            } else if (step.value() == 3) {
+                remove(out, Str{"a"});
+            } else {
+                discard(out, Str{"missing"});
+                clear(out);
+            }
+        }
+    };
+}  // namespace
+
+TEST_CASE("functional TSS mutations enforce strict and tolerant forms") {
+    CHECK_OUTPUT(eval_node<FunctionalSetMutation>(values<Int>(1, 2)),
+                 values<Value>(set_delta<Int>({1, 2}, {}), set_delta<Int>({3}, {1})));
+}
+
+TEST_CASE("functional TSD mutations preserve structural and invalidation semantics") {
+    CHECK_OUTPUT(eval_node<FunctionalDictMutation>(values<Int>(1, 2, 3)),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"a", 1}, {"b", 2}}),
+                               dict_delta<Str, TS<Int>>({{"b", 4}, {"c", 5}}, {"a"}), dict_delta<Str, TS<Int>>({}, {"b", "c"})));
+}
+
+TEST_CASE("tolerant functional mutations do not produce empty ticks") {
+    CHECK_OUTPUT(eval_node<FunctionalSetNoOpMutation>(values<Int>(1, 2, 3, 4)),
+                 values<Value>(set_delta<Int>({1}, {}), none, set_delta<Int>({}, {1}), none));
+    CHECK_OUTPUT(eval_node<FunctionalDictNoOpMutation>(values<Int>(1, 2, 3, 4)),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"a", 1}}), none, dict_delta<Str, TS<Int>>({}, {"a"}), none));
+}

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -23,6 +23,7 @@
 #include <hgraph/types/static_schema.h>
 #include <hgraph/types/storage_metrics.h>
 #include <hgraph/types/table_type_ops.h>
+#include <hgraph/types/time_series/output_mutation.h>
 #include <hgraph/types/time_series/ts_data/ops.h>
 #include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/time_series/visitor.h>
@@ -52,6 +53,13 @@
 
 namespace
 {
+    static_assert(requires(const hgraph::Out<hgraph::TSS<hgraph::Int>> &out) {
+        hgraph::upsert(out, hgraph::Int{1});
+    });
+    static_assert(requires(const hgraph::Out<hgraph::TSD<hgraph::Str, hgraph::TS<hgraph::Int>>> &out) {
+        hgraph::update(out, hgraph::Str{"key"}, hgraph::Int{1});
+    });
+
     struct ConsumerExtensionScalar
     {
         std::int32_t value{0};


### PR DESCRIPTION
## Summary

- add the public functional mutation facade for typed TSS and TSD outputs
- preserve the existing raw View and `Out<>` member spellings while enforcing strict `insert`/`update`/`remove` and tolerant `upsert`/`discard` behavior
- distinguish keyed child invalidation from structural removal without using create-on-access lookup
- verify the installed SDK exposes the new public header

This is the first implementation PR stacked on #801. Dynamic TSL stack mutations and HGL compiler/library integration follow as separate slices.

## Validation

- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2 --output-on-failure` — 1760 passed
- installed SDK consumer configure/build/test — passed
- Python 3.12 stable-ABI wheel installed into Python 3.14
- `python -m pytest python/tests -q -m "not wip"` — 3421 passed, 10 skipped
- `python -m sphinx -W --keep-going -b html docs/source docs/_build/html` — passed