### PR TITLE
feat(hgl): lower collection output mutations

### DIFF
--- a/include/hgraph/types/time_series/output_mutation.h
+++ b/include/hgraph/types/time_series/output_mutation.h
@@ -36,7 +36,7 @@ namespace hgraph
         inline constexpr bool is_dynamic_list_extent = [] {
             using descriptor = static_schema_detail::size_parameter_descriptor<N>;
             if constexpr (!descriptor::is_concrete()) { return false; }
-            return descriptor::concrete_size() == 0;
+            return descriptor::concrete_size() == unbounded_tsl_size;
         }();
     }  // namespace output_mutation_detail
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1055,6 +1055,13 @@ rollback to the previous size on failure; `pop` and `clear` lower to shrinking
 last-write-wins and cancellation rather than reimplementing delta bookkeeping
 in the compiler.
 
+The current C++ lowering fails closed unless a map value or pushed list element
+is a scalar, a representable `atomic<T>` snapshot, or a `ref<T>` token. A live
+structural child such as `set<i64>` is a TSS, not a complete set value, and must
+eventually be handled through typed child mutation rather than passed to the
+whole-child staging façade. The explicit `atomic<set<i64>>` form is a complete
+set snapshot and is compiled through that façade.
+
 Runtime lowering must obey hgraph's native contracts:
 
 - generated node implementations are empty static structs;

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -649,6 +649,7 @@ namespace hgl::codegen
             std::vector<gir::OperatorId> operator_declarations_{};
             std::vector<gir::CallableId> callable_declarations_{};
             bool                         uses_analytics_{false};
+            bool                         uses_output_mutations_{false};
             /// Locals declared in the current function, for unique C++ names.
             std::unordered_map<std::string, int>                local_counts_{};
             std::unordered_set<std::string>                     local_names_{};
@@ -2800,6 +2801,39 @@ namespace hgl::codegen
                 result.range = range;
                 return result;
             }
+            if (name == "insert" || name == "update" || name == "upsert" || name == "remove" || name == "discard" ||
+                name == "invalidate" || name == "clear" || name == "push" || name == "pop") {
+                if (!frame.runtime) { fail(Category::Phase, range, "output mutations are only available in runtime hooks"); }
+                if (call.arguments.empty()) { backend(range, "output mutation has no output argument"); }
+                const Value output = eval_planned_expr(call.arguments.front().value, frame);
+                if (!output.is_runtime() || output.selector.empty() || output.selector != "hgl_output") {
+                    fail(Category::Type, call.arguments.front().range,
+                         "'" + name + "' requires the injected output as its first argument");
+                }
+
+                std::vector<std::string> arguments{output.selector};
+                for (std::size_t index = 1U; index < call.arguments.size(); ++index) {
+                    const Value value = eval_planned_expr(call.arguments[index].value, frame);
+                    HType       expected;
+                    if (output.type.kind == HType::Kind::Map) {
+                        expected = output.type.children[index == 1U ? 0U : 1U];
+                    } else if (output.type.kind == HType::Kind::Set || (output.type.kind == HType::Kind::List && name == "push")) {
+                        expected = output.type.children.front();
+                    } else if (output.type.kind == HType::Kind::List && name == "invalidate") {
+                        expected = scalar_type(hir::ScalarType::I64);
+                    } else {
+                        backend(range, "typed HIR admitted arguments for an incompatible output mutation");
+                    }
+                    arguments.push_back(as_runtime(value, expected, value.range, "output mutation argument"));
+                }
+
+                uses_output_mutations_ = true;
+                Value result;
+                result.kind  = Value::Kind::Void;
+                result.code  = "hgraph::" + name + "(" + join(arguments, ", ") + ")";
+                result.range = range;
+                return result;
+            }
             if (name == "valid" || name == "modified" || name == "all_valid") {
                 if (call.arguments.empty()) {
                     if (name == "all_valid") { fail(Category::Type, range, "'all_valid' takes at least one argument"); }
@@ -4112,9 +4146,9 @@ namespace hgl::codegen
             if (has_planned_result(planned.result, planned.range)) {
                 const HType result = planned_type(planned.result, planned.range);
                 if (result.kind != HType::Kind::Scalar && result.kind != HType::Kind::Struct && result.kind != HType::Kind::Map &&
-                    result.kind != HType::Kind::Reference) {
+                    result.kind != HType::Kind::Set && result.kind != HType::Kind::List && result.kind != HType::Kind::Reference) {
                     backend(graph_type(planned.result, planned.range).range,
-                            "the runtime-node slice supports scalar, struct, map, and ref outputs");
+                            "the runtime-node slice supports scalar, struct, collection, and ref outputs");
                 }
             }
 
@@ -4330,9 +4364,17 @@ namespace hgl::codegen
             }
             if (include_output && info.out_binding.valid()) {
                 const HType result = planned_type(planned.result, planned.range);
-                Value       value  = make_runtime("hgl_output.value().checked_as<" +
-                                                      value_type(result, graph_type(planned.result, planned.range).range) + ">()",
-                                                  result, planned_binding(info.out_binding, planned.range).range, "hgl_output");
+                Value       value;
+                if (result.kind == HType::Kind::List) {
+                    value.kind     = Value::Kind::Runtime;
+                    value.type     = result;
+                    value.range    = planned_binding(info.out_binding, planned.range).range;
+                    value.selector = "hgl_output";
+                } else {
+                    value = make_runtime("hgl_output.value().checked_as<" +
+                                             value_type(result, graph_type(planned.result, planned.range).range) + ">()",
+                                         result, planned_binding(info.out_binding, planned.range).range, "hgl_output");
+                }
                 if (!frame.planned_bindings.emplace(info.out_binding.value, std::move(value)).second) {
                     backend(planned.range, "hgraph IR callable repeats the output capability binding");
                 }
@@ -4876,6 +4918,12 @@ namespace hgl::codegen
             for (const gir::CallableId id : exports) {
                 if (callable(id).kind == gir::CallableKind::Composition) { emit_function(id, public_functions, Form::OutOfLine); }
             }
+            Writer public_header_functions;
+            public_header_functions.indent();
+            for (const gir::CallableId id : exports) {
+                emit_function(id, public_header_functions,
+                              callable(id).kind == gir::CallableKind::RuntimeNode ? Form::InlineStruct : Form::Declaration);
+            }
 
             Writer body;
             body.line("namespace " + namespace_);
@@ -4999,6 +5047,7 @@ namespace hgl::codegen
             emit_include("<hgraph/types/operator_dispatch.h>");
             emit_include("<hgraph/types/static_node.h>");
             emit_include("<hgraph/types/static_schema.h>");
+            if (uses_output_mutations_) { emit_include("<hgraph/types/time_series/output_mutation.h>"); }
             header.line();
             emit_include("<chrono>");
             emit_include("<cstddef>");
@@ -5035,11 +5084,8 @@ namespace hgl::codegen
                 header.close("  // namespace operators");
                 header.line();
             }
-            for (const gir::CallableId id : exports) {
-                emit_function(id, header,
-                              callable(id).kind == gir::CallableKind::RuntimeNode ? Form::InlineStruct : Form::Declaration);
-                result.exports.push_back(std::string{callable_name(id)});
-            }
+            header.append(public_header_functions.str());
+            for (const gir::CallableId id : exports) { result.exports.push_back(std::string{callable_name(id)}); }
             header.line("/// Register the module's operators and implementations with the hgraph");
             header.line("/// registry and return the exact removable provider generation.");
             header.line("hgraph::OperatorProviderHandle register_operators();");

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -4163,11 +4163,11 @@ namespace hgl::codegen
                     parameter.is_const ? gir::BindingKind::ConstParameter : gir::BindingKind::SignalParameter;
                 if (binding.kind != expected) { backend(binding.range, "hgraph IR runtime parameter has the wrong binding kind"); }
                 const HType type = planned_type(parameter.type, planned.range);
-                if (type.kind != HType::Kind::Scalar && type.kind != HType::Kind::Map && type.kind != HType::Kind::Set &&
-                    type.kind != HType::Kind::List && type.kind != HType::Kind::Rolling && type.kind != HType::Kind::Reference &&
-                    type.kind != HType::Kind::Signal) {
+                if (type.kind != HType::Kind::Scalar && type.kind != HType::Kind::Atomic && type.kind != HType::Kind::Map &&
+                    type.kind != HType::Kind::Set && type.kind != HType::Kind::List && type.kind != HType::Kind::Rolling &&
+                    type.kind != HType::Kind::Reference && type.kind != HType::Kind::Signal) {
                     backend(graph_type(parameter.type, planned.range).range,
-                            "the runtime-node slice supports scalar, collection, ref, and signal parameters");
+                            "the runtime-node slice supports scalar, atomic, collection, ref, and signal parameters");
                 }
                 if (!parameter.is_const) { ++temporal_count; }
             }

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -2515,6 +2515,93 @@ namespace hgl::ir
                 return nullptr;
             }
 
+            [[nodiscard]] bool injected_output(ExprId id) const noexcept {
+                if (!id.valid()) { return false; }
+                const auto *reference = std::get_if<SymbolRef>(&module_.expr(id).node);
+                if (reference == nullptr || !reference->symbol.valid()) { return false; }
+                const Symbol &symbol = module_.symbol(reference->symbol);
+                return symbol.kind == SymbolKind::InjectedCapability && symbol.name == "out";
+            }
+
+            void check_output_mutation_call(Expr &expression, const Call &call, std::string_view name,
+                                            const std::vector<ExprId> &args) {
+                for (const Argument &argument : call.arguments) {
+                    if (!argument.name.empty()) { type_error(argument.range, "output mutation arguments are positional"); }
+                }
+                if (args.empty()) {
+                    type_error(expression.range, "'" + std::string{name} + "' requires an injected output argument");
+                    expression.type = void_type_;
+                    return;
+                }
+
+                Expr &output = check_expr(args.front());
+                for (std::size_t index = 1; index < args.size(); ++index) { (void)check_expr(args[index]); }
+                if (!injected_output(args.front())) {
+                    type_error(output.range, "'" + std::string{name} + "' requires 'out' as its first argument");
+                }
+                const TypeId collection    = unwrap_atomic(output.type);
+                const Type  *shape         = collection.valid() ? &type(collection) : nullptr;
+                const auto   require_arity = [&](std::size_t arity) {
+                    if (args.size() != arity) {
+                        type_error(expression.range, "'" + std::string{name} + "' takes " + std::to_string(arity) + " arguments");
+                    }
+                    return args.size() == arity;
+                };
+                const auto require_argument = [&](std::size_t index, TypeId expected, std::string_view role) {
+                    if (index < args.size() && expected.valid()) {
+                        require_assignable(expected, module_.expr(args[index]), std::string{role});
+                    }
+                };
+                const bool set  = shape != nullptr && shape->kind == TypeKind::Set && shape->children.size() == 1U;
+                const bool map  = shape != nullptr && shape->kind == TypeKind::Map && shape->children.size() == 2U;
+                const bool list = shape != nullptr && shape->kind == TypeKind::List && shape->children.size() == 1U;
+
+                if (name == "insert" || name == "upsert") {
+                    if (set) {
+                        if (require_arity(2U)) { require_argument(1U, shape->children[0], "set member"); }
+                    } else if (map) {
+                        if (require_arity(3U)) {
+                            require_argument(1U, shape->children[0], "map key");
+                            require_argument(2U, shape->children[1], "map value");
+                        }
+                    } else {
+                        type_error(output.range, "'" + std::string{name} + "' requires a set or map output");
+                    }
+                } else if (name == "update") {
+                    if (!map) {
+                        type_error(output.range, "'update' requires a map output");
+                    } else if (require_arity(3U)) {
+                        require_argument(1U, shape->children[0], "map key");
+                        require_argument(2U, shape->children[1], "map value");
+                    }
+                } else if (name == "remove" || name == "discard") {
+                    if (!set && !map) {
+                        type_error(output.range, "'" + std::string{name} + "' requires a set or map output");
+                    } else if (require_arity(2U)) {
+                        require_argument(1U, shape->children[0], set ? "set member" : "map key");
+                    }
+                } else if (name == "invalidate") {
+                    if (!map && !list) {
+                        type_error(output.range, "'invalidate' requires a map or list output");
+                    } else if (require_arity(2U)) {
+                        require_argument(1U, map ? shape->children[0] : scalar(ScalarType::I64), map ? "map key" : "list index");
+                    }
+                } else if (name == "clear") {
+                    if (!set && !map && !(list && shape->unbounded)) {
+                        type_error(output.range, "'clear' requires a set, map, or unbounded list output");
+                    }
+                    (void)require_arity(1U);
+                } else if (name == "push" || name == "pop") {
+                    if (!list || !shape->unbounded) {
+                        type_error(output.range, "'" + std::string{name} + "' requires an unbounded list output");
+                    }
+                    const std::size_t arity = name == "push" ? 2U : 1U;
+                    if (require_arity(arity) && name == "push") { require_argument(1U, shape->children[0], "list value"); }
+                }
+
+                expression.type = void_type_;
+            }
+
             void check_intrinsic_call(Expr &expression, const Call &call, SymbolId target, TypeId expected) {
                 const std::string  &name = module_.symbol(target).external_name;
                 std::vector<ExprId> args;
@@ -2599,10 +2686,17 @@ namespace hgl::ir
                     expression.effects = Effect::IterateCollection;
                 } else if (name == "added" || name == "removed") {
                     expression.type = make_type(TypeKind::Callable);
+                } else if (name == "insert" || name == "update" || name == "upsert" || name == "remove" || name == "discard" ||
+                           name == "invalidate" || name == "clear" || name == "push" || name == "pop") {
+                    check_output_mutation_call(expression, call, name, args);
                 } else {
                     type_error(expression.range, "unsupported intrinsic '" + name + "'");
                 }
                 finish_call_semantics(expression, args);
+                if (name == "insert" || name == "update" || name == "upsert" || name == "remove" || name == "discard" ||
+                    name == "invalidate" || name == "clear" || name == "push" || name == "pop") {
+                    expression.effects |= Effect::UseCapability | Effect::WriteOutput;
+                }
                 if (expression.type.valid() && type(expression.type).kind == TypeKind::Iterator) {
                     expression.phase      = runtime_owner(expression.owner) ? Phase::Runtime : Phase::Wiring;
                     expression.value_kind = ValueKind::Iterator;

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -2523,6 +2523,29 @@ namespace hgl::ir
                 return symbol.kind == SymbolKind::InjectedCapability && symbol.name == "out";
             }
 
+            [[nodiscard]] bool representable_atomic_value(TypeId id) const noexcept {
+                id = canonical(id);
+                if (!id.valid()) { return false; }
+                const Type &value = type(id);
+                if (value.kind == TypeKind::Scalar) { return true; }
+                if (value.kind == TypeKind::Symbol && value.symbol.valid()) {
+                    return module_.symbol(value.symbol).kind == SymbolKind::Struct;
+                }
+                if (value.kind == TypeKind::Tuple || value.kind == TypeKind::Set || value.kind == TypeKind::Map) {
+                    return std::ranges::all_of(value.children, [&](TypeId child) { return representable_atomic_value(child); });
+                }
+                return false;
+            }
+
+            [[nodiscard]] bool stageable_output_value(TypeId id) const noexcept {
+                id = canonical(id);
+                if (!id.valid()) { return false; }
+                const Type &value = type(id);
+                if (value.kind == TypeKind::Scalar || value.kind == TypeKind::Reference) { return true; }
+                return value.kind == TypeKind::Atomic && value.children.size() == 1U &&
+                       representable_atomic_value(value.children.front());
+            }
+
             void check_output_mutation_call(Expr &expression, const Call &call, std::string_view name,
                                             const std::vector<ExprId> &args) {
                 for (const Argument &argument : call.arguments) {
@@ -2552,6 +2575,13 @@ namespace hgl::ir
                         require_assignable(expected, module_.expr(args[index]), std::string{role});
                     }
                 };
+                const auto require_stageable_value = [&](std::size_t index, TypeId expected, std::string_view role) {
+                    if (index < args.size() && expected.valid() && !stageable_output_value(expected)) {
+                        type_error(module_.expr(args[index]).range,
+                                   std::string{"'"} + std::string{name} + "' cannot stage a structural " + std::string{role} +
+                                       "; use a scalar, representable atomic<T>, or ref<T> child value");
+                    }
+                };
                 const bool set  = shape != nullptr && shape->kind == TypeKind::Set && shape->children.size() == 1U;
                 const bool map  = shape != nullptr && shape->kind == TypeKind::Map && shape->children.size() == 2U;
                 const bool list = shape != nullptr && shape->kind == TypeKind::List && shape->children.size() == 1U;
@@ -2563,6 +2593,7 @@ namespace hgl::ir
                         if (require_arity(3U)) {
                             require_argument(1U, shape->children[0], "map key");
                             require_argument(2U, shape->children[1], "map value");
+                            require_stageable_value(2U, shape->children[1], "map value");
                         }
                     } else {
                         type_error(output.range, "'" + std::string{name} + "' requires a set or map output");
@@ -2573,6 +2604,7 @@ namespace hgl::ir
                     } else if (require_arity(3U)) {
                         require_argument(1U, shape->children[0], "map key");
                         require_argument(2U, shape->children[1], "map value");
+                        require_stageable_value(2U, shape->children[1], "map value");
                     }
                 } else if (name == "remove" || name == "discard") {
                     if (!set && !map) {
@@ -2596,7 +2628,10 @@ namespace hgl::ir
                         type_error(output.range, "'" + std::string{name} + "' requires an unbounded list output");
                     }
                     const std::size_t arity = name == "push" ? 2U : 1U;
-                    if (require_arity(arity) && name == "push") { require_argument(1U, shape->children[0], "list value"); }
+                    if (require_arity(arity) && name == "push") {
+                        require_argument(1U, shape->children[0], "list value");
+                        require_stageable_value(1U, shape->children[0], "list value");
+                    }
                 }
 
                 expression.type = void_type_;

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -26,8 +26,11 @@ namespace hgl::semantics
         constexpr std::string_view kernel_std       = "hgraph.std";
         constexpr std::string_view kernel_analytics = "hgraph.analytics";
 
-        constexpr std::string_view intrinsics[] = {"valid", "modified", "all_valid", "last_modified", "delta", "key_set",
-                                                   "keys",  "values",   "elements",  "items",         "added", "removed"};
+        constexpr std::string_view intrinsics[] = {
+            "valid",  "modified", "all_valid", "last_modified", "delta",   "key_set", "keys",
+            "values", "elements", "items",     "added",         "removed", "insert",  "update",
+            "upsert", "remove",   "discard",   "invalidate",    "clear",   "push",    "pop",
+        };
 
         [[nodiscard]] std::string join_path(const std::vector<ast::Name> &path) {
             std::string result;

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -2038,6 +2038,48 @@ export fn through_private(a: f64) -> f64 => private_total(a)
     CHECK(contains(emitted->source, "hgraph::wire<private_total>(w, a)"));
 }
 
+TEST_CASE("emit-cpp lowers functional collection output mutations", "[codegen][runtime][collection]") {
+    Unit       unit{R"(
+module t
+
+export fn map_mutations(key: str, value: i64) -> map<str, i64> {
+    inject out
+    when {
+        insert(out, key, value)
+        update(out, key, value)
+        upsert(out, key, value)
+        invalidate(out, key)
+        discard(out, key)
+        clear(out)
+    }
+}
+
+export fn list_mutations(value: i64) -> list<i64, unbounded> {
+    inject out
+    when {
+        push(out, value)
+        invalidate(out, 0)
+        pop(out)
+        clear(out)
+    }
+}
+)"};
+    const auto emitted = unit.emit();
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE(emitted);
+
+    CHECK(contains(emitted->header, "#include <hgraph/types/time_series/output_mutation.h>"));
+    CHECK(contains(emitted->header, "hgraph::insert(hgl_output, key.value(), value.value());"));
+    CHECK(contains(emitted->header, "hgraph::update(hgl_output, key.value(), value.value());"));
+    CHECK(contains(emitted->header, "hgraph::upsert(hgl_output, key.value(), value.value());"));
+    CHECK(contains(emitted->header, "hgraph::invalidate(hgl_output, key.value());"));
+    CHECK(contains(emitted->header, "hgraph::discard(hgl_output, key.value());"));
+    CHECK(contains(emitted->header, "hgraph::push(hgl_output, value.value());"));
+    CHECK(contains(emitted->header, "hgraph::invalidate(hgl_output, hgraph::Int{0});"));
+    CHECK(contains(emitted->header, "hgraph::pop(hgl_output);"));
+    CHECK(occurrences(emitted->header, "hgraph::clear(hgl_output);") == 2U);
+}
+
 TEST_CASE("emit-cpp expands default runtime activation and validity predicates", "[codegen][runtime]") {
     Unit       unit{R"(
 module t

--- a/language/tests/codegen/generated_runtime_tests.cpp
+++ b/language/tests/codegen/generated_runtime_tests.cpp
@@ -113,6 +113,32 @@ TEST_CASE("generated inject out exposes the previous value and writes non-termin
                  values<Float>(1.0, 3.0, 6.0));
 }
 
+TEST_CASE("generated HGL mutates set outputs through the functional facade", "[codegen][runtime][collection]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::operators::mutate_set>(values<Int>(1, 2)),
+                 values<Value>(set_delta<Int>({1, 2}, {}), set_delta<Int>({3}, {1})));
+}
+
+TEST_CASE("generated HGL mutates map outputs through the functional facade", "[codegen][runtime][collection]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::operators::mutate_map>(values<Int>(1, 2, 3)),
+                 values<Value>(dict_delta<Str, TS<Int>>({{"a", 1}, {"b", 2}}),
+                               dict_delta<Str, TS<Int>>({{"b", 4}, {"c", 5}}, {"a"}),
+                               dict_delta<Str, TS<Int>>({}, {"b", "c"})));
+}
+
+TEST_CASE("generated HGL mutates unbounded list outputs through the functional facade",
+          "[codegen][runtime][collection]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::operators::mutate_list>(values<Int>(1, 2, 3)),
+                 values<Value>(dynamic_list_delta<TS<Int>>({{0, 1}, {1, 2}}),
+                               dynamic_list_delta<TS<Int>>({{1, 3}}),
+                               dynamic_list_delta<TS<Int>>({}, {0, 1})));
+}
+
 TEST_CASE("generated runtime lifecycle hooks run around evaluation", "[codegen][runtime]")
 {
     session();

--- a/language/tests/codegen/runtime.hgl
+++ b/language/tests/codegen/runtime.hgl
@@ -88,6 +88,60 @@ export fn running_total(value: f64) -> f64 {
     }
 }
 
+export fn mutate_set(step: i64) -> set<i64> {
+    inject out
+
+    when {
+        if step == 1 {
+            insert(out, 1)
+            upsert(out, 1)
+            upsert(out, 2)
+            discard(out, 99)
+        } else {
+            remove(out, 1)
+            upsert(out, 3)
+        }
+    }
+}
+
+export fn mutate_map(step: i64) -> map<str, i64> {
+    inject out
+
+    when {
+        if step == 1 {
+            insert(out, "a", 1)
+            upsert(out, "b", 2)
+            discard(out, "missing")
+        } else if step == 2 {
+            update(out, "a", 3)
+            upsert(out, "b", 4)
+            upsert(out, "c", 5)
+            remove(out, "a")
+        } else {
+            invalidate(out, "b")
+            clear(out)
+        }
+    }
+}
+
+export fn mutate_list(step: i64) -> list<i64, unbounded> {
+    inject out
+
+    when {
+        if step == 1 {
+            push(out, 1)
+            push(out, 2)
+        } else if step == 2 {
+            pop(out)
+            push(out, 3)
+        } else {
+            pop(out)
+            invalidate(out, 0)
+            clear(out)
+        }
+    }
+}
+
 export fn lifecycle_value(value: f64) -> f64 {
     state ready: bool = false
 

--- a/language/tests/codegen/runtime.hgl
+++ b/language/tests/codegen/runtime.hgl
@@ -142,6 +142,15 @@ export fn mutate_list(step: i64) -> list<i64, unbounded> {
     }
 }
 
+# An explicit atomic boundary makes a complete collection snapshot stageable.
+export fn mutate_atomic_map(value: atomic<set<i64>>) -> map<str, atomic<set<i64>>> {
+    inject out
+
+    when {
+        upsert(out, "value", value)
+    }
+}
+
 export fn lifecycle_value(value: f64) -> f64 {
     state ready: bool = false
 

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -2062,6 +2062,59 @@ TEST_CASE("typed HIR admits only approved injectables", "[ir][typed][injectable]
               .find("injectable: 'out' requires a function output") != std::string::npos);
 }
 
+TEST_CASE("typed HIR constrains functional output mutations", "[ir][typed][collection][mutation]") {
+    CHECK(completes("module checks.output_mutations\n"
+                    "fn set_ops(value: i64) -> set<i64> {\n"
+                    "    inject out\n"
+                    "    when {\n"
+                    "        insert(out, value)\n"
+                    "        upsert(out, value)\n"
+                    "        remove(out, value)\n"
+                    "        discard(out, value)\n"
+                    "        clear(out)\n"
+                    "    }\n"
+                    "}\n"
+                    "fn map_ops(key: str, value: i64) -> map<str, i64> {\n"
+                    "    inject out\n"
+                    "    when {\n"
+                    "        insert(out, key, value)\n"
+                    "        update(out, key, value)\n"
+                    "        upsert(out, key, value)\n"
+                    "        remove(out, key)\n"
+                    "        discard(out, key)\n"
+                    "        invalidate(out, key)\n"
+                    "        clear(out)\n"
+                    "    }\n"
+                    "}\n"
+                    "fn list_ops(value: i64) -> list<i64, unbounded> {\n"
+                    "    inject out\n"
+                    "    when {\n"
+                    "        push(out, value)\n"
+                    "        invalidate(out, 0)\n"
+                    "        pop(out)\n"
+                    "        clear(out)\n"
+                    "    }\n"
+                    "}\n"));
+    CHECK(completion_diagnostics("module checks.mutation_target\n"
+                                 "fn f(value: set<i64>) -> set<i64> {\n"
+                                 "    inject out\n"
+                                 "    when { insert(value, 1) }\n"
+                                 "}\n")
+              .find("'insert' requires 'out' as its first argument") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.fixed_push\n"
+                                 "fn f(value: i64) -> list<i64, 2> {\n"
+                                 "    inject out\n"
+                                 "    when { push(out, value) }\n"
+                                 "}\n")
+              .find("'push' requires an unbounded list output") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.set_update\n"
+                                 "fn f(value: i64) -> set<i64> {\n"
+                                 "    inject out\n"
+                                 "    when { update(out, value, value) }\n"
+                                 "}\n")
+              .find("'update' requires a map output") != std::string::npos);
+}
+
 TEST_CASE("typed HIR enforces runtime body placement", "[ir][typed][function-kind]") {
     CHECK(completion_diagnostics("module checks.late_state\n"
                                  "fn f(value: f64) -> f64 {\n"

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -2113,6 +2113,23 @@ TEST_CASE("typed HIR constrains functional output mutations", "[ir][typed][colle
                                  "    when { update(out, value, value) }\n"
                                  "}\n")
               .find("'update' requires a map output") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.structural_map_value\n"
+                                 "fn f(values: set<i64>) -> map<str, set<i64>> {\n"
+                                 "    inject out\n"
+                                 "    when { upsert(out, \"key\", values) }\n"
+                                 "}\n")
+              .find("'upsert' cannot stage a structural map value") != std::string::npos);
+    CHECK(completion_diagnostics("module checks.structural_list_value\n"
+                                 "fn f(values: set<i64>) -> list<set<i64>, unbounded> {\n"
+                                 "    inject out\n"
+                                 "    when { push(out, values) }\n"
+                                 "}\n")
+              .find("'push' cannot stage a structural list value") != std::string::npos);
+    CHECK(completes("module checks.atomic_collection_value\n"
+                    "fn f(values: atomic<set<i64>>) -> map<str, atomic<set<i64>>> {\n"
+                    "    inject out\n"
+                    "    when { upsert(out, \"key\", values) }\n"
+                    "}\n"));
 }
 
 TEST_CASE("typed HIR enforces runtime body placement", "[ir][typed][function-kind]") {

--- a/language/tests/semantics/resolve_tests.cpp
+++ b/language/tests/semantics/resolve_tests.cpp
@@ -320,6 +320,8 @@ fn f(y: f64, const k: i64 = 2) -> f64 {
     CHECK(resolved.binding_of("valid")->kind == BindingKind::Intrinsic);
     CHECK(resolved.binding_of("valid")->registry_name == "valid");
     CHECK(is_intrinsic("key_set"));
+    CHECK(is_intrinsic("insert"));
+    CHECK(is_intrinsic("push"));
     CHECK_FALSE(is_intrinsic("helper"));
 }
 

--- a/tests/cpp/test_output_mutation.cpp
+++ b/tests/cpp/test_output_mutation.cpp
@@ -27,6 +27,8 @@ namespace
     static_assert(!accepts_dict_update<Out<TSS<Int>>>);
     static_assert(!accepts_dict_update<Out<TSD<Str, TSS<Int>>>>);
     static_assert(accepts_list_push<Out<TSL<TS<Int>>>>);
+    static_assert(accepts_list_push<Out<TSL<TS<Int>, -1>>>);
+    static_assert(!accepts_list_push<Out<TSL<TS<Int>, 0>>>);
     static_assert(!accepts_list_push<Out<TSL<TS<Int>, 2>>>);
     static_assert(!accepts_list_push<Out<TSL<TSS<Int>>>>);
 


### PR DESCRIPTION
## Summary

- register the accepted collection-mutation names as HGL prelude intrinsics
- type-check each effect against the injected output, collection kind, arity, key/value types, and dynamic-list bounds
- reject live structural map/list child values before code generation when the C++ facade cannot stage them
- preserve explicit atomic<T> snapshots and compile a generated atomic collection mutation through the facade
- emit readable calls to the public C++ mutation facade and include it only when generated code uses it
- exercise generated set, map, and unbounded-list nodes against the real runtime

## Stack

This PR is based on #883. The stack root is the documentation PR #881, which is based directly on main. The recovered-proposals PR #801 is not an ancestor and can be discarded independently once its remaining design notes have been dealt with.

## Deliberate boundary

No standard-library operator is promoted in this slice. The proposed collection union still depends on unresolved membership and simultaneous-delta semantics, so graduating it here would invent language behavior rather than implement an accepted contract.

## Validation

- HGL-enabled build and complete CTest suite: 1830/1830 passed
- all HGL language test executables passed independently
- generated atomic<set<i64>> mutation compiled through the C++ facade
- Python 3.14 compatibility suite: 3432 passed, 10 skipped
- installed native-package consumer passed as part of CTest
- Sphinx HTML build passed with warnings as errors