### PR TITLE
Add native operator pack cardinality bounds

### DIFF
--- a/docs/source/developer_guide/operators.rst
+++ b/docs/source/developer_guide/operators.rst
@@ -1098,7 +1098,9 @@ registrations accept one bound after the explicit ``OperatorNodePack`` mode::
 Bounds reject a candidate during normal call matching and do not alter its
 rank. A ``Kwargs<>`` static node that accepts both positional and keyword call
 styles must select an explicit mode before it can declare cardinality; otherwise
-it is ambiguous which pack the bound describes.
+it is ambiguous which pack the bound describes. Both bounds are retained by
+``overload_signatures()`` so language bridges and generated documentation expose
+the same accepted call shape as the resolver.
 
 Graph overloads receive positional packs through ``VarIn``. Static nodes can
 instead receive a homogeneous ``Args<>`` aggregate, or a ``Kwargs<>`` aggregate

--- a/docs/source/developer_guide/operators.rst
+++ b/docs/source/developer_guide/operators.rst
@@ -1084,8 +1084,25 @@ sugar):
   signature wins against the variadic default;
 - candidate labels render the variadic parameter with a ``*`` prefix.
 
-Static-node signatures remain fixed-arity today. Variadic operator overloads
-should therefore be authored as graph overloads that receive ``VarIn``. A
+An overload can constrain the inclusive size of each pack with
+``OperatorPackCardinality``. The default is zero through unbounded. Graph
+registrations accept independent positional and keyword bounds; aggregate-node
+registrations accept one bound after the explicit ``OperatorNodePack`` mode::
+
+   register_graph_overload<op_, graph_impl,
+                           OperatorPackCardinality{2, OperatorPackCardinality::unbounded},
+                           OperatorPackCardinality{1, 4}>();
+   register_overload<op_, node_impl, OperatorNodePack::KeywordOnly,
+                     OperatorPackCardinality{1, 4}>();
+
+Bounds reject a candidate during normal call matching and do not alter its
+rank. A ``Kwargs<>`` static node that accepts both positional and keyword call
+styles must select an explicit mode before it can declare cardinality; otherwise
+it is ambiguous which pack the bound describes.
+
+Graph overloads receive positional packs through ``VarIn``. Static nodes can
+instead receive a homogeneous ``Args<>`` aggregate, or a ``Kwargs<>`` aggregate
+with an explicit positional-only or keyword-only mode. A
 non-empty ``VarIn`` tail can be passed as a normal operator argument where a
 collection input is expected; the dispatcher erases it as a fixed structural
 ``TSL`` with one child per tail element. This is the variadic-tail counterpart of

--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -497,7 +497,11 @@ namespace hgraph
         std::vector<OperatorSignatureParameter> parameters{};
         bool                                    variadic{false};
         std::size_t                             positional_params{0};
+        /** Inclusive size accepted by the positional pack. */
+        OperatorPackCardinality                 positional_pack_cardinality{};
         bool                                    has_kwargs{false};
+        /** Inclusive size accepted by the keyword pack. */
+        OperatorPackCardinality                 keyword_pack_cardinality{};
         std::optional<std::string>              kwargs_pattern{};
         bool                                    has_output{false};
         std::optional<std::string>              output_pattern{};

--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -86,6 +86,23 @@ namespace hgraph
         KeywordOnly,     ///< Heterogeneous ``...{Fields}`` named pack.
     };
 
+    /** Inclusive argument-count bounds for one variadic operator parameter. */
+    struct OperatorPackCardinality
+    {
+        static constexpr std::size_t unbounded = static_cast<std::size_t>(-1);
+
+        std::size_t minimum{0};
+        std::size_t maximum{unbounded};
+
+        [[nodiscard]] constexpr bool valid() const noexcept { return maximum == unbounded || minimum <= maximum; }
+
+        [[nodiscard]] constexpr bool contains(std::size_t count) const noexcept {
+            return count >= minimum && (maximum == unbounded || count <= maximum);
+        }
+
+        friend constexpr bool operator==(OperatorPackCardinality, OperatorPackCardinality) noexcept = default;
+    };
+
     namespace operator_dispatch_detail
     {
         using call_args_detail::is_named_arg;
@@ -361,6 +378,8 @@ namespace hgraph
         bool                       variadic{false};
         /** Every variadic argument participates in the same type-variable bindings. */
         bool                       homogeneous_variadic{false};
+        /** Inclusive bounds for the positional variadic tail. */
+        OperatorPackCardinality positional_pack_cardinality{};
         /**
          * Number of leading params fillable POSITIONALLY. Params beyond this
          * (other than the variadic tail) are **keyword-only** — Python's
@@ -370,6 +389,8 @@ namespace hgraph
         std::size_t                positional_params{static_cast<std::size_t>(-1)};
         /** Unmatched keyword time-series args collect into the candidate (``**kwargs``). */
         bool                       has_kwargs{false};
+        /** Inclusive bounds for unmatched arguments collected by ``**kwargs``. */
+        OperatorPackCardinality keyword_pack_cardinality{};
         /** Declared pack pattern for ``**kwargs`` (issue #224): matched at
             dispatch against the synthesized un-named TSB of the supplied
             keywords, which binds pack-level schema vars (TSB[TS_SCHEMA]) so
@@ -2102,9 +2123,8 @@ namespace hgraph
     }  // namespace operator_dispatch_detail
 
     /** Reflect a C++ static-node implementation ``Impl`` into an operator candidate named ``name``. */
-    template <typename Impl, OperatorNodePack Pack = OperatorNodePack::Infer>
-    [[nodiscard]] OperatorImpl make_operator_impl(std::string name)
-    {
+    template <typename Impl, OperatorNodePack Pack = OperatorNodePack::Infer, OperatorPackCardinality Cardinality = {}>
+    [[nodiscard]] OperatorImpl make_operator_impl(std::string name) {
         using sig = StaticNodeSignature<Impl>;
         static_assert(std::is_empty_v<Impl>, "operator implementations must be stateless static nodes");
 
@@ -2114,6 +2134,7 @@ namespace hgraph
         impl.params = operator_dispatch_detail::build_node_params<Impl>();
 
         using layout = operator_dispatch_detail::node_param_layout<Impl>;
+        static_assert(Cardinality.valid(), "operator pack cardinality has its maximum below its minimum");
         impl.variadic = layout::has_pack;
         impl.homogeneous_variadic =
             layout::pack_kind == graph_wiring_detail::node_collection_pack_kind::tsl;
@@ -2134,6 +2155,7 @@ namespace hgraph
             static_assert(layout::pack_kind == graph_wiring_detail::node_collection_pack_kind::tsb,
                           "PositionalOnly requires a Kwargs<> node input");
             impl.has_kwargs = false;
+            impl.positional_pack_cardinality = Cardinality;
         }
         else if constexpr (Pack == OperatorNodePack::KeywordOnly)
         {
@@ -2141,6 +2163,14 @@ namespace hgraph
                           "KeywordOnly requires a Kwargs<> node input");
             impl.variadic = false;
             impl.params.pop_back();
+            impl.keyword_pack_cardinality = Cardinality;
+        } else if constexpr (layout::pack_kind == graph_wiring_detail::node_collection_pack_kind::tsl) {
+            impl.positional_pack_cardinality = Cardinality;
+        } else if constexpr (layout::pack_kind == graph_wiring_detail::node_collection_pack_kind::tsb) {
+            static_assert(Cardinality == OperatorPackCardinality{},
+                          "a Kwargs<> node accepting both call styles needs an explicit pack mode before cardinality");
+        } else {
+            static_assert(Cardinality == OperatorPackCardinality{}, "operator pack cardinality requires an aggregate pack input");
         }
 
         if constexpr (sig::has_output())
@@ -2175,9 +2205,8 @@ namespace hgraph
     }
 
     /** Reflect a C++ sub-graph implementation ``Impl`` into an operator candidate named ``name``. */
-    template <typename Impl>
-    [[nodiscard]] OperatorImpl make_operator_graph_impl(std::string name)
-    {
+    template <typename Impl, OperatorPackCardinality PositionalCardinality = {}, OperatorPackCardinality KeywordCardinality = {}>
+    [[nodiscard]] OperatorImpl make_operator_graph_impl(std::string name) {
         using sig = StaticGraphSignature<Impl>;
         static_assert(std::is_empty_v<Impl>, "operator graph implementations must be stateless graph structs");
 
@@ -2187,6 +2216,12 @@ namespace hgraph
         impl.params = operator_dispatch_detail::build_graph_params<Impl>();
 
         using layout = operator_dispatch_detail::graph_param_layout<Impl>;
+        static_assert(PositionalCardinality.valid(), "positional pack cardinality has its maximum below its minimum");
+        static_assert(KeywordCardinality.valid(), "keyword pack cardinality has its maximum below its minimum");
+        static_assert(layout::variadic || PositionalCardinality == OperatorPackCardinality{},
+                      "positional pack cardinality requires a VarIn graph parameter");
+        static_assert(layout::kwargs_count != 0 || KeywordCardinality == OperatorPackCardinality{},
+                      "keyword pack cardinality requires a KwargsIn graph parameter");
         impl.has_kwargs        = layout::kwargs_count != 0;
         if constexpr (layout::kwargs_count != 0)
         {
@@ -2200,7 +2235,9 @@ namespace hgraph
                 impl.kwargs_pattern     = to_pattern<pack_schema>();
             }
         }
-        impl.variadic          = layout::variadic;
+        impl.variadic                    = layout::variadic;
+        impl.positional_pack_cardinality = PositionalCardinality;
+        impl.keyword_pack_cardinality    = KeywordCardinality;
         impl.positional_params = layout::prefix_count + (layout::variadic ? 0 : layout::kwonly_count);
 
         using output_type = typename sig::output_type;
@@ -2358,27 +2395,28 @@ namespace hgraph
     }
 
     /** Register the C++ implementation ``Impl`` as an overload of operator ``Op``. */
-    template <typename Op, typename Impl, OperatorNodePack Pack = OperatorNodePack::Infer>
-    void register_overload()
-    {
+    template <typename Op, typename Impl, OperatorNodePack Pack = OperatorNodePack::Infer, OperatorPackCardinality Cardinality = {}>
+    void register_overload() {
         if constexpr (operator_dispatch_detail::lifted_operator_impl<Impl>)
         {
             static_assert(Pack == OperatorNodePack::Infer,
                           "a lifted overload does not have a static-node aggregate pack");
+            static_assert(Cardinality == OperatorPackCardinality{}, "a lifted overload does not have a variadic operator pack");
             OperatorRegistry::instance().register_overload(
                 operator_dispatch_detail::make_lifted_operator_impl<Impl>(std::string{Op::name}));
         }
         else
         {
-            OperatorRegistry::instance().register_overload(make_operator_impl<Impl, Pack>(std::string{Op::name}));
+            OperatorRegistry::instance().register_overload(make_operator_impl<Impl, Pack, Cardinality>(std::string{Op::name}));
         }
     }
 
     /** Register the C++ graph ``Impl`` as an overload of operator ``Op``. */
-    template <typename Op, typename Impl>
-    void register_graph_overload()
-    {
-        OperatorRegistry::instance().register_overload(make_operator_graph_impl<Impl>(std::string{Op::name}));
+    template <typename Op, typename Impl, OperatorPackCardinality PositionalCardinality = {},
+              OperatorPackCardinality KeywordCardinality = {}>
+    void register_graph_overload() {
+        OperatorRegistry::instance().register_overload(
+            make_operator_graph_impl<Impl, PositionalCardinality, KeywordCardinality>(std::string{Op::name}));
     }
 
     /**

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -341,8 +341,16 @@ def _operator_overload_signatures(name):
         return ()
     signatures = []
     for raw in raw_signatures:
-        (parameters, variadic, positional_params, has_kwargs,
-         kwargs_pattern, has_output, output_pattern) = raw
+        if len(raw) == 7:
+            # Development/source-import compatibility with a pre-cardinality
+            # extension while the native module is being rebuilt.
+            (parameters, variadic, positional_params, has_kwargs,
+             kwargs_pattern, has_output, output_pattern) = raw
+            positional_pack_cardinality = keyword_pack_cardinality = (0, None)
+        else:
+            (parameters, variadic, positional_params, positional_pack_cardinality,
+             has_kwargs, keyword_pack_cardinality, kwargs_pattern,
+             has_output, output_pattern) = raw
         signatures.append({
             "parameters": tuple({
                 "name": parameter_name,
@@ -355,7 +363,9 @@ def _operator_overload_signatures(name):
               in parameters),
             "variadic": bool(variadic),
             "positional_params": int(positional_params),
+            "positional_pack_cardinality": tuple(positional_pack_cardinality),
             "has_kwargs": bool(has_kwargs),
+            "keyword_pack_cardinality": tuple(keyword_pack_cardinality),
             "kwargs_pattern": kwargs_pattern,
             "has_output": bool(has_output),
             "output_pattern": output_pattern,
@@ -370,7 +380,9 @@ def _operator_signature_key(signature):
               for parameter in signature["parameters"]),
         signature["variadic"],
         signature["positional_params"],
+        signature["positional_pack_cardinality"],
         signature["has_kwargs"],
+        signature["keyword_pack_cardinality"],
         signature["kwargs_pattern"],
         signature["has_output"],
         signature["output_pattern"],
@@ -390,9 +402,19 @@ def _pattern_category(is_time_series, type_argument):
     return "scalar"
 
 
+def _format_pack_cardinality(cardinality):
+    minimum, maximum = cardinality
+    if minimum == 0 and maximum is None:
+        return ""
+    if minimum == maximum:
+        return f"{{{minimum}}}"
+    return f"{{{minimum}:{'*' if maximum is None else maximum}}}"
+
+
 def _format_operator_signature(name, signature_key):
-    (raw_parameters, variadic, positional_params, has_kwargs,
-     kwargs_pattern, has_output, output_pattern) = signature_key
+    (raw_parameters, variadic, positional_params, positional_pack_cardinality,
+     has_kwargs, keyword_pack_cardinality, kwargs_pattern,
+     has_output, output_pattern) = signature_key
     parameters = list(raw_parameters)
     formatter = PublicTypePatternFormatter()
     # Name the time-series inputs first, then the output, so a type argument
@@ -417,7 +439,10 @@ def _format_operator_signature(name, signature_key):
         parameter_name = parameter_name or "args"
         type_pattern = formatter.format(
             type_pattern, category=_pattern_category(is_time_series, type_argument))
-        rendered.append(f"*{parameter_name}: {type_pattern}")
+        rendered.append(
+            f"*{parameter_name}: {type_pattern}"
+            f"{_format_pack_cardinality(positional_pack_cardinality)}"
+        )
     elif positional_count < len(parameters):
         rendered.append("*")
     for index, (parameter_name, is_time_series, type_pattern, has_default, type_argument) in enumerate(
@@ -429,7 +454,10 @@ def _format_operator_signature(name, signature_key):
     if has_kwargs:
         kwargs_pattern = formatter.format(
             kwargs_pattern or "time-series", category="time_series")
-        rendered.append(f"**kwargs: {kwargs_pattern}")
+        rendered.append(
+            f"**kwargs: {kwargs_pattern}"
+            f"{_format_pack_cardinality(keyword_pack_cardinality)}"
+        )
     output = (
         formatter.format(output_pattern, category="time_series", output=True)
         if has_output else "None"

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -1728,14 +1728,14 @@ namespace hgraph::python_bridge
                 nb::object output_pattern = signature.output_pattern.has_value()
                                                 ? nb::cast(*signature.output_pattern)
                                                 : nb::none();
-                signatures.append(nb::make_tuple(
-                    std::move(parameters),
-                    signature.variadic,
-                    signature.positional_params,
-                    signature.has_kwargs,
-                    std::move(kwargs_pattern),
-                    signature.has_output,
-                    std::move(output_pattern)));
+                const auto cardinality    = [](OperatorPackCardinality value) {
+                    nb::object maximum = value.maximum == OperatorPackCardinality::unbounded ? nb::none() : nb::cast(value.maximum);
+                    return nb::make_tuple(value.minimum, std::move(maximum));
+                };
+                signatures.append(nb::make_tuple(std::move(parameters), signature.variadic, signature.positional_params,
+                                                 cardinality(signature.positional_pack_cardinality), signature.has_kwargs,
+                                                 cardinality(signature.keyword_pack_cardinality), std::move(kwargs_pattern),
+                                                 signature.has_output, std::move(output_pattern)));
             }
             return signatures;
         },

--- a/python/tests/test_api_inventory.py
+++ b/python/tests/test_api_inventory.py
@@ -18,6 +18,8 @@ from tools.api_inventory import (
     DEFAULT_OPERATOR_CATALOGUE,
     DEFAULT_RST,
     DEFAULT_STUB,
+    _format_public_signature,
+    _generated_python_example,
     _parse_doxygen,
     collect_authoring_api,
     collect_inventory,
@@ -26,6 +28,40 @@ from tools.api_inventory import (
 
 _EXTENSION_MODULES = ("hgraph_persistence", "hgraph_web", "hgraph_kafka", "hgraph_analytics")
 _core_inventory_cache = None
+
+
+def test_bounded_pack_metadata_is_rendered_and_generates_valid_examples():
+    overload = {
+        "parameters": ({
+            "name": "values",
+            "kind": "time-series",
+            "type_argument": None,
+            "type_pattern": "TS[int]",
+            "has_default": False,
+        },),
+        "variadic": True,
+        "positional_params": 0,
+        "positional_pack_cardinality": (3, None),
+        "has_kwargs": True,
+        "keyword_pack_cardinality": (1, 2),
+        "kwargs_pattern": "TS[str]",
+        "has_output": True,
+        "output_pattern": "TS[int]",
+    }
+    operator = {
+        "name": "bounded",
+        "overloads": (overload,),
+        "grouped_overrides": (),
+        "explicit_root": False,
+        "python_parameters": (),
+    }
+
+    assert _format_public_signature("bounded", overload) == (
+        "bounded(*values: TS[int]{3:*}, **kwargs: TS[str]{1:2}) -> TS[int]"
+    )
+    assert _generated_python_example(operator) == (
+        "result = hg.bounded(value_1, value_2, value_3, field_1=field_1)"
+    )
 
 
 def collect_core_inventory():

--- a/python/tests/test_native_docstrings.py
+++ b/python/tests/test_native_docstrings.py
@@ -125,12 +125,18 @@ def test_native_documentation_is_available_at_runtime_and_in_the_stub():
 
         overloads = _hgraph.operator_overload_signatures("add_")
         assert len(overloads) > 1
+        assert all(
+            positional_cardinality == (0, None)
+            and keyword_cardinality == (0, None)
+            for (_, _, _, positional_cardinality, _, keyword_cardinality, _, _, _)
+            in overloads
+        )
         assert any(
             [(name, pattern, has_default)
              for name, _, pattern, has_default, _ in parameters]
             == [("lhs", "TS[int]", False), ("rhs", "TS[int]", False)]
             and has_output and output_pattern == "TS[int]"
-            for (parameters, _, _, _, _, has_output, output_pattern) in overloads
+            for (parameters, _, _, _, _, _, _, has_output, output_pattern) in overloads
         )
 
         # The partitioned (partition_names/removed_names) replay overload

--- a/python/tests/test_wiring_introspection_cache.py
+++ b/python/tests/test_wiring_introspection_cache.py
@@ -11,6 +11,31 @@ import hgraph._wiring._resolution as wiring_resolution
 import hgraph._types as hgraph_types
 
 
+def test_operator_overload_cardinality_is_preserved_and_rendered(monkeypatch):
+    raw = [(
+        [("values", True, "TS[int]", False, None)],
+        True,
+        0,
+        (2, None),
+        True,
+        (1, 4),
+        "TS[str]",
+        True,
+        "TS[int]",
+    )]
+    monkeypatch.setattr(
+        wiring_core._hgraph, "operator_overload_signatures", lambda _: raw
+    )
+
+    signatures = wiring_core._operator_overload_signatures("bounded")
+    assert signatures[0]["positional_pack_cardinality"] == (2, None)
+    assert signatures[0]["keyword_pack_cardinality"] == (1, 4)
+    assert (
+        "bounded(*values: TS[int]{2:*}, **kwargs: TS[str]{1:4}) -> TS[int]"
+        in wiring_core._operator_documentation("bounded", signatures)
+    )
+
+
 def test_fast_partial_binding_matches_inspect_for_ordinary_signatures():
     def fn(first=1, second=2, *, option=3):
         pass

--- a/src/hgraph/types/operator_dispatch.cpp
+++ b/src/hgraph/types/operator_dispatch.cpp
@@ -1621,9 +1621,11 @@ namespace hgraph
         for (const OperatorImpl &impl : found->second)
         {
             OperatorOverloadSignature signature;
-            signature.variadic = impl.variadic;
-            signature.has_kwargs = impl.has_kwargs;
-            signature.has_output = impl.has_output;
+            signature.variadic                    = impl.variadic;
+            signature.positional_pack_cardinality = impl.positional_pack_cardinality;
+            signature.has_kwargs                  = impl.has_kwargs;
+            signature.keyword_pack_cardinality    = impl.keyword_pack_cardinality;
+            signature.has_output                  = impl.has_output;
             signature.parameters.reserve(impl.params.size());
             for (const ParamPattern &parameter : impl.params)
             {

--- a/src/hgraph/types/operator_dispatch.cpp
+++ b/src/hgraph/types/operator_dispatch.cpp
@@ -591,6 +591,25 @@ namespace hgraph
                 }
                 return false;
             }
+            const auto cardinality_matches = [&](std::string_view kind, const OperatorPackCardinality &cardinality,
+                                                 std::size_t count) {
+                if (cardinality.contains(count)) { return true; }
+                if (why != nullptr) {
+                    if (cardinality.maximum == OperatorPackCardinality::unbounded) {
+                        *why = fmt::format("{} pack expects at least {} argument(s), got {}", kind, cardinality.minimum, count);
+                    } else if (cardinality.minimum == cardinality.maximum) {
+                        *why = fmt::format("{} pack expects exactly {} argument(s), got {}", kind, cardinality.minimum, count);
+                    } else {
+                        *why = fmt::format("{} pack expects {} to {} argument(s), got {}", kind, cardinality.minimum,
+                                           cardinality.maximum, count);
+                    }
+                }
+                return false;
+            };
+            if (impl.variadic && !cardinality_matches("positional", impl.positional_pack_cardinality, args.size() - fixed_params)) {
+                return false;
+            }
+            if (impl.has_kwargs && !cardinality_matches("keyword", impl.keyword_pack_cardinality, kwargs.size())) { return false; }
             if (impl.homogeneous_variadic) { map.bind_size("args_len", args.size() - fixed_params); }
             if (impl.argument_normalizer)
             {
@@ -1117,6 +1136,15 @@ namespace hgraph
 
     void OperatorRegistry::register_overload(OperatorImpl impl)
     {
+        if (!impl.positional_pack_cardinality.valid() || !impl.keyword_pack_cardinality.valid()) {
+            throw std::invalid_argument("operator pack cardinality has its maximum below its minimum");
+        }
+        if (!impl.variadic && impl.positional_pack_cardinality != OperatorPackCardinality{}) {
+            throw std::invalid_argument("positional pack cardinality requires a variadic operator overload");
+        }
+        if (!impl.has_kwargs && impl.keyword_pack_cardinality != OperatorPackCardinality{}) {
+            throw std::invalid_argument("keyword pack cardinality requires a keyword-pack operator overload");
+        }
         impl.provider = active_provider_;
         const std::string name = impl.name;
         auto &overloads = overloads_[name];

--- a/tests/cpp/test_operators.cpp
+++ b/tests/cpp/test_operators.cpp
@@ -607,6 +607,27 @@ TEST_CASE("operators: Kwargs node packs can preserve positional-only and keyword
     REQUIRE_THROWS_AS(eval_node<packed_keyword_count_>(values<Int>(1)), OperatorResolutionError);
 }
 
+TEST_CASE("operators: aggregate node packs enforce inclusive cardinality bounds") {
+    register_overload<packed_sum_, packed_sum_impl, OperatorNodePack::Infer, OperatorPackCardinality{2, 3}>();
+    register_overload<packed_positional_count_, packed_count_impl, OperatorNodePack::PositionalOnly,
+                      OperatorPackCardinality{2, 3}>();
+    register_overload<packed_keyword_count_, packed_count_impl, OperatorNodePack::KeywordOnly, OperatorPackCardinality{1, 2}>();
+
+    CHECK_OUTPUT(eval_node<packed_sum_>(values<Int>(1), values<Int>(2)), values<Int>(3));
+    REQUIRE_THROWS_AS(eval_node<packed_sum_>(values<Int>(1)), OperatorResolutionError);
+
+    CHECK_OUTPUT(eval_node<packed_positional_count_>(values<Int>(1), values<Str>(Str{"x"})), values<Int>(2));
+    REQUIRE_THROWS_AS(eval_node<packed_positional_count_>(values<Int>(1)), OperatorResolutionError);
+    REQUIRE_THROWS_AS(eval_node<packed_positional_count_>(values<Int>(1), values<Int>(2), values<Int>(3), values<Int>(4)),
+                      OperatorResolutionError);
+
+    CHECK_OUTPUT(eval_node<packed_keyword_count_>(arg<"value">(values<Int>(1))), values<Int>(1));
+    REQUIRE_THROWS_AS((eval_node<packed_keyword_count_, TS<Int>>()), OperatorResolutionError);
+    REQUIRE_THROWS_AS(
+        eval_node<packed_keyword_count_>(arg<"a">(values<Int>(1)), arg<"b">(values<Int>(2)), arg<"c">(values<Int>(3))),
+        OperatorResolutionError);
+}
+
 TEST_CASE("operators: typed Kwargs node packs preserve names and field schemas") {
     register_overload<packed_typed_count_, packed_typed_int_str_impl, OperatorNodePack::KeywordOnly>();
     register_overload<packed_typed_count_, packed_typed_str_int_impl, OperatorNodePack::KeywordOnly>();
@@ -1485,6 +1506,17 @@ TEST_CASE("operators: exact fixed graph overload ranks ahead of a variadic fallb
     auto [impl, map, call_args, call_kwargs] = OperatorRegistry::instance().resolve("variadic_rank", std::span<const WiringArg>{args});
     REQUIRE(impl != nullptr);
     CHECK(impl->label.find("variadic_rank_fixed") != std::string::npos);
+}
+
+TEST_CASE("operators: graph variadic packs enforce cardinality before matching") {
+    register_graph_overload<variadic_rank_, variadic_rank_fallback, OperatorPackCardinality{2, 2}>();
+
+    std::array<WiringArg, 3> accepted{ts_arg(ts_type<TS<Int>>()), ts_arg(ts_type<TS<Int>>()), ts_arg(ts_type<TS<Int>>())};
+    CHECK(OperatorRegistry::instance().resolve("variadic_rank", std::span<const WiringArg>{accepted}).impl != nullptr);
+
+    std::array<WiringArg, 2> rejected{ts_arg(ts_type<TS<Int>>()), ts_arg(ts_type<TS<Int>>())};
+    REQUIRE_THROWS_AS(OperatorRegistry::instance().resolve("variadic_rank", std::span<const WiringArg>{rejected}),
+                      OperatorResolutionError);
 }
 
 TEST_CASE("operators: packed VarIn tails prefer variadic overloads over converted TSL overloads")

--- a/tests/cpp/test_operators.cpp
+++ b/tests/cpp/test_operators.cpp
@@ -626,6 +626,13 @@ TEST_CASE("operators: aggregate node packs enforce inclusive cardinality bounds"
     REQUIRE_THROWS_AS(
         eval_node<packed_keyword_count_>(arg<"a">(values<Int>(1)), arg<"b">(values<Int>(2)), arg<"c">(values<Int>(3))),
         OperatorResolutionError);
+
+    const auto positional = OperatorRegistry::instance().overload_signatures("packed_positional_count");
+    REQUIRE(positional.size() == 1);
+    CHECK((positional.front().positional_pack_cardinality == OperatorPackCardinality{2, 3}));
+    const auto keyword = OperatorRegistry::instance().overload_signatures("packed_keyword_count");
+    REQUIRE(keyword.size() == 1);
+    CHECK((keyword.front().keyword_pack_cardinality == OperatorPackCardinality{1, 2}));
 }
 
 TEST_CASE("operators: typed Kwargs node packs preserve names and field schemas") {

--- a/tools/api_inventory.py
+++ b/tools/api_inventory.py
@@ -378,8 +378,15 @@ def collect_inventory() -> dict[str, Any]:
         semantic_documentation = operator_documentation.get(name)
         overloads = []
         for raw_overload in _hgraph.operator_overload_signatures(name):
-            (raw_parameters, variadic, positional_params, has_kwargs,
-             kwargs_pattern, has_output, output_pattern) = raw_overload
+            if len(raw_overload) == 7:
+                (raw_parameters, variadic, positional_params, has_kwargs,
+                 kwargs_pattern, has_output, output_pattern) = raw_overload
+                positional_pack_cardinality = keyword_pack_cardinality = (0, None)
+            else:
+                (raw_parameters, variadic, positional_params,
+                 positional_pack_cardinality, has_kwargs,
+                 keyword_pack_cardinality, kwargs_pattern,
+                 has_output, output_pattern) = raw_overload
             parameters = tuple({
                 "name": parameter_name,
                 "kind": (
@@ -393,7 +400,7 @@ def collect_inventory() -> dict[str, Any]:
                 "has_default": bool(has_default),
             } for parameter_name, is_time_series, type_pattern, has_default, type_argument
               in raw_parameters)
-            overloads.append({
+            overload = {
                 "parameters": parameters,
                 "variadic": bool(variadic),
                 "positional_params": int(positional_params),
@@ -401,7 +408,12 @@ def collect_inventory() -> dict[str, Any]:
                 "kwargs_pattern": kwargs_pattern,
                 "has_output": bool(has_output),
                 "output_pattern": output_pattern,
-            })
+            }
+            if tuple(positional_pack_cardinality) != (0, None):
+                overload["positional_pack_cardinality"] = tuple(positional_pack_cardinality)
+            if tuple(keyword_pack_cardinality) != (0, None):
+                overload["keyword_pack_cardinality"] = tuple(keyword_pack_cardinality)
+            overloads.append(overload)
         explicit_root = name in hgraph.__all__
         python_signature = None
         python_parameters = ()
@@ -804,7 +816,9 @@ def _overload_key(overload: dict[str, Any]) -> tuple[Any, ...]:
               for parameter in overload["parameters"]),
         overload["variadic"],
         overload["positional_params"],
+        overload.get("positional_pack_cardinality", (0, None)),
         overload["has_kwargs"],
+        overload.get("keyword_pack_cardinality", (0, None)),
         overload["kwargs_pattern"],
         overload["has_output"],
         overload["output_pattern"],
@@ -816,6 +830,15 @@ def _unique_overloads(operator: dict[str, Any]) -> list[dict[str, Any]]:
     for overload in operator["overloads"]:
         unique.setdefault(_overload_key(overload), overload)
     return list(unique.values())
+
+
+def _format_pack_cardinality(cardinality: tuple[int, int | None]) -> str:
+    minimum, maximum = cardinality
+    if minimum == 0 and maximum is None:
+        return ""
+    if minimum == maximum:
+        return f"{{{minimum}}}"
+    return f"{{{minimum}:{'*' if maximum is None else maximum}}}"
 
 
 def _format_public_signature(name: str, overload: dict[str, Any]) -> str:
@@ -839,7 +862,10 @@ def _format_public_signature(name: str, overload: dict[str, Any]) -> str:
             variadic_parameter["type_pattern"],
             category=_pattern_category(variadic_parameter),
         )
-        rendered.append(f"*{parameter_name}: {pattern}")
+        cardinality = overload.get("positional_pack_cardinality", (0, None))
+        rendered.append(
+            f"*{parameter_name}: {pattern}{_format_pack_cardinality(cardinality)}"
+        )
     elif positional_count < len(parameters):
         rendered.append("*")
     for index, parameter in enumerate(parameters[positional_count:], start=positional_count):
@@ -853,7 +879,10 @@ def _format_public_signature(name: str, overload: dict[str, Any]) -> str:
     if overload["has_kwargs"]:
         pattern = formatter.format(
             overload["kwargs_pattern"] or "time-series", category="time_series")
-        rendered.append(f"**kwargs: {pattern}")
+        cardinality = overload.get("keyword_pack_cardinality", (0, None))
+        rendered.append(
+            f"**kwargs: {pattern}{_format_pack_cardinality(cardinality)}"
+        )
     output = (
         formatter.format(
             overload["output_pattern"], category="time_series", output=True)
@@ -1025,6 +1054,8 @@ def _example_overload(operator: dict[str, Any]) -> dict[str, Any] | None:
     def rank(overload: dict[str, Any]) -> tuple[int, int, int]:
         required = sum(
             not parameter["has_default"] for parameter in overload["parameters"])
+        required += overload.get("positional_pack_cardinality", (0, None))[0]
+        required += overload.get("keyword_pack_cardinality", (0, None))[0]
         return required, len(overload["parameters"]), bool(overload["variadic"])
 
     return min(overloads, key=rank)
@@ -1060,12 +1091,23 @@ def _generated_python_example(operator: dict[str, Any]) -> str:
                 if parameter["has_default"]:
                     continue
                 if overload["variadic"] and index == len(parameters) - 1:
-                    arguments.extend(("first", "second"))
+                    minimum, maximum = overload.get(
+                        "positional_pack_cardinality", (0, None))
+                    count = max(minimum, 2)
+                    if maximum is not None:
+                        count = min(count, maximum)
+                    arguments.extend(f"value_{item + 1}" for item in range(count))
                 elif index < positional_count:
                     arguments.append(parameter["name"] or f"arg{index}")
                 else:
                     parameter_name = parameter["name"] or f"arg{index}"
                     arguments.append(f"{parameter_name}={parameter_name}")
+            keyword_minimum = overload.get(
+                "keyword_pack_cardinality", (0, None))[0]
+            arguments.extend(
+                f"field_{item + 1}=field_{item + 1}"
+                for item in range(keyword_minimum)
+            )
     call = f"hg.{name}({', '.join(arguments)})"
     return_patterns = _operator_return_patterns(operator)
     return call if return_patterns == ("None",) else f"result = {call}"


### PR DESCRIPTION
## Summary

- add inclusive minimum/maximum cardinality metadata for positional and keyword operator packs
- enforce pack bounds during native overload matching without changing candidate ranking
- expose compile-time-safe bounds on static-node and graph overload registration
- document the native API and cover homogeneous, heterogeneous positional, keyword, and graph packs

This is the native resolver foundation for the accepted HGL `{n}`, `{n:*}`, and `{n:m}` syntax. Unbounded bounds use the existing hgraph `size_t(-1)` sentinel through the named `OperatorPackCardinality::unbounded` constant.

## Validation

- `ctest --test-dir cmake-build-hgl --output-on-failure --parallel 2` (1833/1833)
- `ctest --test-dir cmake-build-hgl -R hgraph_language --output-on-failure --parallel 2` (64/64)
- Python 3.14 non-WIP compatibility suite (3432 passed, 10 skipped)
- Sphinx warnings-as-errors build
- focused aggregate-node and graph cardinality tests