### PR TITLE
feat(cpp): add functional collection output mutations

### DIFF
--- a/docs/source/user_guide/cpp/authoring_nodes.rst
+++ b/docs/source/user_guide/cpp/authoring_nodes.rst
@@ -730,6 +730,16 @@ conveniences.
        }
    };
 
+For code shared conceptually with HGL, include
+``<hgraph/types/time_series/output_mutation.h>`` and use the constrained free
+functions ``insert``, ``update``, ``upsert``, ``remove``, ``discard``,
+``invalidate``, and ``clear``. They preserve the member API above: the
+functions validate strict preconditions and then delegate to ``add``,
+``remove``, ``erase``, ``set``, child invalidation, or ``clear``. In
+particular, ``remove`` requires membership while ``discard`` tolerates an
+absent member or key, and ``invalidate(out, key)`` retains the dictionary key
+without using its create-on-access lookup.
+
 ``TSD`` replay/record uses the canonical
 ``Bundle{removed: Set<K>, modified: Map<K, delta(V)>}`` delta. Build expected
 test deltas with ``dict_delta<K, V>``; ``V`` can itself be any supported

--- a/include/hgraph/types/time_series/output_mutation.h
+++ b/include/hgraph/types/time_series/output_mutation.h
@@ -3,8 +3,10 @@
 
 #include <hgraph/types/static_node.h>
 
+#include <concepts>
 #include <memory>
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 
 namespace hgraph
@@ -15,8 +17,20 @@ namespace hgraph
             return ValueView{out.data_view().layout().key_binding, std::addressof(value)};
         }
 
+        template <typename TSchema> using output_value_t = typename Out<TSchema>::value_type;
+
         template <typename TSchema, typename TValue>
-        concept settable_output = requires(const Out<TSchema> &out, TValue &&value) { out.set(std::forward<TValue>(value)); };
+        concept stageable_output =
+            requires { typename output_value_t<TSchema>; } && std::constructible_from<output_value_t<TSchema>, TValue> &&
+            std::is_nothrow_move_constructible_v<output_value_t<TSchema>> &&
+            std::is_nothrow_move_assignable_v<output_value_t<TSchema>> &&
+            requires(const Out<TSchema> &out, output_value_t<TSchema> value) { out.set(std::move(value)); };
+
+        template <typename TSchema, typename TValue>
+            requires stageable_output<TSchema, TValue>
+        [[nodiscard]] output_value_t<TSchema> stage(TValue &&value) {
+            return output_value_t<TSchema>{std::forward<TValue>(value)};
+        }
     }  // namespace output_mutation_detail
 
     /** Insert an absent member into a set output. */
@@ -52,32 +66,35 @@ namespace hgraph
 
     /** Insert and initialize an absent dictionary child. */
     template <typename TKey, typename TValueSchema, typename TValue>
-        requires output_mutation_detail::settable_output<TValueSchema, TValue>
+        requires output_mutation_detail::stageable_output<TValueSchema, TValue>
     void insert(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key, TValue &&value) {
         if (out.contains(key)) { throw std::invalid_argument("insert requires an absent TSD key"); }
 
+        auto resolved = output_mutation_detail::stage<TValueSchema>(std::forward<TValue>(value));
         auto rollback = make_scope_exit<true>([&] { static_cast<void>(out.erase(key)); });
-        out[key].set(std::forward<TValue>(value));
+        out[key].set(std::move(resolved));
         rollback.release();
     }
 
     /** Update and tick an existing dictionary child. */
     template <typename TKey, typename TValueSchema, typename TValue>
-        requires output_mutation_detail::settable_output<TValueSchema, TValue>
+        requires output_mutation_detail::stageable_output<TValueSchema, TValue>
     void update(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key, TValue &&value) {
         if (!out.contains(key)) { throw std::out_of_range("update requires a present TSD key"); }
-        out.at_slot(out.find_slot(key)).set(std::forward<TValue>(value));
+        auto resolved = output_mutation_detail::stage<TValueSchema>(std::forward<TValue>(value));
+        out.at_slot(out.find_slot(key)).set(std::move(resolved));
     }
 
     /** Insert or update a dictionary child. */
     template <typename TKey, typename TValueSchema, typename TValue>
-        requires output_mutation_detail::settable_output<TValueSchema, TValue>
+        requires output_mutation_detail::stageable_output<TValueSchema, TValue>
     void upsert(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key, TValue &&value) {
+        auto       resolved = output_mutation_detail::stage<TValueSchema>(std::forward<TValue>(value));
         const bool existed  = out.contains(key);
         auto       rollback = make_scope_exit<true>([&] {
             if (!existed) { static_cast<void>(out.erase(key)); }
         });
-        out[key].set(std::forward<TValue>(value));
+        out[key].set(std::move(resolved));
         rollback.release();
     }
 

--- a/include/hgraph/types/time_series/output_mutation.h
+++ b/include/hgraph/types/time_series/output_mutation.h
@@ -1,0 +1,108 @@
+#ifndef HGRAPH_TYPES_TIME_SERIES_OUTPUT_MUTATION_H
+#define HGRAPH_TYPES_TIME_SERIES_OUTPUT_MUTATION_H
+
+#include <hgraph/types/static_node.h>
+
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+namespace hgraph
+{
+    namespace output_mutation_detail
+    {
+        template <typename TValue> [[nodiscard]] ValueView key_view(const Out<TSS<TValue>> &out, const TValue &value) {
+            return ValueView{out.data_view().layout().key_binding, std::addressof(value)};
+        }
+
+        template <typename TSchema, typename TValue>
+        concept settable_output = requires(const Out<TSchema> &out, TValue &&value) { out.set(std::forward<TValue>(value)); };
+    }  // namespace output_mutation_detail
+
+    /** Insert an absent member into a set output. */
+    template <typename TValue> void insert(const Out<TSS<TValue>> &out, const TValue &value) {
+        if (out.contains(output_mutation_detail::key_view(out, value))) {
+            throw std::invalid_argument("insert requires an absent TSS member");
+        }
+        if (!out.add(value)) { throw std::logic_error("TSS insert did not add the absent member"); }
+    }
+
+    /** Ensure that a member exists in a set output. */
+    template <typename TValue> void upsert(const Out<TSS<TValue>> &out, const TValue &value) {
+        if (!out.contains(output_mutation_detail::key_view(out, value))) { static_cast<void>(out.add(value)); }
+    }
+
+    /** Remove a present member from a set output. */
+    template <typename TValue> void remove(const Out<TSS<TValue>> &out, const TValue &value) {
+        if (!out.contains(output_mutation_detail::key_view(out, value))) {
+            throw std::out_of_range("remove requires a present TSS member");
+        }
+        if (!out.remove(value)) { throw std::logic_error("TSS remove did not remove the present member"); }
+    }
+
+    /** Remove a member from a set output if it exists. */
+    template <typename TValue> void discard(const Out<TSS<TValue>> &out, const TValue &value) {
+        if (out.contains(output_mutation_detail::key_view(out, value))) { static_cast<void>(out.remove(value)); }
+    }
+
+    /** Remove every member from a set output. */
+    template <typename TValue> void clear(const Out<TSS<TValue>> &out) {
+        if (!out.empty()) { out.clear(); }
+    }
+
+    /** Insert and initialize an absent dictionary child. */
+    template <typename TKey, typename TValueSchema, typename TValue>
+        requires output_mutation_detail::settable_output<TValueSchema, TValue>
+    void insert(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key, TValue &&value) {
+        if (out.contains(key)) { throw std::invalid_argument("insert requires an absent TSD key"); }
+
+        auto rollback = make_scope_exit<true>([&] { static_cast<void>(out.erase(key)); });
+        out[key].set(std::forward<TValue>(value));
+        rollback.release();
+    }
+
+    /** Update and tick an existing dictionary child. */
+    template <typename TKey, typename TValueSchema, typename TValue>
+        requires output_mutation_detail::settable_output<TValueSchema, TValue>
+    void update(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key, TValue &&value) {
+        if (!out.contains(key)) { throw std::out_of_range("update requires a present TSD key"); }
+        out.at_slot(out.find_slot(key)).set(std::forward<TValue>(value));
+    }
+
+    /** Insert or update a dictionary child. */
+    template <typename TKey, typename TValueSchema, typename TValue>
+        requires output_mutation_detail::settable_output<TValueSchema, TValue>
+    void upsert(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key, TValue &&value) {
+        const bool existed  = out.contains(key);
+        auto       rollback = make_scope_exit<true>([&] {
+            if (!existed) { static_cast<void>(out.erase(key)); }
+        });
+        out[key].set(std::forward<TValue>(value));
+        rollback.release();
+    }
+
+    /** Remove a present dictionary child. */
+    template <typename TKey, typename TValueSchema> void remove(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key) {
+        if (!out.contains(key)) { throw std::out_of_range("remove requires a present TSD key"); }
+        if (!out.erase(key)) { throw std::logic_error("TSD remove did not remove the present key"); }
+    }
+
+    /** Remove a dictionary child if it exists. */
+    template <typename TKey, typename TValueSchema> void discard(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key) {
+        if (out.contains(key)) { static_cast<void>(out.erase(key)); }
+    }
+
+    /** Invalidate an existing dictionary child without removing its key. */
+    template <typename TKey, typename TValueSchema> void invalidate(const Out<TSD<TKey, TValueSchema>> &out, const TKey &key) {
+        if (!out.contains(key)) { throw std::out_of_range("invalidate requires a present TSD key"); }
+        auto child = out.at_slot(out.find_slot(key));
+        static_cast<void>(child.begin_mutation(child.evaluation_time()).invalidate());
+    }
+
+    /** Remove every child from a dictionary output. */
+    template <typename TKey, typename TValueSchema> void clear(const Out<TSD<TKey, TValueSchema>> &out) {
+        if (!out.empty()) { out.clear(); }
+    }
+}  // namespace hgraph
+
+#endif  // HGRAPH_TYPES_TIME_SERIES_OUTPUT_MUTATION_H

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -224,6 +224,7 @@ hgraph_add_test_objects(hgraph_wiring_test_objects
     test_nested_wiring.cpp
     test_operator_calls.cpp
     test_operators.cpp
+    test_output_mutation.cpp
     test_race_semantics.cpp
     test_service_push_sources.cpp
     test_service_runtime.cpp

--- a/tests/cpp/header_compile_check.cpp
+++ b/tests/cpp/header_compile_check.cpp
@@ -30,6 +30,7 @@
 #include <hgraph/types/time_series/ts_data/types.h>
 #include <hgraph/types/time_series/ts_data/window_view.h>
 #include <hgraph/types/time_series/endpoint_schema.h>
+#include <hgraph/types/time_series/output_mutation.h>
 #include <hgraph/types/time_series/ts_input.h>
 #include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/type_pointer.h>

--- a/tests/cpp/test_output_mutation.cpp
+++ b/tests/cpp/test_output_mutation.cpp
@@ -1,0 +1,128 @@
+#include <hgraph/lib/testing/check_output.h>
+#include <hgraph/lib/testing/eval_node.h>
+#include <hgraph/types/time_series/output_mutation.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <concepts>
+#include <stdexcept>
+
+namespace
+{
+    using namespace hgraph;
+    using namespace hgraph::testing;
+
+    template <typename TOut>
+    concept accepts_set_upsert = requires(const TOut &out) { hgraph::upsert(out, Int{1}); };
+
+    template <typename TOut>
+    concept accepts_dict_update = requires(const TOut &out) { hgraph::update(out, Str{"key"}, Int{1}); };
+
+    static_assert(accepts_set_upsert<Out<TSS<Int>>>);
+    static_assert(!accepts_set_upsert<Out<TS<Int>>>);
+    static_assert(accepts_dict_update<Out<TSD<Str, TS<Int>>>>);
+    static_assert(!accepts_dict_update<Out<TSS<Int>>>);
+    static_assert(!accepts_dict_update<Out<TSD<Str, TSS<Int>>>>);
+
+    struct FunctionalSetMutation
+    {
+        static constexpr auto name = "functional_set_mutation";
+
+        static void eval(In<"step", TS<Int>> step, Out<TSS<Int>> out) {
+            if (step.value() == 1) {
+                insert(out, Int{1});
+                upsert(out, Int{1});
+                upsert(out, Int{2});
+                REQUIRE_THROWS_AS(insert(out, Int{2}), std::invalid_argument);
+                discard(out, Int{99});
+            } else {
+                remove(out, Int{1});
+                REQUIRE_THROWS_AS(remove(out, Int{1}), std::out_of_range);
+                upsert(out, Int{3});
+                discard(out, Int{99});
+            }
+        }
+    };
+
+    struct FunctionalDictMutation
+    {
+        static constexpr auto name = "functional_dict_mutation";
+
+        static void eval(In<"step", TS<Int>> step, Out<TSD<Str, TS<Int>>> out) {
+            if (step.value() == 1) {
+                insert(out, Str{"a"}, Int{1});
+                upsert(out, Str{"b"}, Int{2});
+                REQUIRE_THROWS_AS(insert(out, Str{"a"}, Int{9}), std::invalid_argument);
+                REQUIRE_THROWS_AS(update(out, Str{"missing"}, Int{9}), std::out_of_range);
+                discard(out, Str{"missing"});
+            } else if (step.value() == 2) {
+                update(out, Str{"a"}, Int{3});
+                upsert(out, Str{"b"}, Int{4});
+                upsert(out, Str{"c"}, Int{5});
+                remove(out, Str{"a"});
+                REQUIRE_THROWS_AS(remove(out, Str{"a"}), std::out_of_range);
+            } else {
+                invalidate(out, Str{"b"});
+                REQUIRE(out.contains(Str{"b"}));
+                REQUIRE_FALSE(out.at_slot(out.find_slot(Str{"b"})).valid());
+                REQUIRE_THROWS_AS(invalidate(out, Str{"missing"}), std::out_of_range);
+                clear(out);
+            }
+        }
+    };
+
+    struct FunctionalSetNoOpMutation
+    {
+        static constexpr auto name = "functional_set_no_op_mutation";
+
+        static void eval(In<"step", TS<Int>> step, Out<TSS<Int>> out) {
+            if (step.value() == 1) {
+                upsert(out, Int{1});
+            } else if (step.value() == 2) {
+                upsert(out, Int{1});
+                discard(out, Int{99});
+            } else if (step.value() == 3) {
+                remove(out, Int{1});
+            } else {
+                discard(out, Int{99});
+                clear(out);
+            }
+        }
+    };
+
+    struct FunctionalDictNoOpMutation
+    {
+        static constexpr auto name = "functional_dict_no_op_mutation";
+
+        static void eval(In<"step", TS<Int>> step, Out<TSD<Str, TS<Int>>> out) {
+            if (step.value() == 1) {
+                upsert(out, Str{"a"}, Int{1});
+            } else if (step.value() == 2) {
+                discard(out, Str{"missing"});
+            } else if (step.value() == 3) {
+                remove(out, Str{"a"});
+            } else {
+                discard(out, Str{"missing"});
+                clear(out);
+            }
+        }
+    };
+}  // namespace
+
+TEST_CASE("functional TSS mutations enforce strict and tolerant forms") {
+    CHECK_OUTPUT(eval_node<FunctionalSetMutation>(values<Int>(1, 2)),
+                 values<Value>(set_delta<Int>({1, 2}, {}), set_delta<Int>({3}, {1})));
+}
+
+TEST_CASE("functional TSD mutations preserve structural and invalidation semantics") {
+    CHECK_OUTPUT(eval_node<FunctionalDictMutation>(values<Int>(1, 2, 3)),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"a", 1}, {"b", 2}}),
+                               dict_delta<Str, TS<Int>>({{"b", 4}, {"c", 5}}, {"a"}), dict_delta<Str, TS<Int>>({}, {"b", "c"})));
+}
+
+TEST_CASE("tolerant functional mutations do not produce empty ticks") {
+    CHECK_OUTPUT(eval_node<FunctionalSetNoOpMutation>(values<Int>(1, 2, 3, 4)),
+                 values<Value>(set_delta<Int>({1}, {}), none, set_delta<Int>({}, {1}), none));
+    CHECK_OUTPUT(eval_node<FunctionalDictNoOpMutation>(values<Int>(1, 2, 3, 4)),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"a", 1}}), none, dict_delta<Str, TS<Int>>({}, {"a"}), none));
+}

--- a/tests/cpp/test_output_mutation.cpp
+++ b/tests/cpp/test_output_mutation.cpp
@@ -24,6 +24,11 @@ namespace
     static_assert(!accepts_dict_update<Out<TSS<Int>>>);
     static_assert(!accepts_dict_update<Out<TSD<Str, TSS<Int>>>>);
 
+    struct ThrowingIntSource
+    {
+        operator Int() const { throw std::runtime_error("conversion failed"); }
+    };
+
     struct FunctionalSetMutation
     {
         static constexpr auto name = "functional_set_mutation";
@@ -107,6 +112,16 @@ namespace
             }
         }
     };
+
+    struct FunctionalDictFailedInitialization
+    {
+        static constexpr auto name = "functional_dict_failed_initialization";
+
+        static void eval(In<"step", TS<Int>>, Out<TSD<Str, TS<Int>>> out) {
+            REQUIRE_THROWS_AS(insert(out, Str{"a"}, ThrowingIntSource{}), std::runtime_error);
+            REQUIRE_FALSE(out.contains(Str{"a"}));
+        }
+    };
 }  // namespace
 
 TEST_CASE("functional TSS mutations enforce strict and tolerant forms") {
@@ -125,4 +140,8 @@ TEST_CASE("tolerant functional mutations do not produce empty ticks") {
                  values<Value>(set_delta<Int>({1}, {}), none, set_delta<Int>({}, {1}), none));
     CHECK_OUTPUT(eval_node<FunctionalDictNoOpMutation>(values<Int>(1, 2, 3, 4)),
                  values<Value>(dict_delta<Str, TS<Int>>({{"a", 1}}), none, dict_delta<Str, TS<Int>>({}, {"a"}), none));
+}
+
+TEST_CASE("dictionary insertion stages a converted value before publishing its key") {
+    CHECK_OUTPUT(eval_node<FunctionalDictFailedInitialization>(values<Int>(1)), values<Value>(none));
 }

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -23,6 +23,7 @@
 #include <hgraph/types/static_schema.h>
 #include <hgraph/types/storage_metrics.h>
 #include <hgraph/types/table_type_ops.h>
+#include <hgraph/types/time_series/output_mutation.h>
 #include <hgraph/types/time_series/ts_data/ops.h>
 #include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/time_series/visitor.h>
@@ -52,6 +53,13 @@
 
 namespace
 {
+    static_assert(requires(const hgraph::Out<hgraph::TSS<hgraph::Int>> &out) {
+        hgraph::upsert(out, hgraph::Int{1});
+    });
+    static_assert(requires(const hgraph::Out<hgraph::TSD<hgraph::Str, hgraph::TS<hgraph::Int>>> &out) {
+        hgraph::update(out, hgraph::Str{"key"}, hgraph::Int{1});
+    });
+
     struct ConsumerExtensionScalar
     {
         std::int32_t value{0};


### PR DESCRIPTION
## Summary

- add a public, constrained free-function facade for collection output mutation
- expose strict insert / update / remove and tolerant upsert / discard
- expose keyed invalidate separately from structural removal
- preserve true no-op behavior for existing set upserts, absent discards, and empty clears
- stage TSD child values before touching live output, so failed conversion produces no key and no tick
- cover public wiring behavior, compile-time constraints, header compilation, installed-SDK consumption, and C++ authoring guidance

This implementation PR is stacked on the clean accepted-language documentation in #881. It has no dependency on the recovered-proposals PR #801. It supersedes #878. Raw C++ View spellings remain unchanged.

## Validation

The corrected stack was validated at its C++ top (#883):

- full native C++ suite: 1766/1766 passed
- focused collection mutation suite: 22 assertions across 6 cases passed
- installed-SDK consumer: 1/1 passed
- stable-ABI wheel built with Python 3.12 and tested under Python 3.14
- Python non-WIP suite: 3432 passed, 10 skipped
- Sphinx HTML build with warnings as errors passed