### PR TITLE
feat(cpp): add functional dynamic list mutations

### DIFF
--- a/docs/source/user_guide/cpp/authoring_nodes.rst
+++ b/docs/source/user_guide/cpp/authoring_nodes.rst
@@ -698,6 +698,13 @@ Truncation removes trailing indices only; ``added_indices()`` /
 ``removed_indices()`` report the change and the removed children stay readable
 for the rest of the cycle (RFC 0031).
 
+The functional façade in
+``<hgraph/types/time_series/output_mutation.h>`` exposes ``push`` / ``pop`` /
+``clear`` for an unbounded ``TSL`` while leaving ``resize`` as the raw View
+mechanism. ``push`` initializes the appended child as one rollback-safe
+operation, and ``pop`` is an effect-only operation that rejects an empty list.
+The overloads are not available for a fixed ``TSL``.
+
 **Dict (``TSD<K, V>``) — available and recursive.** ``In`` derives from
 ``TSDInputView`` and adds typed key lookup. ``contains(key)`` and
 ``find_slot(key)`` are typed; ``at(key)`` / ``operator[](key)`` return

--- a/include/hgraph/types/time_series/output_mutation.h
+++ b/include/hgraph/types/time_series/output_mutation.h
@@ -31,6 +31,13 @@ namespace hgraph
         [[nodiscard]] output_value_t<TSchema> stage(TValue &&value) {
             return output_value_t<TSchema>{std::forward<TValue>(value)};
         }
+
+        template <auto N>
+        inline constexpr bool is_dynamic_list_extent = [] {
+            using descriptor = static_schema_detail::size_parameter_descriptor<N>;
+            if constexpr (!descriptor::is_concrete()) { return false; }
+            return descriptor::concrete_size() == 0;
+        }();
     }  // namespace output_mutation_detail
 
     /** Insert an absent member into a set output. */
@@ -119,6 +126,41 @@ namespace hgraph
     /** Remove every child from a dictionary output. */
     template <typename TKey, typename TValueSchema> void clear(const Out<TSD<TKey, TValueSchema>> &out) {
         if (!out.empty()) { out.clear(); }
+    }
+
+    /** Append and initialize a child on an unbounded list output. */
+    template <typename TElementSchema, auto N, typename TValue>
+        requires(output_mutation_detail::is_dynamic_list_extent<N> &&
+                 output_mutation_detail::stageable_output<TElementSchema, TValue>)
+    void push(const Out<TSL<TElementSchema, N>> &out, TValue &&value) {
+        auto              resolved      = output_mutation_detail::stage<TElementSchema>(std::forward<TValue>(value));
+        const std::size_t previous_size = out.size();
+        out.resize(previous_size + 1);
+        auto rollback = make_scope_exit<true>([&] { out.resize(previous_size); });
+        out[previous_size].set(std::move(resolved));
+        rollback.release();
+    }
+
+    /** Remove the trailing child from a non-empty unbounded list output. */
+    template <typename TElementSchema, auto N>
+        requires output_mutation_detail::is_dynamic_list_extent<N>
+    void pop(const Out<TSL<TElementSchema, N>> &out) {
+        if (out.empty()) { throw std::out_of_range("pop requires a non-empty unbounded TSL"); }
+        out.resize(out.size() - 1);
+    }
+
+    /** Remove every child from an unbounded list output. */
+    template <typename TElementSchema, auto N>
+        requires output_mutation_detail::is_dynamic_list_extent<N>
+    void clear(const Out<TSL<TElementSchema, N>> &out) {
+        out.resize(0);
+    }
+
+    /** Invalidate an existing list child without changing the list length. */
+    template <typename TElementSchema, auto N> void invalidate(const Out<TSL<TElementSchema, N>> &out, std::size_t index) {
+        if (index >= out.size()) { throw std::out_of_range("invalidate requires an existing TSL index"); }
+        auto child = out[index];
+        static_cast<void>(child.begin_mutation(child.evaluation_time()).invalidate());
     }
 }  // namespace hgraph
 

--- a/tests/cpp/test_output_mutation.cpp
+++ b/tests/cpp/test_output_mutation.cpp
@@ -18,11 +18,17 @@ namespace
     template <typename TOut>
     concept accepts_dict_update = requires(const TOut &out) { hgraph::update(out, Str{"key"}, Int{1}); };
 
+    template <typename TOut>
+    concept accepts_list_push = requires(const TOut &out) { hgraph::push(out, Int{1}); };
+
     static_assert(accepts_set_upsert<Out<TSS<Int>>>);
     static_assert(!accepts_set_upsert<Out<TS<Int>>>);
     static_assert(accepts_dict_update<Out<TSD<Str, TS<Int>>>>);
     static_assert(!accepts_dict_update<Out<TSS<Int>>>);
     static_assert(!accepts_dict_update<Out<TSD<Str, TSS<Int>>>>);
+    static_assert(accepts_list_push<Out<TSL<TS<Int>>>>);
+    static_assert(!accepts_list_push<Out<TSL<TS<Int>, 2>>>);
+    static_assert(!accepts_list_push<Out<TSL<TSS<Int>>>>);
 
     struct ThrowingIntSource
     {
@@ -122,6 +128,39 @@ namespace
             REQUIRE_FALSE(out.contains(Str{"a"}));
         }
     };
+
+    struct FunctionalDynamicListMutation
+    {
+        static constexpr auto name = "functional_dynamic_list_mutation";
+
+        static void eval(In<"step", TS<Int>> step, Out<TSL<TS<Int>>> out) {
+            if (step.value() == 1) {
+                push(out, Int{1});
+                push(out, Int{2});
+            } else if (step.value() == 2) {
+                pop(out);
+                push(out, Int{3});
+                out[0].set(Int{4});
+            } else {
+                pop(out);
+                invalidate(out, 0);
+                REQUIRE(out.size() == 1);
+                REQUIRE_FALSE(out[0].valid());
+                clear(out);
+                REQUIRE_THROWS_AS(pop(out), std::out_of_range);
+            }
+        }
+    };
+
+    struct FunctionalDynamicListFailedInitialization
+    {
+        static constexpr auto name = "functional_dynamic_list_failed_initialization";
+
+        static void eval(In<"step", TS<Int>>, Out<TSL<TS<Int>>> out) {
+            REQUIRE_THROWS_AS(push(out, ThrowingIntSource{}), std::runtime_error);
+            REQUIRE(out.empty());
+        }
+    };
 }  // namespace
 
 TEST_CASE("functional TSS mutations enforce strict and tolerant forms") {
@@ -144,4 +183,14 @@ TEST_CASE("tolerant functional mutations do not produce empty ticks") {
 
 TEST_CASE("dictionary insertion stages a converted value before publishing its key") {
     CHECK_OUTPUT(eval_node<FunctionalDictFailedInitialization>(values<Int>(1)), values<Value>(none));
+}
+
+TEST_CASE("functional unbounded TSL mutations provide stack operations") {
+    CHECK_OUTPUT(eval_node<FunctionalDynamicListMutation>(values<Int>(1, 2, 3)),
+                 values<Value>(dynamic_list_delta<TS<Int>>({{0, 1}, {1, 2}}), dynamic_list_delta<TS<Int>>({{0, 4}, {1, 3}}),
+                               dynamic_list_delta<TS<Int>>({}, {0, 1})));
+}
+
+TEST_CASE("list push stages a converted value before growing the output") {
+    CHECK_OUTPUT(eval_node<FunctionalDynamicListFailedInitialization>(values<Int>(1)), values<Value>(none));
 }

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -59,6 +59,9 @@ namespace
     static_assert(requires(const hgraph::Out<hgraph::TSD<hgraph::Str, hgraph::TS<hgraph::Int>>> &out) {
         hgraph::update(out, hgraph::Str{"key"}, hgraph::Int{1});
     });
+    static_assert(requires(const hgraph::Out<hgraph::TSL<hgraph::TS<hgraph::Int>>> &out) {
+        hgraph::push(out, hgraph::Int{1});
+    });
 
     struct ConsumerExtensionScalar
     {


### PR DESCRIPTION
## Summary

- expose constrained push, pop, clear, and indexed invalidate free functions for unbounded TSL outputs
- keep the raw C++ View resize API unchanged
- restrict push to dynamic lists with stageable scalar children
- stage value conversion before growing the live list
- verify stack deltas, strict empty-pop behavior, fixed-list rejection, and failed-conversion no-op behavior
- extend installed-SDK compile coverage and C++ authoring documentation

This clean replacement supersedes #879. It is based only on the accepted documentation and implementation stack rooted at main; #801 is not an ancestor.

## Validation

- full native C++ suite: 1766/1766 passed
- focused combined collection mutation suite: 22 assertions across 6 cases passed
- installed-SDK consumer: 1/1 passed
- stable-ABI wheel built with Python 3.12 and tested under Python 3.14
- Python non-WIP suite: 3432 passed, 10 skipped
- Sphinx HTML build with warnings as errors passed