### PR TITLE
Suppress the accepted empty-set rendering by family, not by fingerprint

### DIFF
--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -475,7 +475,10 @@ issue, rationale, and review date.  They remain in the corpus: once a fix lands,
 the same recipe changes from a known mismatch into a passing regression.
 
 Two mechanisms keep an accepted deviation from re-filing as noise.  Exact
-``divergences`` entries suppress a specific fingerprint.  ``families`` entries
+``divergences`` entries suppress a specific fingerprint — which covers only
+the recipe that minted it, so a deviation reachable by a whole parameter space
+needs a family instead, or the generator files it again under a fresh
+fingerprint (as happened to item 4.4 in issue #863).  ``families`` entries
 suppress the deviation's whole parameter space — a template plus a
 ``parameters_not_equal`` map matching every recipe whose named parameters
 differ from the stated identity (an omitted parameter runs at the template
@@ -507,6 +510,12 @@ way:
   accepts the difference only when projecting each candidate concrete event
   back to the base (and dropping only the leaf fields) makes the complete
   traces identical.
+* ``empty-set-renders-as-braces`` covers issue #810 item 4.4: ``str_`` of an
+  EMPTY set renders ``set()`` upstream and ``{}`` here.  It admits a position
+  holding exactly that pair and requires every other position to match, so a
+  non-empty set — which renders identically on both sides — and the
+  neighbouring renderings decided **fix** (a bool, a TSD, a tuple: issue #819)
+  stay reportable.
 
 An unknown relation, payload corruption, unrelated missing field, candidate
 crash, or status difference does not match and therefore continues through

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -3380,3 +3380,60 @@ def test_projecting_templates_are_the_ones_that_route_through_a_reference():
         spec = catalog.CATALOG[name]
         assert not {"shape:TSL", "binding:non-peered"} & set(spec.features), name
         assert "getitem_" not in spec.operators, name
+
+
+def test_empty_set_family_accepts_only_the_empty_set_rendering():
+    """Issue #810 item 4.4 is an accepted deviation, but its suppression was a
+    FINGERPRINT pin -- so it covered the one corpus recipe it was minted from
+    and a regenerated recipe hitting the same accepted behaviour was filed as
+    a new issue (#863). A family suppresses the behaviour rather than the
+    instance; this pins how narrowly it does so.
+    """
+    from tools.parity.known import load_known_divergences
+
+    _, families = load_known_divergences()
+    families = [
+        family
+        for family in families
+        if family.get("family") == "empty-set-renders-as-braces"
+    ]
+    assert families, "the empty-set family must be registered"
+
+    recipe = {
+        "template": "unary_operator",
+        "parameters": {"input_type": "tss_int", "operation": "str_"},
+    }
+
+    def classify(reference_trace, candidate_trace):
+        reference = {"status": "ok", "trace": reference_trace}
+        candidate = {"status": "ok", "trace": candidate_trace}
+        difference = compare_outcomes(reference, candidate)
+        assert difference is not None, "expected a difference to classify"
+        return is_known_family_failure(
+            recipe, difference.to_dict(), reference, candidate, families
+        )
+
+    # The accepted deviation itself, alone and beside matching positions.
+    assert classify(["set()"], ["{}"])
+    assert classify(["{1}", "set()"], ["{1}", "{}"])
+
+    # A NON-empty set renders identically on both sides, so a difference there
+    # is a real one.
+    assert not classify(["{1}"], ["{2}"])
+
+    # The neighbouring renderings decided FIX on #810 (issue #819) must stay
+    # reportable -- the family must not become a blanket str_ amnesty.
+    assert not classify(["True"], ["true"])
+    assert not classify(["{'a': 1}"], ["{a: 1}"])
+    assert not classify(["3.0"], ["3"])
+
+    # A payload regression sitting beside the accepted rendering is still a
+    # regression.
+    assert not classify(["set()", "{1}"], ["{}", "{2}"])
+
+    # Extra or missing ticks are not this deviation.
+    assert not classify(["set()"], ["{}", "{}"])
+    assert not classify(["set()", None], ["{}", "{}"])
+
+    # The reverse direction is not the documented deviation either.
+    assert not classify(["{}"], ["set()"])

--- a/tools/parity/known.py
+++ b/tools/parity/known.py
@@ -33,6 +33,7 @@ SWITCH_FLIP_MAP_REMOVAL = "switch-flip-map-removal"
 REQUEST_REPLY_ONE_CYCLE_EARLIER = "request-reply-one-cycle-earlier"
 NESTED_REQUEST_REPLY_ONE_CYCLE_EARLIER = "nested-request-reply-one-cycle-earlier"
 POLYMORPHIC_JSON_PRESERVES_LEAF = "polymorphic-json-preserves-leaf"
+EMPTY_SET_RENDERS_AS_BRACES = "empty-set-renders-as-braces"
 
 _POLYMORPHIC_EVENT_LEAVES = {
     "heartbeat": ("HeartbeatEvent", ("event_id",)),
@@ -648,6 +649,49 @@ def _switch_flip_map_removal_relation(
     return admitted >= 1
 
 
+def _empty_set_renders_as_braces_relation(
+    _recipe: dict[str, Any],
+    difference: dict[str, Any],
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    _family: dict[str, Any],
+) -> bool:
+    """Accepted deviation, issue #810 item 4.4: ``str_`` of an EMPTY set
+    renders Python's ``set()`` upstream and ``{}`` here.
+
+    Every trace position must match exactly except positions holding exactly
+    that pair, and at least one such position must account for the
+    difference. A non-empty set renders identically on both sides, so this
+    admits nothing but the empty case -- any other rendering difference
+    (a bool, a TSD, a tuple: issue #819) stays reportable, as does any
+    payload regression inside the same recipe.
+
+    The pre-existing suppression for this deviation is a fingerprint pin,
+    which only covers the one corpus recipe it was minted from; a freshly
+    generated recipe hitting the same accepted behaviour was filed as a new
+    issue (#863). A family suppresses the behaviour rather than the instance.
+    """
+    if difference.get("classification") != "value":
+        return False
+    reference_trace = reference.get("trace")
+    candidate_trace = candidate.get("trace")
+    if (
+        not isinstance(reference_trace, list)
+        or not isinstance(candidate_trace, list)
+        or len(reference_trace) != len(candidate_trace)
+    ):
+        return False
+    admitted = 0
+    for ref, cand in zip(reference_trace, candidate_trace):
+        if ref == cand:
+            continue
+        if ref == "set()" and cand == "{}":
+            admitted += 1
+            continue
+        return False
+    return admitted >= 1
+
+
 SWITCH_FLIP_VALID_SUBSET = "switch-flip-valid-subset-reduce"
 
 RELATIONS = {
@@ -666,6 +710,7 @@ RELATIONS = {
     POLYMORPHIC_JSON_PRESERVES_LEAF: (
         _polymorphic_json_preserves_leaf_relation
     ),
+    EMPTY_SET_RENDERS_AS_BRACES: _empty_set_renders_as_braces_relation,
 }
 
 

--- a/tools/parity/known_divergences.json
+++ b/tools/parity/known_divergences.json
@@ -198,6 +198,18 @@
       "issue": "https://github.com/hhenson/hg_cpp/issues/105",
       "reason": "Accepted map-validity deviation (issues #105/#117/#119/#133/#145, nested_graphs.rst) composed with RFC 0014 timing: a beta-to-request-reply-alpha switch flip transiently invalidates the mapped child while the response is in flight. Released hgraph publishes an empty TSD delta and retains the stale element; hg_cpp removes every currently-live invalid child output so the map contains exactly its valid outputs. Suppress only an all-live-key, removal-only candidate delta opposite the reference's canonical empty-map delta on the exact beta-to-alpha flip, plus at most the single silent response-feedback cycle removed immediately afterward by RFC 0014; the earlier response and every other payload must match.",
       "review_after": "2027-08-04"
+    },
+    {
+      "family": "empty-set-renders-as-braces",
+      "template": "unary_operator",
+      "parameters_equal": {
+        "operation": "str_"
+      },
+      "parameters_not_equal": {},
+      "relation": "empty-set-renders-as-braces",
+      "issue": "https://github.com/hhenson/hgraph/issues/810",
+      "reason": "Accepted deviation (issue #810 item 4.4): str_ of an EMPTY set renders Python's set() in released hgraph and {} in hgraph. A non-empty set renders identically on both sides, so the relation admits nothing but the empty case; the neighbouring str_ renderings of a bool, a TSD and a tuple are NOT accepted and are fixed under issue #819. This replaces nothing: the existing fingerprint pin covers the one corpus recipe it was minted from, and a regenerated recipe hitting the same accepted behaviour was filed as #863.",
+      "review_after": "2027-09-11"
     }
   ]
 }


### PR DESCRIPTION
Closes #863.

## Why #863 was filed at all

Issue #810 item 4.4 **accepted** that `str_` of an empty set renders Python's `set()` upstream and `{}` here. But the suppression is a **fingerprint pin**:

```json
{ "fingerprint": "aecb307b…", "issue": ".../issues/810",
  "reason": "… Pinned by corpus recipe deviation-unary-str-tss-empty." }
```

A fingerprint covers only the recipe that minted it. The generator produced another recipe reaching the same accepted behaviour, and it was filed as a new issue. This is not a bug in the runtime — it is the suppression mechanism being the wrong shape for a deviation that a whole parameter space can reach.

## The family

`empty-set-renders-as-braces` on `unary_operator` with `operation: str_`, guarded by a bounded relation: **every trace position must match exactly except positions holding exactly `set()` against `{}`**, and at least one such position must account for the difference.

Parameter membership alone never suffices in this harness, and the relation is what does the real work here — a non-empty set renders identically on both sides, so nothing but the empty case can be admitted.

## What stays reportable

The new test pins the narrowness against the **real** `known_divergences.json` records rather than a fixture — eleven cases, of which **nine must NOT be suppressed**:

| case | suppressed? |
|---|---|
| `["set()"]` vs `["{}"]` | yes |
| `["{1}", "set()"]` vs `["{1}", "{}"]` | yes |
| `["{1}"]` vs `["{2}"]` — non-empty set | no |
| `["True"]` vs `["true"]` — #819 | no |
| `["{'a': 1}"]` vs `["{a: 1}"]` — #819 | no |
| `["3.0"]` vs `["3"]` — #819 | no |
| `["set()", "{1}"]` vs `["{}", "{2}"]` — regression beside the deviation | no |
| extra tick, missing tick | no |
| `["{}"]` vs `["set()"]` — reverse direction | no |

The #819 rows matter most: without them this family could quietly become a blanket `str_` amnesty over renderings that were decided **fix**, not accept.

## Gates

- `uv run pytest python/tests` — **3485 passed**, 9 skipped, 0 failures (3484 baseline + 1 new).
- No C++ change; `tools/parity` is Python-only.

## Doc

`developer_guide/parity_testing.rst`: the new relation joins the documented family list, and the paragraph introducing the two mechanisms now says plainly what a fingerprint pin does and does not cover — which is the thing that produced this issue.

## Not in scope

The rest of what `str_` renders differently — tuples as `[a, b]` rather than `('a', 'b')`, strings unquoted inside containers, `true`/`false`, `3` for `3.0` — is issue #819, decided **fix**. I measured that surface and posted the full table there, including two cases the issue did not yet list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga