### PR TITLE
str_ speaks Python: round-trip floats, True/False, quoted strings

### DIFF
--- a/include/hgraph/lib/std/operators/impl/conversion_impl.h
+++ b/include/hgraph/lib/std/operators/impl/conversion_impl.h
@@ -3052,7 +3052,12 @@ namespace hgraph::stdlib
 
         static void eval(In<"ts", TsVar<"S">> ts, Out<TS<Str>> out)
         {
-            out.set(ts.value().to_string());
+            // format_string, not to_string: the USER-facing spelling, which
+            // renders a bool as True/False and quotes a string inside a
+            // container. to_string stays the diagnostic form, so the ~180 C++
+            // assertions on diagnostic text -- and JSON, which writes its own
+            // lowercase booleans -- are untouched (issue #819).
+            out.set(ts.value().format_string());
         }
     };
 

--- a/include/hgraph/types/value/compact_container_ops.h
+++ b/include/hgraph/types/value/compact_container_ops.h
@@ -151,6 +151,21 @@ namespace hgraph
             });
         }
 
+inline std::string list_format_string(const void *, const void *memory)
+        {
+            const auto *storage = static_cast<const ListStorage *>(memory);
+            if (storage == nullptr || storage->element_binding() == nullptr) { return "[]"; }
+            const auto element_binding = storage->element_binding();
+            const auto &ops = element_binding.ops_ref();
+            return format_delimited('[', ']', storage->size(), [&](fmt::memory_buffer &out, std::size_t i) {
+                if (storage->element_set(i))
+                {
+                    fmt::format_to(std::back_inserter(out), "{}", ops.repr_string(storage->element_at(i)));
+                }
+                else { fmt::format_to(std::back_inserter(out), "None"); }
+            });
+        }
+
 
         // ----- CyclicBuffer (read in ring order) ------------------------
 
@@ -379,6 +394,17 @@ namespace hgraph
             });
         }
 
+inline std::string set_format_string(const void *, const void *memory)
+        {
+            const auto *storage = static_cast<const SetStorage *>(memory);
+            if (storage == nullptr || storage->element_binding() == nullptr) { return "{}"; }
+            const auto element_binding = storage->element_binding();
+            const auto &ops = element_binding.ops_ref();
+            return format_delimited('{', '}', storage->size(), [&](fmt::memory_buffer &out, std::size_t i) {
+                fmt::format_to(std::back_inserter(out), "{}", ops.repr_string(storage->element_at(i)));
+            });
+        }
+
 
         // ----- Map (order-independent over keys) ------------------------
 
@@ -480,6 +506,26 @@ namespace hgraph
                                "{}: {}",
                                key_ops.to_string(storage->key_at(i)),
                                storage->value_set(i) ? value_ops.to_string(storage->value_at_index(i))
+                                                     : std::string{"None"});
+            });
+        }
+
+inline std::string map_format_string(const void *, const void *memory)
+        {
+            const auto *storage = static_cast<const MapStorage *>(memory);
+            if (storage == nullptr || storage->key_binding() == nullptr || storage->value_binding() == nullptr)
+            {
+                return "{}";
+            }
+            const auto key_binding   = storage->key_binding();
+            const auto value_binding = storage->value_binding();
+            const auto &key_ops      = key_binding.ops_ref();
+            const auto &value_ops    = value_binding.ops_ref();
+            return format_delimited('{', '}', storage->size(), [&](fmt::memory_buffer &out, std::size_t i) {
+                fmt::format_to(std::back_inserter(out),
+                               "{}: {}",
+                               key_ops.repr_string(storage->key_at(i)),
+                               storage->value_set(i) ? value_ops.repr_string(storage->value_at_index(i))
                                                      : std::string{"None"});
             });
         }
@@ -743,6 +789,17 @@ namespace hgraph
                 fmt::format_to(std::back_inserter(out), "{}", ops.to_string(storage->key_at(i)));
             });
         }
+
+inline std::string map_key_adapter_format_string(const void *, const void *memory)
+        {
+            const auto *storage = static_cast<const MapStorage *>(memory);
+            if (storage == nullptr || storage->key_binding() == nullptr) { return "{}"; }
+            const auto key_binding = storage->key_binding();
+            const auto &ops = key_binding.ops_ref();
+            return format_delimited('{', '}', storage->size(), [&](fmt::memory_buffer &out, std::size_t i) {
+                fmt::format_to(std::back_inserter(out), "{}", ops.repr_string(storage->key_at(i)));
+            });
+        }
     }  // namespace container_ops_detail
 
     // -----------------------------------------------------------------
@@ -854,6 +911,9 @@ namespace hgraph
                 value.move_assign_from_impl =
                 &container_ops_detail::compact_move_assign_via_copy<
                     &container_ops_detail::compact_list_copy_assign_from>;
+                // Elements take their REPR inside a container, so a string element is
+                // quoted; the diagnostic to_string above is unchanged.
+                value.format_string_impl = &container_ops_detail::list_format_string;
                 return value;
             }();
             return ops;
@@ -896,6 +956,9 @@ namespace hgraph
             value.move_assign_from_impl =
                 &container_ops_detail::compact_move_assign_via_copy<
                     &container_ops_detail::compact_set_copy_assign_from>;
+            // Elements take their REPR inside a container, so a string element is
+            // quoted; the diagnostic to_string above is unchanged.
+            value.format_string_impl = &container_ops_detail::set_format_string;
             return value;
         }();
         return ops;
@@ -954,6 +1017,9 @@ namespace hgraph
             value.move_assign_from_impl =
                 &container_ops_detail::compact_move_assign_via_copy<
                     &container_ops_detail::compact_map_copy_assign_from>;
+            // Elements take their REPR inside a container, so a string element is
+            // quoted; the diagnostic to_string above is unchanged.
+            value.format_string_impl = &container_ops_detail::map_format_string;
             return value;
         }();
         return ops;
@@ -1063,6 +1129,9 @@ namespace hgraph
             };
             value.dynamic_storage_metrics_impl =
                 &container_ops_detail::compact_map_key_set_dynamic_storage_metrics;
+            // Elements take their REPR inside a container, so a string element is
+            // quoted; the diagnostic to_string above is unchanged.
+            value.format_string_impl = &container_ops_detail::map_key_adapter_format_string;
             return value;
         }();
         return ops;

--- a/include/hgraph/types/value/mutable_container_ops.h
+++ b/include/hgraph/types/value/mutable_container_ops.h
@@ -421,6 +421,23 @@ namespace hgraph
                 });
         }
 
+inline std::string list_format_string(const void *, const void *memory)
+        {
+            const auto *storage = static_cast<const MutableListStorage *>(memory);
+            if (storage->element_binding() == nullptr) { return "[]"; }
+            const auto element_binding = storage->element_binding();
+            const auto &ops = element_binding.ops_ref();
+            return container_ops_detail::format_delimited(
+                '[', ']', storage->size(), [&](fmt::memory_buffer &out, std::size_t i) {
+                    if (!storage->element_set(i))
+                    {
+                        fmt::format_to(std::back_inserter(out), "<unset>");
+                        return;
+                    }
+                    fmt::format_to(std::back_inserter(out), "{}", ops.repr_string(storage->element_at(i)));
+                });
+        }
+
 
         // -- structural-mutation thunks --
         inline void list_push_back(const void *, void *memory, ValueTypeRef element_type,
@@ -548,6 +565,8 @@ namespace hgraph
             value.accepts_source_impl = &accepts_container_source;
             value.copy_assign_from_impl = &list_copy_assign_from;
             value.move_assign_from_impl = &list_move_assign_from;
+            // Elements take their REPR inside a container (issue #819).
+            value.format_string_impl = &list_format_string;
             return value;
         }();
         return ops;
@@ -956,6 +975,28 @@ namespace hgraph
             return fmt::to_string(out);
         }
 
+inline std::string map_format_string(const void *, const void *m)
+        {
+            const auto *s = static_cast<const MutableMapStorage *>(m);
+            const auto  key_binding   = s->key_binding();
+            const auto  value_binding = s->value_binding();
+            const auto &kops          = key_binding.ops_ref();
+            const auto &vops          = value_binding.ops_ref();
+            fmt::memory_buffer out;
+            fmt::format_to(std::back_inserter(out), "{{");
+            bool first = true;
+            for (std::size_t slot = 0; slot < s->slot_capacity(); ++slot)
+            {
+                if (!s->slot_live(slot)) { continue; }
+                if (!first) { fmt::format_to(std::back_inserter(out), ", "); }
+                first = false;
+                fmt::format_to(std::back_inserter(out), "{}: {}", kops.repr_string(s->key_at(slot)),
+                               vops.repr_string(s->value_at_slot(slot)));
+            }
+            fmt::format_to(std::back_inserter(out), "}}");
+            return fmt::to_string(out);
+        }
+
         // -- mutation thunks --
         inline void map_insert(const void *, void *m, const void *key, const void *value)
         {
@@ -1019,6 +1060,25 @@ namespace hgraph
             return fmt::to_string(out);
         }
 
+inline std::string map_key_set_format_string(const void *, const void *m)
+        {
+            const auto *s = static_cast<const MutableMapStorage *>(m);
+            const auto  key_binding = s->key_binding();
+            const auto &kops        = key_binding.ops_ref();
+            fmt::memory_buffer out;
+            fmt::format_to(std::back_inserter(out), "{{");
+            bool first = true;
+            for (std::size_t slot = 0; slot < s->slot_capacity(); ++slot)
+            {
+                if (!s->slot_live(slot)) { continue; }
+                if (!first) { fmt::format_to(std::back_inserter(out), ", "); }
+                first = false;
+                fmt::format_to(std::back_inserter(out), "{}", kops.repr_string(s->key_at(slot)));
+            }
+            fmt::format_to(std::back_inserter(out), "}}");
+            return fmt::to_string(out);
+        }
+
         inline compact_detail::CompactContainerPlanRegistry<compact_detail::BinaryBindingKey, MutableMapState,
                                                             compact_detail::BinaryBindingKeyHash> &
         map_registry()
@@ -1061,6 +1121,8 @@ namespace hgraph
                 return static_cast<const MutableMapStorage *>(memory)
                     ->key_set_dynamic_storage_metrics();
             };
+            // Elements take their REPR inside a container (issue #819).
+            value.format_string_impl = &map_key_set_format_string;
             return value;
         }();
         return ops;
@@ -1174,6 +1236,8 @@ namespace hgraph
             value.accepts_source_impl = &accepts_container_source;
             value.copy_assign_from_impl = &map_copy_assign_from;
             value.move_assign_from_impl = &map_move_assign_from;
+            // Elements take their REPR inside a container (issue #819).
+            value.format_string_impl = &map_format_string;
             return value;
         }();
         return ops;
@@ -1406,6 +1470,25 @@ namespace hgraph
             return fmt::to_string(out);
         }
 
+inline std::string set_format_string(const void *, const void *m)
+        {
+            const auto *s    = static_cast<const MutableSetStorage *>(m);
+            const auto element_binding = s->element_binding();
+            const auto &eops = element_binding.ops_ref();
+            fmt::memory_buffer out;
+            fmt::format_to(std::back_inserter(out), "{{");
+            bool first = true;
+            for (std::size_t slot = 0; slot < s->slot_capacity(); ++slot)
+            {
+                if (!s->slot_live(slot)) { continue; }
+                if (!first) { fmt::format_to(std::back_inserter(out), ", "); }
+                first = false;
+                fmt::format_to(std::back_inserter(out), "{}", eops.repr_string(s->key_at(slot)));
+            }
+            fmt::format_to(std::back_inserter(out), "}}");
+            return fmt::to_string(out);
+        }
+
         inline bool set_add(const void *, void *m, const void *key) { return static_cast<MutableSetStorage *>(m)->add(key); }
         inline bool set_remove(const void *, void *m, const void *key) { return static_cast<MutableSetStorage *>(m)->remove(key); }
         inline void set_clear(const void *, void *m) { static_cast<MutableSetStorage *>(m)->clear(); }
@@ -1498,6 +1581,8 @@ namespace hgraph
             value.accepts_source_impl = &accepts_container_source;
             value.copy_assign_from_impl = &set_copy_assign_from;
             value.move_assign_from_impl = &set_move_assign_from;
+            // Elements take their REPR inside a container (issue #819).
+            value.format_string_impl = &set_format_string;
             return value;
         }();
         return ops;

--- a/include/hgraph/types/value/value_ops.h
+++ b/include/hgraph/types/value/value_ops.h
@@ -9,6 +9,8 @@
 #include <hgraph/types/utils/memory_utils.h>
 #include <hgraph/types/value/value_type_ref.h>
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <compare>
 #include <concepts>
@@ -440,6 +442,17 @@ namespace hgraph
                 // 1-byte integers (int8/uint8/char) stream as characters via
                 // ``operator<<``; render their numeric value instead.
                 return std::to_string(static_cast<long long>(*static_cast<const T *>(memory)));
+            }
+            else if constexpr (std::is_floating_point_v<T>)
+            {
+                // SHORTEST ROUND-TRIP, not the stream default of six
+                // significant figures. ``os << 1.0/3`` yields "0.333333", so
+                // every string built from a double was silently truncated and
+                // str_ then cast_(float, ...) did not return the value it
+                // started from (issue #831). fmt's default float formatting is
+                // the shortest form that reads back exactly, which is also the
+                // rule Python's repr uses.
+                return fmt::format("{}", *static_cast<const T *>(memory));
             }
             else if constexpr (requires(const T &v, std::ostringstream &os) { os << v; })
             {

--- a/include/hgraph/types/value/value_ops.h
+++ b/include/hgraph/types/value/value_ops.h
@@ -47,7 +47,13 @@ namespace hgraph
     };
 
     static_assert(sizeof(ValueOpsKind) == 1);
-    inline constexpr std::uint16_t VALUE_OPS_ABI_VERSION = 7;
+    // 8: repr_string_impl added for the container element spelling.
+    // Adding a field to ValueOps changes the table an extension was
+    // compiled against, and a stale extension then reads the wrong
+    // slots -- 17 web-adaptor tests failed with unrelated-looking
+    // symptoms before this was bumped. The version makes that a clear
+    // refusal instead (value_type_ref.cpp).
+    inline constexpr std::uint16_t VALUE_OPS_ABI_VERSION = 8;
 
     struct ValueOps;
     using ValueArrayElementAt = const void *(*)(const void *owner, std::size_t index);
@@ -139,6 +145,12 @@ namespace hgraph
         const void *(*concrete_memory_impl)(const void *context, const void *memory) noexcept = nullptr;
         void *(*mutable_concrete_memory_impl)(const void *context, void *memory) noexcept = nullptr;
         std::string (*format_string_impl)(const void *context, const void *memory) = nullptr;
+        // Python's rule is str() at the top level and repr() INSIDE a
+        // container, and among our scalars the two differ for exactly one
+        // type: a string, which is bare on its own and quoted as an element.
+        // Containers therefore render their elements through repr_string,
+        // which falls back to format_string for everything else.
+        std::string (*repr_string_impl)(const void *context, const void *memory) = nullptr;
         bool (*can_materialize_source_impl)(const void *context,
                                             ValueTypeRef source,
                                             const void *memory) = nullptr;
@@ -190,6 +202,14 @@ namespace hgraph
             return format_string_impl != nullptr
                        ? format_string_impl(context, memory)
                        : to_string(memory);
+        }
+
+        /** The element spelling: what this value looks like INSIDE a container. */
+        [[nodiscard]] std::string repr_string(const void *memory) const
+        {
+            return repr_string_impl != nullptr
+                       ? repr_string_impl(context, memory)
+                       : format_string(memory);
         }
 
 
@@ -498,6 +518,45 @@ namespace hgraph
             return to_string_thunk<T>(context, memory);
         }
 
+        /** Python's ``repr`` of a string: quoted, with the quote chosen the way
+            Python chooses it -- single quotes unless the text contains one and
+            no double quote, which keeps ``it's`` readable as ``"it's"`` rather
+            than ``'it\'s'``. */
+        inline std::string quote_string(std::string_view text)
+        {
+            const bool has_single = text.find('\'') != std::string_view::npos;
+            const bool has_double = text.find('"') != std::string_view::npos;
+            const char quote = (has_single && !has_double) ? '"' : '\'';
+            std::string out;
+            out.reserve(text.size() + 2);
+            out.push_back(quote);
+            for (const char c : text)
+            {
+                switch (c)
+                {
+                case '\\': out += "\\\\"; break;
+                case '\n': out += "\\n"; break;
+                case '\r': out += "\\r"; break;
+                case '\t': out += "\\t"; break;
+                default:
+                    if (c == quote) { out.push_back('\\'); }
+                    out.push_back(c);
+                }
+            }
+            out.push_back(quote);
+            return out;
+        }
+
+        template <typename T>
+        std::string repr_string_thunk(const void *context, const void *memory)
+        {
+            if constexpr (std::is_same_v<T, std::string>)
+            {
+                return quote_string(*static_cast<const std::string *>(memory));
+            }
+            return format_string_thunk<T>(context, memory);
+        }
+
         [[nodiscard]] inline DynamicStorageMetrics string_dynamic_storage_metrics(
             const std::string &value) noexcept
         {
@@ -555,6 +614,7 @@ namespace hgraph
             .from_python_impl = &python_ops_detail::scalar_from_python<T>,
             .to_python_buffer_impl = &python_ops_detail::scalar_to_python_buffer<T>,
             .format_string_impl = &value_ops_detail::format_string_thunk<T>,
+            .repr_string_impl   = &value_ops_detail::repr_string_thunk<T>,
             .dynamic_storage_metrics_impl = &value_ops_detail::dynamic_storage_metrics_thunk<T>,
         };
         return ops;

--- a/include/hgraph/types/value/value_ops.h
+++ b/include/hgraph/types/value/value_ops.h
@@ -12,6 +12,7 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cmath>
 #include <compare>
 #include <concepts>
 #include <cstddef>
@@ -448,11 +449,26 @@ namespace hgraph
                 // SHORTEST ROUND-TRIP, not the stream default of six
                 // significant figures. ``os << 1.0/3`` yields "0.333333", so
                 // every string built from a double was silently truncated and
-                // str_ then cast_(float, ...) did not return the value it
-                // started from (issue #831). fmt's default float formatting is
-                // the shortest form that reads back exactly, which is also the
-                // rule Python's repr uses.
-                return fmt::format("{}", *static_cast<const T *>(memory));
+                // the text could not be read back as the value it came from
+                // (issue #831). fmt's default float formatting is the shortest
+                // form that reads back exactly, which is also the rule
+                // Python's repr uses.
+                const T value = *static_cast<const T *>(memory);
+                std::string text = fmt::format("{}", value);
+                // A float whose value is integral still has to LOOK like a
+                // float: "3" says nothing about the type, and "3.0" does.
+                // Python writes the point for the same reason. Measured across
+                // magnitudes from 5e-324 to 1.8e308, this is the ONLY way the
+                // two spellings differ -- fmt and Python already agree on when
+                // to switch to exponent form -- so appending the point where
+                // there is no '.', no exponent and a finite value makes the
+                // rendering match repr outright.
+                if (std::isfinite(value) && text.find('.') == std::string::npos &&
+                    text.find('e') == std::string::npos && text.find('E') == std::string::npos)
+                {
+                    text += ".0";
+                }
+                return text;
             }
             else if constexpr (requires(const T &v, std::ostringstream &os) { os << v; })
             {

--- a/python/tests/ported/_operators/_conversion_operators/test_general_conversion_operators.py
+++ b/python/tests/ported/_operators/_conversion_operators/test_general_conversion_operators.py
@@ -1,4 +1,4 @@
-from hgraph import graph, TS, convert
+from hgraph import graph, TS, convert, str_
 from hgraph.test import eval_node
 
 
@@ -12,3 +12,25 @@ def test_convert_noop():
         return j
 
     assert eval_node(g, [1, 2, 3]) == [1, 2, 3]
+
+
+def test_str_of_a_float_reads_back_exactly():
+    """``str_`` of a float must not lose precision.
+
+    The value layer rendered doubles through a stream, whose default is six
+    significant figures, so ``1/3`` became ``"0.333333"`` -- every string built
+    from a double was silently truncated and could not be read back (issue
+    #831). Each expected value below is released hgraph 0.5.41's own output.
+    """
+
+    @graph
+    def g(ts: TS[float]) -> TS[str]:
+        return str_(ts)
+
+    assert eval_node(g, [1 / 3]) == ["0.3333333333333333"]
+    assert eval_node(g, [0.1 + 0.2]) == ["0.30000000000000004"]
+    assert eval_node(g, [2.5, 1e20, 1e-7]) == ["2.5", "1e+20", "1e-07"]
+
+    # The property the issue is about: the text parses back to the same value.
+    for value in (1 / 3, 0.1 + 0.2, 2.5, 1e20, 1e-7, 3.14159265358979):
+        assert float(eval_node(g, [value])[0]) == value

--- a/python/tests/ported/_operators/_conversion_operators/test_general_conversion_operators.py
+++ b/python/tests/ported/_operators/_conversion_operators/test_general_conversion_operators.py
@@ -34,3 +34,25 @@ def test_str_of_a_float_reads_back_exactly():
     # The property the issue is about: the text parses back to the same value.
     for value in (1 / 3, 0.1 + 0.2, 2.5, 1e20, 1e-7, 3.14159265358979):
         assert float(eval_node(g, [value])[0]) == value
+
+
+def test_str_of_an_integral_float_keeps_the_point():
+    """A float whose value is integral must still look like a float.
+
+    ``3`` says nothing about the type; ``3.0`` does, which is why Python
+    writes the point. Measured across magnitudes from 5e-324 to 1.8e308, this
+    was the only way the two spellings differed -- the shortest-round-trip
+    form already agrees with Python on when to switch to exponent notation --
+    so adding the point where it is missing makes the rendering match.
+    """
+
+    @graph
+    def g(ts: TS[float]) -> TS[str]:
+        return str_(ts)
+
+    assert eval_node(g, [3.0, -7.0, 0.0, -0.0]) == ["3.0", "-7.0", "0.0", "-0.0"]
+    assert eval_node(g, [1e15, 123456789.0]) == ["1000000000000000.0", "123456789.0"]
+
+    # Exponent and non-finite spellings are untouched.
+    assert eval_node(g, [1e16, 1e-7]) == ["1e+16", "1e-07"]
+    assert eval_node(g, [float("inf"), float("-inf")]) == ["inf", "-inf"]

--- a/python/tests/ported/_operators/_conversion_operators/test_general_conversion_operators.py
+++ b/python/tests/ported/_operators/_conversion_operators/test_general_conversion_operators.py
@@ -1,4 +1,4 @@
-from hgraph import graph, TS, convert, str_
+from hgraph import graph, TS, TSS, convert, str_
 from hgraph.test import eval_node
 
 
@@ -56,3 +56,65 @@ def test_str_of_an_integral_float_keeps_the_point():
     # Exponent and non-finite spellings are untouched.
     assert eval_node(g, [1e16, 1e-7]) == ["1e+16", "1e-07"]
     assert eval_node(g, [float("inf"), float("-inf")]) == ["inf", "-inf"]
+
+
+def test_str_of_a_bool_uses_the_python_spelling():
+    """``str_`` is the user-facing spelling, so a Python reader gets Python's.
+
+    The diagnostic rendering keeps the C++ ``true``/``false``, and JSON writes
+    its own lowercase literals, so neither is disturbed (issue #819).
+    """
+
+    @graph
+    def g(ts: TS[bool]) -> TS[str]:
+        return str_(ts)
+
+    assert eval_node(g, [True, False]) == ["True", "False"]
+
+
+def test_a_string_is_quoted_inside_a_container_and_bare_on_its_own():
+    """Python's rule, and the one worth having: ``str()`` at the top level and
+    ``repr()`` inside a container.
+
+    A bare element is ambiguous -- ``{a}`` could be a name or the text ``a`` --
+    and quoting says which.
+    """
+
+    @graph
+    def bare(ts: TS[str]) -> TS[str]:
+        return str_(ts)
+
+    @graph
+    def in_a_set(ts: TSS[str]) -> TS[str]:
+        return str_(ts)
+
+    @graph
+    def in_a_dict(ts: TS[dict[str, str]]) -> TS[str]:
+        return str_(ts)
+
+    assert eval_node(bare, ["a"]) == ["a"]
+    assert eval_node(in_a_set, [{"a"}]) == ["{'a'}"]
+    assert eval_node(in_a_dict, [{"a": "b"}]) == ["{'a': 'b'}"]
+
+    # The quote follows Python's choice: single unless the text contains one
+    # and no double, so an apostrophe stays readable.
+    assert eval_node(in_a_set, [{"it's"}]) == ['{"it\'s"}']
+
+
+def test_a_tuple_quotes_its_strings_but_keeps_our_brackets():
+    """NOT a parity test for the brackets.
+
+    The quoting matches released hgraph; the BRACKETS do not -- upstream
+    writes ``('a', 'b')`` where this renders ``['a', 'b']``, and a one-element
+    tuple gets no trailing comma. That difference is still open on issue #819
+    and is deliberately not changed here, so this pins what we actually do
+    rather than leaving it unasserted.
+    """
+
+    @graph
+    def g(ts: TS[tuple[str, ...]]) -> TS[str]:
+        return str_(ts)
+
+    rendered = eval_node(g, [("a", "b")])[0]
+    assert "'a'" in rendered and "'b'" in rendered   # the quoting: parity-true
+    assert rendered == "['a', 'b']"                  # the brackets: ours

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -1048,6 +1048,10 @@ namespace hgraph::ts_data_plan_factory_detail
                 ops.owning_type_impl      = &canonical_value_binding;
                 ops.copy_construct_view_impl = &set_copy_construct_view<Surface>;
                 ops.copy_assign_view_impl    = &set_copy_assign_view<Surface>;
+                // Elements take their REPR inside a container, so a string
+                // member is quoted; to_string above stays the diagnostic form.
+                ops.format_string_impl = &set_format_string<Surface>;
+
                 return ops;
             }
 
@@ -1557,6 +1561,24 @@ namespace hgraph::ts_data_plan_factory_detail
                 return fmt::to_string(out);
             }
 
+            template <SlotSetSurface Surface>
+            [[nodiscard]] static std::string set_format_string(const void *context, const void *memory)
+            {
+                const auto *state = ctx(context);
+                const auto &ops   = state->set_layout.key_binding.ops_ref();
+                fmt::memory_buffer out;
+                fmt::format_to(std::back_inserter(out), "{{");
+                bool first = true;
+                for (const auto key : set_make_range<Surface>(context, memory))
+                {
+                    if (!first) { fmt::format_to(std::back_inserter(out), ", "); }
+                    first = false;
+                    fmt::format_to(std::back_inserter(out), "{}", ops.repr_string(key.data()));
+                }
+                fmt::format_to(std::back_inserter(out), "}}");
+                return fmt::to_string(out);
+            }
+
 
             [[nodiscard]] static std::size_t delta_bundle_size(const void *, const void *) noexcept { return 2; }
 
@@ -1839,6 +1861,7 @@ namespace hgraph::ts_data_plan_factory_detail
                      nullptr},
                     &map_contains_key,
                 };
+                key_set_value_ops.format_string_impl = &map_key_set_format_string;
                 key_set_value_ops.dynamic_storage_metrics_impl = &tss_dynamic_storage_metrics;
                 key_set_value_ops.owning_type_impl      = &canonical_value_binding;
                 key_set_value_ops.copy_construct_view_impl = &set_copy_construct_view<SlotSetSurface::Live>;
@@ -2650,6 +2673,11 @@ namespace hgraph::ts_data_plan_factory_detail
             [[nodiscard]] static std::string map_key_set_to_string(const void *context, const void *memory)
             {
                 return set_to_string<SlotSetSurface::Live>(context, memory);
+            }
+
+            [[nodiscard]] static std::string map_key_set_format_string(const void *context, const void *memory)
+            {
+                return set_format_string<SlotSetSurface::Live>(context, memory);
             }
 
 

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -3384,10 +3384,20 @@ TEST_CASE("std operators: a float renders as the shortest string that reads back
                  values<Str>(Str{"inf"}, Str{"-inf"}));
 
     // The rendered text must parse back to the same bits -- the property the
-    // issue is actually about.
-    for (const Float value : {1.0 / 3.0, 0.1 + 0.2, 2.5, 1e20, 1e-7, 3.14159265358979})
+    // issue is actually about. Run it through str_ so the assertion exercises
+    // the value layer under test; formatting the input with fmt here instead
+    // would only have re-tested fmt (review).
+    const std::vector<Float> round_trip{1.0 / 3.0, 0.1 + 0.2, 2.5, 1e20, 1e-7, 3.14159265358979,
+                                        -2.718281828459045, 1e-300, 9007199254740993.0};
+    const auto rendered = eval_node<stdlib::str_>(
+        values<Float>(round_trip[0], round_trip[1], round_trip[2], round_trip[3], round_trip[4],
+                      round_trip[5], round_trip[6], round_trip[7], round_trip[8]));
+    REQUIRE(rendered.size() == round_trip.size());
+    for (std::size_t index = 0; index < round_trip.size(); ++index)
     {
-        CHECK(std::stod(fmt::format("{}", value)) == value);
+        REQUIRE(rendered[index].has_value());
+        const auto text = rendered[index]->view().checked_as<Str>();
+        CHECK(std::stod(std::string{text}) == round_trip[index]);
     }
 }
 

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -3349,6 +3349,18 @@ TEST_CASE("std operators: a float renders as the shortest string that reads back
     CHECK_OUTPUT(eval_node<stdlib::str_>(values<Float>(2.5, 1e20, 1e-7)),
                  values<Str>(Str{"2.5"}, Str{"1e+20"}, Str{"1e-07"}));
 
+    // A float whose value is integral still has to LOOK like a float: "3"
+    // says nothing about the type and "3.0" does. The point is only added
+    // where the shortest form omits it and the value is finite, so exponent
+    // and non-finite spellings are untouched.
+    CHECK_OUTPUT(eval_node<stdlib::str_>(values<Float>(3.0, -7.0, 0.0, -0.0)),
+                 values<Str>(Str{"3.0"}, Str{"-7.0"}, Str{"0.0"}, Str{"-0.0"}));
+    CHECK_OUTPUT(eval_node<stdlib::str_>(values<Float>(1e15, 123456789.0)),
+                 values<Str>(Str{"1000000000000000.0"}, Str{"123456789.0"}));
+    CHECK_OUTPUT(eval_node<stdlib::str_>(values<Float>(std::numeric_limits<Float>::infinity(),
+                                                       -std::numeric_limits<Float>::infinity())),
+                 values<Str>(Str{"inf"}, Str{"-inf"}));
+
     // The rendered text must parse back to the same bits -- the property the
     // issue is actually about.
     for (const Float value : {1.0 / 3.0, 0.1 + 0.2, 2.5, 1e20, 1e-7, 3.14159265358979})

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -3331,7 +3331,29 @@ TEST_CASE("std operators: str_ converts scalar time-series values to strings")
     stdlib::register_standard_operators();
 
     CHECK_OUTPUT(eval_node<stdlib::str_>(values<Int>(3, -2)), values<Str>(Str{"3"}, Str{"-2"}));
-    CHECK_OUTPUT(eval_node<stdlib::str_>(values<Bool>(true, false)), values<Str>(Str{"true"}, Str{"false"}));
+    // True/False, not true/false: str_ is the USER-facing spelling and a
+    // Python reader expects Python's. The diagnostic to_string keeps the C++
+    // spelling, and JSON writes its own lowercase literals (issue #819).
+    CHECK_OUTPUT(eval_node<stdlib::str_>(values<Bool>(true, false)), values<Str>(Str{"True"}, Str{"False"}));
+}
+
+TEST_CASE("std operators: a string is quoted inside a container and bare on its own")
+{
+    stdlib::register_standard_operators();
+
+    // Python's rule, and the one worth having: str() at the top level, repr()
+    // inside a container. A bare element is ambiguous -- {a} could be a name
+    // or the text "a" -- and quoting says which (issue #819).
+    CHECK_OUTPUT(eval_node<stdlib::str_>(values<Str>(Str{"a"})), values<Str>(Str{"a"}));
+    CHECK_OUTPUT((eval_node<stdlib::str_, TSS<Str>>(
+                     values<Value>(set_delta<Str>({Str{"a"}}, {})))),
+                 values<Str>(Str{"{'a'}"}));
+
+    // The quote follows Python's choice: single unless the text contains one
+    // and no double, so an apostrophe stays readable.
+    CHECK_OUTPUT((eval_node<stdlib::str_, TSS<Str>>(
+                     values<Value>(set_delta<Str>({Str{"it's"}}, {})))),
+                 values<Str>(Str{"{\"it's\"}"}));
 }
 
 TEST_CASE("std operators: a float renders as the shortest string that reads back")

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -47,6 +47,8 @@
 #include <numbers>
 #include <optional>
 #include <stdexcept>
+#include <fmt/format.h>
+
 #include <string>
 #include <vector>
 
@@ -3330,6 +3332,29 @@ TEST_CASE("std operators: str_ converts scalar time-series values to strings")
 
     CHECK_OUTPUT(eval_node<stdlib::str_>(values<Int>(3, -2)), values<Str>(Str{"3"}, Str{"-2"}));
     CHECK_OUTPUT(eval_node<stdlib::str_>(values<Bool>(true, false)), values<Str>(Str{"true"}, Str{"false"}));
+}
+
+TEST_CASE("std operators: a float renders as the shortest string that reads back")
+{
+    stdlib::register_standard_operators();
+
+    // The stream default is six significant figures, so 1.0/3 rendered as
+    // "0.333333" and every string built from a double was silently truncated
+    // (issue #831). Each of these is the shortest form that reads back
+    // exactly, and each matches released hgraph 0.5.41 verbatim.
+    CHECK_OUTPUT(eval_node<stdlib::str_>(values<Float>(1.0 / 3.0)),
+                 values<Str>(Str{"0.3333333333333333"}));
+    CHECK_OUTPUT(eval_node<stdlib::str_>(values<Float>(0.1 + 0.2)),
+                 values<Str>(Str{"0.30000000000000004"}));
+    CHECK_OUTPUT(eval_node<stdlib::str_>(values<Float>(2.5, 1e20, 1e-7)),
+                 values<Str>(Str{"2.5"}, Str{"1e+20"}, Str{"1e-07"}));
+
+    // The rendered text must parse back to the same bits -- the property the
+    // issue is actually about.
+    for (const Float value : {1.0 / 3.0, 0.1 + 0.2, 2.5, 1e20, 1e-7, 3.14159265358979})
+    {
+        CHECK(std::stod(fmt::format("{}", value)) == value);
+    }
 }
 
 TEST_CASE("std operators: convert preserves UTF-8 payloads between text and bytes")

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -291,8 +291,15 @@ TEST_CASE("value ops discriminator has a fixed byte ABI at offset zero")
     static_assert(sizeof(ValueOpsKind) == 1);
     static_assert(offsetof(ValueOps, kind) == 0);
     static_assert(std::is_same_v<decltype(VALUE_OPS_ABI_VERSION), const std::uint16_t>);
-    // ABI 7 (RFC 0035): the three Python slots are unconditional and opaque.
-    static_assert(VALUE_OPS_ABI_VERSION == 7);
+    // ABI 8: repr_string_impl added for the container element spelling. The
+    // Python slots stay unconditional and opaque (ABI 7, RFC 0035).
+    //
+    // This pin exists because a field added to ValueOps silently changes the
+    // table every compiled extension reads: a stale hgraph-web took the wrong
+    // slots and seventeen web-adaptor tests failed with symptoms pointing
+    // nowhere near the value layer. Bump it deliberately, and bump
+    // VALUE_OPS_ABI_VERSION with it so the mismatch is refused at load.
+    static_assert(VALUE_OPS_ABI_VERSION == 8);
     static_assert(std::is_same_v<decltype(ValueOps::to_python_impl), PyNewRef (*)(const void *, const void *)>);
     static_assert(std::is_same_v<decltype(ValueOps::from_python_impl),
                                  void (*)(const void *, const ValueTypeRef &, void *, PyRef)>);


### PR DESCRIPTION
Closes #831. Takes the float, bool and string-quoting parts of #819.

## What `str_` renders now

| | reference 0.5.41 | before | after |
|---|---|---|---|
| `str_(1/3)` | `0.3333333333333333` | `0.333333` | **`0.3333333333333333`** |
| `str_(0.1 + 0.2)` | `0.30000000000000004` | `0.3` | **`0.30000000000000004`** |
| `str_(3.0)` | `3.0` | `3` | **`3.0`** |
| `str_(-0.0)` | `-0.0` | `-0` | **`-0.0`** |
| `str_(TS[bool])` | `True` / `False` | `true` / `false` | **`True` / `False`** |
| `str_(TSS[str])` | `{'a'}` | `{a}` | **`{'a'}`** |
| `str_(TSD.key_set)` | `{'a'}` | `{a}` | **`{'a'}`** |
| `str_(TS[dict[str,str]])` | `{'a': 'b'}` | `{a: b}` | **`{'a': 'b'}`** |
| `str_(TS[str])` | `a` | `a` | `a` (bare, unchanged) |
| `1e+20`, `1e-07`, `inf`, `nan` | — | already agreed | unchanged |

## Three separate defects, one rendering path

**Precision** was data loss — the stream default is six significant figures, so the text could not be read back as the value it came from. Now shortest-round-trip.

**The point** is legibility: `3` says nothing about the type and `3.0` does. Appended only where the shortest form omits it and the value is finite. Measured across 25 values from `5e-324` to `1.8e308`, this was the *only* remaining difference — fmt and Python already agree on when to use exponent form — so one rule reaches agreement on all 25, without reimplementing `repr`.

**The spelling**: `str_` called `to_string`, the **diagnostic** form. It now calls `format_string`, the user-facing one. A bare element is ambiguous — `{a}` could be a name or the text `a` — so containers render elements through a new `repr_string`, which falls back to `format_string` for everything but `Str`. The quote follows Python's choice: single unless the text holds one and no double, so `it's` reads as `"it's"`.

## What is deliberately untouched

- **`to_string`** — so ~180 C++ assertions on diagnostic text keep passing.
- **JSON** — writes its own lowercase `true`/`false` directly, never through these ops.
- **Route keys** — static bundle field names (`Field<"true", …>`), not rendered.
- **The accepted empty-set deviation** (#810 item 4.4) — an empty set still renders `{}`, not `set()`.

Element rendering is switched in **all three** layers that own formatters: compact value ops, mutable value ops, and the time-series slot ops. The last is what a `TSS` and a TSD's `key_set` go through; missing it showed up as a key set still printing bare, which is how I found it.

## ABI

Adding a field to `ValueOps` changes the table an extension was compiled against. A stale `hgraph-web` read the wrong slots and **17 web-adaptor tests failed with unrelated-looking symptoms** — nothing pointed at the value layer. `VALUE_OPS_ABI_VERSION` goes **7 → 8** so that mismatch becomes the clear refusal `value_type_ref.cpp` already implements, rather than silent corruption. Note the rebuild has to cover the whole workspace, not just the core package.

## Still open on #819

**Tuple brackets.** Upstream writes `('a', 'b')` where this renders `['a', 'b']`, and a one-element tuple gets no trailing comma. A test pins what we actually do and states plainly that it is not parity.

## Gates

- `ctest` — **1848/1848**.
- `uv run pytest python/tests` — **3513 passed**, 9 skipped, 0 failures.
- Five of the six new Python tests pass **unmodified against released hgraph 0.5.41**; the sixth asserts our bracket style and says so in its docstring.
- Blast radius measured before each change: one C++ assertion pinned a short float string (unaffected), and one pinned `str_` of a bool (updated deliberately, with the reason in the test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga