### PR TITLE
Instrument the H2 server read loop for the PING-ACK flake

### DIFF
--- a/extensions/web/include/hgraph/web/testing/h2_diagnostics.h
+++ b/extensions/web/include/hgraph/web/testing/h2_diagnostics.h
@@ -1,0 +1,55 @@
+#ifndef HGRAPH_WEB_TESTING_H2_DIAGNOSTICS_H
+#define HGRAPH_WEB_TESTING_H2_DIAGNOSTICS_H
+
+#include <hgraph/web/export.h>
+
+#include <cstdint>
+
+namespace hgraph::web::testing
+{
+    /**
+     * Server-side counters for the HTTP/2 read loop, for FAILURE DIAGNOSIS
+     * only -- nothing reads them on a passing run.
+     *
+     * The h2 loopback flake (issue #849) has been diagnosed blind three times.
+     * The client-side counters added since then established what the server
+     * does NOT do: on both Linux and macOS, byte for byte, it sends its
+     * SETTINGS and SETTINGS ACK (36 bytes, 2 frames) and then nothing, while
+     * the client sits with an empty socket and an empty OpenSSL buffer. That
+     * rules out a missed client wakeup and narrows it to the server's read
+     * loop, which has exactly three ways to stop:
+     *
+     *   read_stalled     > 0   the backpressure path in read_next() was taken
+     *   receive_rejected > 0   engine_.receive() reported a fatal protocol error
+     *   reads_armed == reads_completed + 1
+     *                          a read is outstanding that never completed --
+     *                          the client's bytes never reached the server
+     *   reads_armed == reads_completed
+     *                          the loop was simply not re-armed
+     *
+     * Those four are mutually exclusive, so one snapshot separates them.
+     *
+     * The counters are process-wide and monotonic. A test that needs a clean
+     * baseline calls ``h2_read_loop_reset`` first; they are plain relaxed
+     * atomics, so reading them races with a live connection and the snapshot
+     * is indicative rather than a consistent instant.
+     */
+    struct H2ReadLoopSnapshot
+    {
+        std::uint64_t reads_armed{};       ///< async_read_some issued
+        std::uint64_t reads_completed{};   ///< its handler ran without an error
+        std::uint64_t read_errors{};       ///< its handler ran WITH an error
+        std::uint64_t bytes_received{};    ///< bytes handed to the h2 engine
+        std::uint64_t receive_rejected{};  ///< engine_.receive() returned false
+        std::uint64_t read_stalled{};      ///< backpressure path taken
+        std::uint64_t writes_armed{};      ///< async_write issued
+        std::uint64_t writes_completed{};  ///< its handler ran without an error
+        std::uint64_t write_errors{};      ///< its handler ran WITH an error
+        std::uint64_t bytes_written{};     ///< bytes handed to async_write
+    };
+
+    [[nodiscard]] HGRAPH_WEB_EXPORT H2ReadLoopSnapshot h2_read_loop_snapshot() noexcept;
+    HGRAPH_WEB_EXPORT void h2_read_loop_reset() noexcept;
+}  // namespace hgraph::web::testing
+
+#endif  // HGRAPH_WEB_TESTING_H2_DIAGNOSTICS_H

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -9,6 +9,7 @@
 #include <hgraph/web/value_builders.h>
 
 #include "detail/h2_engine.h"
+#include <hgraph/web/testing/h2_diagnostics.h>
 #include "detail/route_table.h"
 #include "detail/service_transport.h"
 #include "detail/web_bindings.h"
@@ -62,6 +63,34 @@ namespace websocket = boost::beast::websocket;
 using tcp = asio::ip::tcp;
 
 namespace hgraph::web::detail {
+
+// Failure-diagnosis counters for the H2 read loop (issue #849). Relaxed
+// atomics on the IO path only -- never per tick -- and nothing reads them on a
+// passing run. See hgraph/web/testing/h2_diagnostics.h for how the four
+// terminal states are told apart.
+struct H2ReadLoopCounters {
+  std::atomic<std::uint64_t> reads_armed{};
+  std::atomic<std::uint64_t> reads_completed{};
+  std::atomic<std::uint64_t> read_errors{};
+  std::atomic<std::uint64_t> bytes_received{};
+  std::atomic<std::uint64_t> receive_rejected{};
+  std::atomic<std::uint64_t> read_stalled{};
+  std::atomic<std::uint64_t> writes_armed{};
+  std::atomic<std::uint64_t> writes_completed{};
+  std::atomic<std::uint64_t> write_errors{};
+  std::atomic<std::uint64_t> bytes_written{};
+};
+
+H2ReadLoopCounters &h2_counters() {
+  static H2ReadLoopCounters counters;
+  return counters;
+}
+
+inline void h2_bump(std::atomic<std::uint64_t> &counter,
+                    std::uint64_t by = 1) noexcept {
+  counter.fetch_add(by, std::memory_order_relaxed);
+}
+
 namespace {
 // All transport-side value construction goes through WebBindings
 // (detail/web_bindings.h): resolved once at start so io threads never touch
@@ -3732,22 +3761,28 @@ void H2Driver::read_next() {
       static_cast<std::size_t>(config_->h2_initial_window_bytes)) {
     // Enough unadmitted bytes are already buffered: stop reading the
     // connection so TCP backpressure applies until accounting drains.
+    h2_bump(h2_counters().read_stalled);
     read_stalled_ = true;
     return;
   }
   beast::get_lowest_layer(stream_).expires_after(config_->idle_timeout);
+  h2_bump(h2_counters().reads_armed);
   stream_.async_read_some(
       asio::buffer(read_buffer_),
       asio::bind_executor(
           strand_, [self = shared_from_this()](beast::error_code ec,
                                                std::size_t received) {
             if (ec) {
+              h2_bump(h2_counters().read_errors);
               self->close();
               return;
             }
+            h2_bump(h2_counters().reads_completed);
+            h2_bump(h2_counters().bytes_received, received);
             if (!self->engine_.receive(
                     std::string_view{self->read_buffer_.data(), received})) {
               // Fatal protocol error: flush the GOAWAY and close.
+              h2_bump(h2_counters().receive_rejected);
               self->pump_writes();
               return;
             }
@@ -3782,6 +3817,8 @@ void H2Driver::pump_writes() {
   }
   writing_ = true;
   const std::size_t report_batch = pending_flush_reports_.size();
+  h2_bump(h2_counters().writes_armed);
+  h2_bump(h2_counters().bytes_written, write_buffer_.size());
   asio::async_write(
       stream_, asio::buffer(write_buffer_),
       asio::bind_executor(
@@ -3790,9 +3827,11 @@ void H2Driver::pump_writes() {
                                                     std::size_t) {
             self->writing_ = false;
             if (ec) {
+              h2_bump(h2_counters().write_errors);
               self->close();
               return;
             }
+            h2_bump(h2_counters().writes_completed);
             self->flush_reports(report_batch, true);
             self->pump_writes();
           }));
@@ -4943,3 +4982,30 @@ void register_server(Wiring &w, service::ServicePath path,
       w, std::move(path), std::move(server_config));
 }
 } // namespace hgraph::web
+
+namespace hgraph::web::testing {
+
+H2ReadLoopSnapshot h2_read_loop_snapshot() noexcept {
+  auto &c = hgraph::web::detail::h2_counters();
+  const auto load = [](const std::atomic<std::uint64_t> &v) {
+    return v.load(std::memory_order_relaxed);
+  };
+  return H2ReadLoopSnapshot{
+      load(c.reads_armed),      load(c.reads_completed),
+      load(c.read_errors),      load(c.bytes_received),
+      load(c.receive_rejected), load(c.read_stalled),
+      load(c.writes_armed),     load(c.writes_completed),
+      load(c.write_errors),     load(c.bytes_written)};
+}
+
+void h2_read_loop_reset() noexcept {
+  auto &c = hgraph::web::detail::h2_counters();
+  for (auto *counter : {&c.reads_armed, &c.reads_completed, &c.read_errors,
+                        &c.bytes_received, &c.receive_rejected,
+                        &c.read_stalled, &c.writes_armed, &c.writes_completed,
+                        &c.write_errors, &c.bytes_written}) {
+    counter->store(0, std::memory_order_relaxed);
+  }
+}
+
+}  // namespace hgraph::web::testing

--- a/extensions/web/tests/test_h2_loopback.cpp
+++ b/extensions/web/tests/test_h2_loopback.cpp
@@ -7,6 +7,7 @@
 // exercise incremental admission.
 
 #include <hgraph/web/service.h>
+#include <hgraph/web/testing/h2_diagnostics.h>
 #include <hgraph/web/value_builders.h>
 
 #include <hgraph/lib/std/operators/conversion.h>
@@ -356,17 +357,24 @@ public:
     const std::size_t available = stream_.next_layer().available(ec);
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now() - started);
+    const auto server = hgraph::web::testing::h2_read_loop_snapshot();
     return fmt::format(
         "elapsed={}ms polls={} read_calls={} bytes_read={} bytes_in_total={} "
         "bytes_out_total={} frames_in={} last_frame_type={} "
         "want_read={} want_write={} sock_available={}{} ssl_pending={} "
-        "settings_seen={} ping_acked={}",
+        "settings_seen={} ping_acked={}"
+        " | SERVER reads_armed={} reads_completed={} read_errors={}"
+        " bytes_received={} receive_rejected={} read_stalled={}"
+        " writes_armed={} writes_completed={} write_errors={} bytes_written={}",
         elapsed.count(), polls, read_calls_, bytes_read, bytes_in_, bytes_out_,
         frames_in_, last_frame_type_,
         nghttp2_session_want_read(session_), nghttp2_session_want_write(session_),
         available, ec ? "(query failed)" : "",
         SSL_has_pending(stream_.native_handle()), settings_seen_,
-        ping_acknowledged_);
+        ping_acknowledged_, server.reads_armed, server.reads_completed,
+        server.read_errors, server.bytes_received, server.receive_rejected,
+        server.read_stalled, server.writes_armed, server.writes_completed,
+        server.write_errors, server.bytes_written);
   }
 
 private:


### PR DESCRIPTION
Refs #849. Diagnostics only — no behaviour change.

## The client counters have now caught it twice, and the state is identical

| | Linux (#894, ubuntu-24.04/GCC 14) | macOS (#896, macos-26/Clang) |
|---|---|---|
| `bytes_in_total` / `bytes_out_total` | 36 / 93 | **36 / 93** |
| `frames_in` / `last_frame_type` | 2 / 4 (SETTINGS) | **2 / 4** |
| `bytes_read` during the PING wait | 9 | **9** |
| `sock_available` / `ssl_pending` | 0 / 0 | **0 / 0** |
| `settings_seen` / `ping_acked` | true / false | **true / false** |
| `polls` / `read_calls` | 4644 / 2 | 618 / 3 |

Only the poll counts differ, and those are scheduling. **This kills the "Linux/GCC-specific" reading** I gave earlier: the connection reaches one specific state and stops, on both toolchains.

36 bytes in 2 frames decomposes with no slack — server SETTINGS (9 + 3×6 = 27) plus SETTINGS ACK (9). The server completes the handshake and then sends nothing for five seconds, while the client sits with an empty socket **and** an empty OpenSSL buffer.

That rules out the two things previous fixes targeted: it is not a missed client wakeup (the `aaf874b01` class — both buffers are empty, there was nothing to miss), and it is not loop starvation.

## What the counters separate

The server's read loop has exactly four ways to reach that state, and they are mutually exclusive:

| reading | meaning |
|---|---|
| `read_stalled > 0` | the backpressure path in `read_next()` was taken |
| `receive_rejected > 0` | `engine_.receive()` reported a fatal protocol error |
| `reads_armed == reads_completed + 1` | a read is outstanding that never completed — **the client's bytes never reached the server** |
| `reads_armed == reads_completed` | the loop was simply not re-armed |

One snapshot on the failure path tells them apart. That is the step I said on #849 was needed; this is it.

## Shape

- Relaxed atomics on the **IO path only**, never per tick, read by nothing on a passing run.
- Exposed through `hgraph/web/testing/h2_diagnostics.h`, beside the existing `fake_transport.h` testing header.
- The test appends the block to the string it already throws, so no new failure mode.

## Verified

Forced a timeout to confirm the line renders, and the artificial case is already informative:

```
… | SERVER reads_armed=3 reads_completed=2 read_errors=0 bytes_received=33
  receive_rejected=0 read_stalled=0 writes_armed=2 writes_completed=2
  write_errors=0 bytes_written=36
```

`bytes_written=36` there matches the `bytes_in_total=36` both CI failures report — confirming 36 bytes is the whole of what the server ever sends in the handshake, and giving us the healthy baseline to compare the failure against.

**Not reproducible locally**: 80 sequential runs under 8× CPU load and 72 parallel runs, all clean, on macOS arm64. Instrumentation is the route, not a repro.

## Gates

`ctest` — **1837/1837**, including `hgraph_web_h2_loopback_tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga