### PR TITLE
sum_ over a window is a running sum, not a gated one

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -39,7 +39,7 @@ Accepted deviations (decision list, 2026-09-09)
 
 The differential parity campaign (``tools/parity``) reported 47 outstanding
 discrepancies against released hgraph 0.5.41. Each was decided individually on
-issue #810 as *accept*, *fix* or *discuss*. The fifteen accepted here are
+issue #810 as *accept*, *fix* or *discuss*. The fourteen accepted here are
 permanent: released behaviour this runtime deliberately does not reproduce.
 Every one of them is either pinned by a fingerprint in
 ``tools/parity/known_divergences.json``, so the campaign exercises it and stops
@@ -71,9 +71,6 @@ Pinned by a corpus recipe and a fingerprint
      - ``set()``
      - ``{}``. The neighbouring ``str_`` renderings of a bool and a TSD are
        **not** accepted and are fixed under issue #819
-   * - ``to_window`` with ``min_window_period``
-     - Emits before the minimum period is satisfied, ignoring its own parameter
-     - Waits for the period. The divergence is the released implementation's
    * - Three-input ``intersection`` / ``symmetric_difference``
      - Fails at wiring: no set zero exists for the fold
      - Evaluates the fold. A superset, so no released program changes meaning

--- a/include/hgraph/lib/std/operators/impl/stream_impl.h
+++ b/include/hgraph/lib/std/operators/impl/stream_impl.h
@@ -315,7 +315,23 @@ namespace hgraph::stdlib
                 if (!ts.valid()) { return; }
                 const TSWInputView window_input{ts.base().borrowed_ref()};
                 auto window = window_input.data_view();
-                if (!tsw_ready(window)) { return; }
+                // ``mean`` waits for the minimum window -- an average over
+                // fewer points than were asked for is not the average that was
+                // asked for, and upstream's mean_tsw carries all_valid=("ts",)
+                // to say so. ``sum_`` does NOT: upstream's sum_tsw has no such
+                // gate and maintains a RUNNING total from the first tick, so
+                // it answers 1 for a window holding just [1] even when the
+                // minimum is 2 (parity #857). Partial contents are readable
+                // either way -- ``tsw_ready`` is a separate gate, not a bound
+                // on what the view exposes.
+                if constexpr (Mean)
+                {
+                    if (!tsw_ready(window)) { return; }
+                }
+                else
+                {
+                    if (window.size() == 0) { return; }
+                }
 
                 T total{};
                 for (std::size_t index = 0; index < window.size(); ++index)

--- a/python/tests/ported/_operators/test_tsw_operators.py
+++ b/python/tests/ported/_operators/test_tsw_operators.py
@@ -15,6 +15,37 @@ def test_tsw_sum():
     assert eval_node(g, [1, 2, 3]) == [1, 3, 6]
 
 
+def test_tsw_sum_is_a_running_sum_below_the_minimum_window():
+    """``sum_`` over a window does NOT wait for the minimum window period.
+
+    Upstream's ``sum_tsw`` carries no ``all_valid`` gate and maintains a
+    running total from the first tick, so it answers 1 for a window holding
+    just [1] even when the minimum is 2. Its neighbours ``mean``/``min_``/
+    ``max_`` DO carry ``all_valid=("ts",)`` -- an average over fewer points
+    than were asked for is not the average that was asked for -- which is why
+    only ``sum_`` behaves this way (parity #857).
+    """
+
+    @graph
+    def g(ts: TS[int]) -> TS[int]:
+        return sum_(to_window(ts, 2, min_window_period=2))
+
+    # A single tick, below the minimum of 2: still summed.
+    assert eval_node(g, [0]) == [0]
+    assert eval_node(g, [5]) == [5]
+    assert eval_node(g, [1, 2, 3]) == [1, 3, 5]
+
+
+def test_tsw_mean_still_waits_for_the_minimum_window():
+    """The guard for the above: the gate is dropped for ``sum_`` only."""
+
+    @graph
+    def g(ts: TS[int]) -> TS[float]:
+        return mean(to_window(ts, 3, min_window_period=2))
+
+    assert eval_node(g, [1, 2, 3, 4]) == [None, 1.5, 2.0, 3.0]
+
+
 def test_tsw_abs():
 
     @graph

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -2084,6 +2084,29 @@ TEST_CASE("std operators: add_ supports datetime + timedelta -> datetime")
 
 namespace
 {
+    /** sum_ over a window with a MINIMUM period larger than what has
+        arrived (parity #857). */
+    struct SumOverMinWindowGraph
+    {
+        static constexpr auto name = "sum_over_min_window_graph";
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> ts)
+        {
+            auto window = wire<stdlib::to_window>(w, ts, Int{2}, Int{2});
+            return wire<stdlib::sum_>(w, window).as<TS<Int>>();
+        }
+    };
+
+    /** The guard: mean over the same window still waits. */
+    struct MeanOverMinWindowGraph
+    {
+        static constexpr auto name = "mean_over_min_window_graph";
+        static Port<TS<Float>> compose(Wiring &w, Port<TS<Int>> ts)
+        {
+            auto window = wire<stdlib::to_window>(w, ts, Int{3}, Int{2});
+            return wire<stdlib::mean>(w, window).as<TS<Float>>();
+        }
+    };
+
     struct LenOverWindowGraph
     {
         static constexpr auto name = "len_over_window_graph";
@@ -2104,6 +2127,28 @@ namespace
         }
     };
 }  // namespace
+
+TEST_CASE("std operators: sum over a window is a running sum below the minimum")
+{
+    stdlib::register_standard_operators();
+
+    // sum_ carries no minimum-window gate: upstream's sum_tsw maintains a
+    // running total from the first tick, so a window holding just [1] sums to
+    // 1 even though its minimum is 2 (parity #857).
+    CHECK_OUTPUT(eval_node<SumOverMinWindowGraph>(values<Int>(0)), values<Int>(0));
+    CHECK_OUTPUT(eval_node<SumOverMinWindowGraph>(values<Int>(1, 2, 3)), values<Int>(1, 3, 5));
+}
+
+TEST_CASE("std operators: mean over a window still waits for the minimum")
+{
+    stdlib::register_standard_operators();
+
+    // The guard for the above -- the gate is dropped for sum_ ONLY. An average
+    // over fewer points than were asked for is not the average that was asked
+    // for, and upstream says so with all_valid=("ts",) on mean_tsw.
+    CHECK_OUTPUT(eval_node<MeanOverMinWindowGraph>(values<Int>(1, 2, 3, 4)),
+                 values<Float>(none, 1.5, 2.0, 3.0));
+}
 
 TEST_CASE("std operators: len_ covers windows and composite-element lists (issue #81)")
 {

--- a/tools/parity/corpus/deviation-stream-to-window-min-period-ignored-upstream.json
+++ b/tools/parity/corpus/deviation-stream-to-window-min-period-ignored-upstream.json
@@ -1,8 +1,11 @@
 {
-  "schema_version": 1,
+  "description": "sum_ over a to_window before min_window_period is satisfied. Formerly an accepted deviation (issue #810 item 4.10) on the reading that released hgraph ignores its own parameter. It does not ignore it uniformly: mean_tsw, min_tsw and max_tsw all carry all_valid=(\"ts\",) and wait, while sum_tsw carries no such gate and keeps a RUNNING total from delta_value -- a per-operator choice, not an oversight, and measurably so, since mean, min_, max_ and std already agreed with hgraph at the same minimum. hgraph now runs sum_ the same way and the two AGREE. The recipe is kept to pin that agreement; its known-divergence entry is gone.",
+  "features": [
+    "operation:to_window",
+    "type:int",
+    "family:stream"
+  ],
   "id": "deviation-stream-to-window-min-period-ignored-upstream",
-  "description": "Pin the accepted to_window deviation: released hgraph emits before min_window_period is satisfied, hgraph honours it. The divergence is upstream's. Accepted on issue #810 item 4.10.",
-  "template": "stream_shape",
   "inputs": {
     "ts": [
       1,
@@ -12,16 +15,12 @@
     ]
   },
   "parameters": {
-    "operation": "to_window",
-    "input_type": "int",
     "count": 2,
+    "input_type": "int",
     "min_count": 2,
+    "operation": "to_window",
     "reduction": "sum_"
   },
-  "features": [
-    "operation:to_window",
-    "type:int",
-    "family:stream",
-    "deviation:min-window-period"
-  ]
+  "schema_version": 1,
+  "template": "stream_shape"
 }

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -50,12 +50,6 @@
       "review_after": "2027-09-09"
     },
     {
-      "fingerprint": "c0525119e52f42386904055da4d6eebebe9ddd2a4417e1c5815be3d17797bc51",
-      "issue": "https://github.com/hhenson/hgraph/issues/810",
-      "reason": "Accepted deviation (issue #810 item 4.10): released hgraph emits a to_window reduction before min_window_period is satisfied, so it ticks at the first element where hgraph waits. The divergence is the released implementation ignoring its own parameter. Pinned by corpus recipe deviation-stream-to-window-min-period-ignored-upstream.",
-      "review_after": "2027-09-09"
-    },
-    {
       "fingerprint": "c3ffb96708bb26eef6c0efee2a628da3c7a59320d721ca1daa1a49d27e8ec296",
       "issue": "https://github.com/hhenson/hgraph/issues/810",
       "reason": "No-change-means-no-tick ruling (2026-07-17, roadmap.rst), accepted for switch_ on issue #810 item 6.1: a branch whose output TSD is empty ticks an empty map in released hgraph and emits no tick in hgraph. Same ruling as the mesh entry above. Pinned by corpus recipe deviation-switch-empty-tsd-branch-no-tick.",


### PR DESCRIPTION
Closes #857.

## The bug

`tsw_numeric_aggregate_impl` serves both `sum_` and `mean` from one template, and gated **both** on `tsw_ready` — the minimum-window check. Upstream gates only the mean:

```python
sum_tsw    @compute_node(overloads=sum_)                        # no gate
mean_tsw   @compute_node(overloads=mean, all_valid=("ts",))
min_tsw    @compute_node(overloads=min_, all_valid=("ts",))
max_tsw    @compute_node(overloads=max_, all_valid=("ts",))
```

`sum_tsw` maintains a **running** total from `delta_value`/`removed_value`, so it answers from the first tick regardless of the minimum.

`sum_(to_window(ts, 2, min_window_period=2))`:

| ts | reference 0.5.41 | ours, before | ours, after |
|---|---|---|---|
| `[0]` | `[0]` | *(no ticks)* | `[0]` |
| `[5]` | `[5]` | *(no ticks)* | `[5]` |
| `[0, 1]` | `[0, 1]` | `[None, 1]` | `[0, 1]` |
| `[1, 2, 3]` | `[1, 3, 5]` | `[None, 3, 5]` | `[1, 3, 5]` |

## Why the gate is wrong for `sum_` only

Measured across the whole family at `min_window_period=2` (window 3, input `[1,2,3,4]`):

| operator | reference | ours, before | diverged? |
|---|---|---|---|
| `sum_` | `[1, 3, 6, 9]` | `[None, 3, 6, 9]` | **yes** |
| `mean` | `[None, 1.5, 2.0, 3.0]` | same | no |
| `min_` | `[None, 1.0, 1.0, 2.0]` | same | no |
| `max_` | `[None, 2.0, 3.0, 4.0]` | same | no |
| `std` | `[None, 0.5, 0.8164…, 0.8164…]` | same | no |

Only `sum_` diverged. That is what makes the gate wrong for `sum_` specifically, rather than the minimum-window notion wrong in general — an average over fewer points than were asked for is not the average that was asked for, but a running total over fewer points is still that total.

## The change

The gate alone. Partial contents were always readable — `tsw_ready` is a separate check (`window.size() >= window.min_period()`), not a bound on what the window view exposes — so `sum_` now needs only a non-empty window.

## Gates

- `ctest` — **1826/1826** (1824 baseline + 2 new).
- `uv run pytest python/tests` — **3486 passed**, 9 skipped, 0 failures (3484 baseline + 2 new).
- Both new Python tests pass **unmodified against released hgraph 0.5.41**.
- Verified by stashing the impl change: the `sum_` test fails without it (2 assertions); the `mean` guard passes either way, so the fix provably does not loosen the neighbours.
- Venv extension confirmed newer than the edited header before any Python result was trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga