### PR TITLE
docs(hgl): specify collection output mutations

### DIFF
--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -707,12 +707,16 @@ In a runtime function, `return value` writes the complete output and terminates
 the current evaluation. Reaching the end without a return or output mutation
 produces no output tick. With `inject out`, whole-output writes are
 last-write-wins; writes to distinct collection children accumulate into one
-delta, and repeated writes to one child use the last value.
+delta, and repeated writes to one child use the last value. Collection effects
+use the typed functional vocabulary `insert`, `update`, `upsert`, `remove`,
+`discard`, `invalidate`, `clear`, `push`, and `pop`; the first argument is the
+injected output. Strict operations inspect staged state, and removal remains
+distinct from child invalidation.
 
 A runtime function without `when` uses hgraph's default input activation and
-validity rules. Calls to scalar kernels, richer structural mutation, output
-access during lifecycle hooks, and exact conditional-expression spelling
-remain open.
+validity rules. Calls to scalar kernels, structural delta forwarding, output
+access during lifecycle hooks, and exact conditional-expression spelling remain
+open.
 
 The compiler must represent a function as unclassified until the explicit
 source rule is applied. Scripted and AOT modes must classify identically.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1044,13 +1044,16 @@ Constraints reject a mismatched key or value, mutation through an input, a map
 operation on a set, and dynamic-size operations on a fixed list before a node
 can be instantiated.
 
-Map insertion and upsert must remove a newly created child if initializing its
-complete value throws. Keyed and indexed invalidation must use non-creating
-lookup. Unbounded-list `push` resizes then initializes the new trailing child
-with rollback to the previous size on failure; `pop` and `clear` lower to
-shrinking `resize`. The generated code relies on the runtime's delta
-normalization for last-write-wins and cancellation rather than reimplementing
-delta bookkeeping in the compiler.
+Map insertion and upsert must construct and validate the complete child value
+before they touch the live collection. The native façade exposes this atomic
+path only when the resolved output value can be moved without throwing; a
+defensive guard removes a newly created child if the live commit nevertheless
+fails. Keyed and indexed invalidation must use non-creating lookup.
+Unbounded-list `push` resizes then initializes the new trailing child with
+rollback to the previous size on failure; `pop` and `clear` lower to shrinking
+`resize`. The generated code relies on the runtime's delta normalization for
+last-write-wins and cancellation rather than reimplementing delta bookkeeping
+in the compiler.
 
 Runtime lowering must obey hgraph's native contracts:
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1036,6 +1036,22 @@ Collection projections lower to the typed output view's incremental mutation
 operations, preserving one combined delta for writes to distinct children.
 Reaching the end without a return or output mutation produces no output tick.
 
+The functional collection effects lower to constrained public C++ free
+functions with the same names. For example, `upsert(out, key, value)` becomes
+`hgraph::upsert(hgl_output, key, value)`. The façade delegates to the existing
+typed `Out`/View methods; it does not rename or redesign those raw C++ methods.
+Constraints reject a mismatched key or value, mutation through an input, a map
+operation on a set, and dynamic-size operations on a fixed list before a node
+can be instantiated.
+
+Map insertion and upsert must remove a newly created child if initializing its
+complete value throws. Keyed and indexed invalidation must use non-creating
+lookup. Unbounded-list `push` resizes then initializes the new trailing child
+with rollback to the previous size on failure; `pop` and `clear` lower to
+shrinking `resize`. The generated code relies on the runtime's delta
+normalization for last-write-wins and cancellation rather than reimplementing
+delta bookkeeping in the compiler.
+
 Runtime lowering must obey hgraph's native contracts:
 
 - generated node implementations are empty static structs;

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1060,7 +1060,13 @@ An unqualified name resolves, innermost first, to:
 4. a selectively imported operator;
 5. a prelude intrinsic: `valid`, `modified`, `all_valid`, `last_modified`,
    `delta`, `key_set`, `keys`, `values`, `elements`, `items`, `added`,
-   `removed`.
+   `removed`, `insert`, `update`, `upsert`, `remove`, `discard`, `invalidate`,
+   `clear`, `push`, `pop`.
+
+The collection-mutation intrinsics are available without an import. Their
+effect-specific validation still requires the first argument to resolve to the
+function's injected `out` binding, as described under collection output
+mutation below.
 
 A module alias is only a qualifier: `alias::name` resolves `name` in that
 module's public interface and nothing else. Declaring a name twice in one

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1840,8 +1840,37 @@ writes made by earlier blocks.
 
 `return value` is semantically equivalent to assigning the complete output and
 then returning. A bare `return` terminates evaluation after any preceding
-incremental output mutations. Detailed collection mutation operations remain
-part of structural-type design.
+incremental output mutations.
+
+Collection output mutations are function-shaped effects whose first argument
+must be the injected `out` binding:
+
+| Output | Operations |
+| --- | --- |
+| `set<T>` | `insert(out, value)`, `upsert(out, value)`, `remove(out, value)`, `discard(out, value)`, `clear(out)` |
+| `map<K, V>` | `insert(out, key, value)`, `update(out, key, value)`, `upsert(out, key, value)`, `remove(out, key)`, `discard(out, key)`, `invalidate(out, key)`, `clear(out)` |
+| `list<V, unbounded>` | `push(out, value)`, `pop(out)`, `invalidate(out, index)`, `clear(out)` |
+| `list<V, size>` | `invalidate(out, index)` |
+
+`insert`, `update`, `remove`, and `pop` are strict: their required absent,
+present, or non-empty precondition is checked against the staged state at the
+point of the call. `upsert` and `discard` are tolerant. Set `upsert` is an
+idempotent ensure-membership operation; a set has no `update` operation because
+there is no child payload to replace. Map and list `invalidate` preserve
+structure and invalidate an existing child without creating a key or growing a
+list.
+
+Within one evaluation, distinct child changes accumulate and repeated writes to
+one child use the last value. Insert followed by remove of a previously absent
+child cancels; remove followed by insert of a previously present child is a
+modification. Structural removal, child invalidation, and a value-level `null`
+are separate states. Projected children and collection ranges are borrowed for
+the evaluation and cannot escape it.
+
+These operations initially classify and execute only as runtime-node effects.
+Their function shape reserves the same names for a possible graph form, but a
+future graph overload would return a new collection rather than mutate its
+input and requires a separate semantic decision.
 
 Assigning `delta<S>(...)` to `out` performs the same sparse structural update
 and continues evaluation. Explicit `null` on an optional delta field requests

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -939,21 +939,48 @@ information required by the next evaluation. Use `state` when the function
 needs private information, when that information may change without producing
 an output tick, or when it differs from the output shape.
 
-Collection output supports incremental mutation:
+Collection outputs support typed functional mutations. The first argument is
+always the injected output:
 
 ```hgl
 fn latest_by_key(key: str, value: f64) -> map<str, f64> {
     inject out
 
     when modified(value) && valid(key, value) {
-        out[key] = value
+        upsert(out, key, value)
     }
 }
 ```
 
+Use `insert` when absence is required, `update` when presence is required, and
+`upsert` when either state is acceptable. Sets support `insert` and `upsert`;
+they do not need a separate `update` because membership has no child value.
+`remove` requires the member or key to exist, while `discard` silently does
+nothing when it is absent. `invalidate(out, key)` keeps a map key but
+invalidates its child, which is different from removing the key.
+
+An unbounded list is a stack-shaped mutable output:
+
+```hgl
+fn collect_values(value: i64) -> list<i64, unbounded> {
+    inject out
+
+    when {
+        push(out, value)
+    }
+}
+```
+
+`push` appends and initializes one trailing child. `pop` removes the trailing
+child and requires a non-empty list. `clear` is available for sets, maps, and
+unbounded lists. Indexed `invalidate(out, index)` preserves list length and
+never grows the list. Fixed lists do not support `push`, `pop`, or `clear`.
+
 Whole-output assignments are last-write-wins. Writes to different collection
 children accumulate into one output delta; repeated writes to the same child
-use the last value. `inject out` is invalid on an outputless function and `out`
+use the last value. Strict preconditions observe mutations already staged in
+the current evaluation. Removal, invalidation, and a scalar `null` value remain
+different effects. `inject out` is invalid on an outputless function and `out`
 is initially restricted to evaluation code rather than `start` or `stop`.
 
 Once some other node-only construct classifies a function as runtime, omitting


### PR DESCRIPTION
## Summary

- define the accepted functional collection-output vocabulary for sets, maps, and lists
- distinguish strict `insert` / `update` / `remove` / `pop` from tolerant `upsert` / `discard`
- keep structural removal separate from child invalidation and value-level null
- specify staged same-evaluation behavior, borrowed lifetimes, and the C++ free-function lowering boundary
- reserve graph-form overloads for a separate semantic decision

This is a clean documentation root based directly on `main`. It deliberately does not depend on the recovered standard-library proposal PR #801.

## Validation

- `git diff --check`
- reviewed all edited Markdown examples and internal terminology against the existing language user, developer, and design guides
