### PR TITLE
docs(hgl): record temporal functions, caches, and target mappings

### DIFF
--- a/language/README.md
+++ b/language/README.md
@@ -1,10 +1,16 @@
 # hgraph language
 
-This directory hosts the experimental hgraph language toolchain. It is a
+HGL is a temporal programming language for expressing computations over values
+that evolve through time. This directory hosts its experimental toolchain, a
 parallel project which consumes the public hgraph C++ SDK; hgraph core does not
-depend on it. The language is intended for user-authored typed functions over
-hgraph, not for implementing transports, threads, callbacks, or arbitrary
-native extensions.
+depend on it. The language combines temporal computations with value-level
+work and explicit state; transports, threads, callbacks, and arbitrary native
+extensions remain native responsibilities.
+
+The agreed direction for `const fn`, reconstructible caches, and portable
+native contracts is recorded in
+[ADR 0008](docs/design/decisions/0008-temporal-contracts-and-target-mappings.md).
+These are design decisions, not claims of compiler support.
 
 Two backends share one frontend: the direct-wiring backend wires composition
 programs onto the hgraph runtime in process, and the C++ backend writes the
@@ -94,6 +100,7 @@ and preserves those semantics through hgraph's public C++ APIs.
 
 - [Architecture](docs/design/architecture.md)
 - [Language model](docs/design/language-model.md)
+- [Temporal contracts and target mappings](docs/design/decisions/0008-temporal-contracts-and-target-mappings.md)
 - [Modules and native extensions](docs/design/modules.md)
 - [Roadmap](docs/design/roadmap.md)
 - [Distribution and deployment](docs/design/distribution.md)

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -1,5 +1,8 @@
 # hgraph language documentation
 
+HGL is a temporal programming language: change, validity, activation, and
+history are part of its programming model, alongside ordinary value-level work.
+
 The documentation is split by audience:
 
 - The [User Guide](user-guide/README.md) shows how language functions and
@@ -9,15 +12,16 @@ The documentation is split by audience:
 - The design records capture architectural decisions, project boundaries, and
   the delivery roadmap.
 
-The language is still a design preview. The current `hgl` checks every
-example (`hgl check`), runs composition functions directly, compiles and
+The language is still a design preview. The current `hgl` checks the
+compiler example corpus (`hgl check`), runs composition functions directly, compiles and
 loads the scalar runtime-node subset for file-based `hgl test` and `hgl run`
 and the REPL on Unix, and emits the same C++ through `hgl emit-cpp` for
 `hgl_add_module()`. The status of every language surface, with its
 fail-closed boundary or named blocker, is kept in one place: the
 [roadmap status matrix](design/roadmap.md#feature-status-matrix-2026-09-07).
-Provisional syntax is labelled so that examples do not imply an implemented
-compatibility promise.
+Provisional and not-yet-implemented syntax in these documents is labelled;
+those snippets are not part of the accepted compiler example corpus and do not
+imply an implemented compatibility promise.
 
 ## Design records
 
@@ -64,6 +68,11 @@ compatibility promise.
 14. [Operators](design/operators.md) — fixed symbol-to-name mappings, precise
     signatures and lifting, domain-bound properties, numerical exceptions,
     and the boundary between declarations and verified reduction laws.
+15. [Temporal contracts and target mappings](design/decisions/0008-temporal-contracts-and-target-mappings.md)
+    — temporal-language framing, value-level `const fn`, cache versus
+    recordable state, native type lifecycles, and the separation of semantic
+    contracts from target realizations; agreed direction with open syntax and
+    implementation work explicitly identified.
 
 An accepted change should update the relevant guide and its owning design
 record together. The user guide is the source of truth for observable language

--- a/language/docs/design/architecture.md
+++ b/language/docs/design/architecture.md
@@ -4,13 +4,21 @@ Status: accepted direction; prototype migration is tracked in the roadmap
 
 ## Purpose
 
-The hgraph language is a domain-specific authoring language for typed
-functions over hgraph. It gives authors a compact, learnable surface while
-preserving the C++ hgraph runtime as the source of truth.
+HGL is a temporal programming language for computations over values that
+evolve through time. It gives authors a compact, learnable surface for change,
+validity, activation, and history while preserving the C++ hgraph runtime as
+the current implementation's source of truth.
 
 The project is hosted beside hgraph while the design matures, but it is an
 independent consumer of the public hgraph SDK. It must remain possible to move
 the directory into a separate repository without changing hgraph core.
+
+The agreed direction in
+[ADR 0008](decisions/0008-temporal-contracts-and-target-mappings.md) separates
+temporal and value-level functions, recordable state and reconstructible
+caches, and semantic contracts and target mappings. Alternative engine or
+language mappings are future work, not current backend support or a second
+runtime inside the compiler.
 
 ## Goals
 
@@ -75,15 +83,22 @@ imports control names, not which implementation providers are active.
 
 ## Semantic phases
 
-Source uses one `fn` declaration rather than exposing graph and node keywords.
-A function-classification stage maps explicit source syntax to hgraph's
-backend phases:
+The implemented temporal model uses `fn` rather than exposing graph and node
+keywords. A function-classification stage maps explicit source syntax to
+hgraph's backend phases:
 
 | Backend kind | Phase | May do | Must not do |
 | --- | --- | --- | --- |
 | Composition | Wiring | Compose functions, pass ports, inspect `const` values, select fixed topology | Read current time-series values, keep runtime state, perform runtime side effects |
 | Compute or sink | Evaluation | Read admitted runtime inputs, update declared state, produce the contracted tick or side effect | Add topology, resolve overloads, acquire arbitrary external resources |
 | Imported adaptor or service | Native C++ | Own callbacks, threads, queues, protocols, and resources through hgraph lifecycle contracts | Expose unrestricted native execution to language source |
+
+The agreed `const fn` extension is a separate value-level role: no graph
+wiring or independent ticks, but callable on current values inside a node or
+on available wiring-time values when its phase/effect contract permits.
+Function-level `const` means neither compile-time-only nor pure. Execution
+role and native-versus-HGL implementation are independent. This extension is
+not implemented; see the decision for eligibility and lifecycle constraints.
 
 The current implementation classifies an ordinary body as composition. A
 `state` or `inject` declaration or a `start`, `when`, or `stop` block classifies

--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -14,6 +14,23 @@ prototype. That freedom is used to establish explicit pass contracts now,
 before additional syntax and backend behavior make the resolved syntax tree a
 de facto intermediate representation.
 
+## Agreed extension: semantic contracts and target mappings
+
+[ADR 0008](decisions/0008-temporal-contracts-and-target-mappings.md) records the
+next architectural direction, not a new implemented pass pipeline. Typed
+semantics must retain execution role, type identity, capabilities, and
+ownership/effects independently of a provider's emitted type or symbol.
+Target mappings then realize those contracts for a particular engine,
+language, and ABI/platform/profile.
+
+The existing descriptor/HIR/hgraph IR boundaries are the starting point. Native
+`cpp_type` and `cpp_symbol` metadata currently bind the C++ target; they do not
+already provide portable type realization. Introducing a mapping boundary
+must preserve shared resolution and fail-closed diagnostics, not make each
+emitter infer semantics or duplicate hgraph's matcher. The present semantic IR
+remains hgraph-specific; alternative-engine and Rust/Zig integrations require
+their own mappings and conformance evidence.
+
 ## Parsing direction
 
 HGL uses the declarative [lexy](https://github.com/foonathan/lexy) production

--- a/language/docs/design/decisions/0008-temporal-contracts-and-target-mappings.md
+++ b/language/docs/design/decisions/0008-temporal-contracts-and-target-mappings.md
@@ -1,0 +1,310 @@
+# ADR 0008: temporal programming, value functions, and target mappings
+
+Status: accepted design direction, not an implemented language extension.
+`const fn` is the agreed value-function marker. The cache concept and lifecycle
+are agreed; its complete declaration syntax, native-type lifecycle syntax, and
+target-mapping syntax remain open. Examples below do not belong to the
+compiler's accepted example corpus.
+
+## Context
+
+HGL needs to express the core node and graph library without binding its
+language contracts to one implementation's C++ spelling. The immediate cases
+are reusable value-level helpers, recoverable node-local caches, and native
+types with explicit lifetime operations. An alternative C++ engine should be
+able to share some mappings while replacing others; a future Rust or Zig
+target may require different representations entirely.
+
+This is a language design decision, not authorization to implement another
+runtime inside the compiler. The current target remains the public C++ hgraph
+SDK, including its type, operator, lifecycle, and record/replay semantics.
+
+## HGL is a temporal programming language
+
+HGL is a temporal programming language for expressing computations over values
+that evolve through time. It combines temporal computations with value-level
+functions, explicit state, and native implementations.
+
+Change, validity, activation, and history are part of the programming model.
+Graphs and nodes describe how temporal computations compose and execute; they
+are not competing source-language categories. Native or imported types remain
+nominal atomic values, like `i64`, `f64`, and `str`, rather than becoming
+time-series types by virtue of their declaration. Their use in a temporal
+parameter introduces the temporal context.
+
+## Value-level functions
+
+Use `const fn` to declare a non-temporal function. It executes directly on
+values, or on explicitly admitted views, and has no independent activation,
+output ticks, or graph topology. Its arguments and result are value-level;
+they are not recursively temporalized as ordinary temporal parameters are.
+
+An ordinary `fn` retains the current temporal callable model. Calling it at
+wiring time either composes existing operations or wires a runtime node,
+depending on its body. In particular, an ordinary `fn` containing `when`
+does not become a value function merely because its body runs at tick time.
+
+| Call context | Temporal `fn` or operator implementation | Value-level `const fn` implementation |
+| --- | --- | --- |
+| Graph construction | Compose topology or wire a node | Execute on available values, if its phase/effect contract permits wiring-time use |
+| Runtime node evaluation | Cannot wire or invoke a temporal computation as a value call | Execute on current values or admitted views; the caller owns activation and output |
+| Node lifecycle hook | Cannot introduce topology | Execute only if the helper is admitted in that lifecycle phase |
+
+The marker does not mean compile-time-only, constant folding, purity, immutable
+arguments, or absence of side effects. A native helper may mutate an explicitly
+permitted cache argument. Mutation, allocation, I/O, borrowing, and allowed
+lifecycle phases need their own contracts; `const fn` does not authorize them.
+Nor may a value function declare node state, inject a node capability, or
+contain `when`, `start`, or `stop` blocks. Its calls must remain value-level.
+
+Parameter-level `const` retains its existing meaning: fixed wiring-time
+configuration on a temporal callable. Function-level `const` is not shorthand
+for adding that qualifier to every parameter. A source configured entirely by
+fixed values can still tick, so an all-`const` signature is not evidence that
+the function is non-temporal.
+
+### HGL example and C++ expectation
+
+The following uses the agreed, not-yet-implemented `const fn` spelling:
+
+```hgl
+const fn scale(value: f64, factor: f64) -> f64 =>
+    value * factor
+
+fn scaled(value: f64, const factor: f64) -> f64 {
+    when modified(value) && valid(value) {
+        return scale(value, factor)
+    }
+}
+```
+
+The expected C++ shape is a plain value helper called by the containing node's
+evaluation hook, not another node. Illustrative lowering, not current emitter
+output:
+
+```cpp
+double scale(double value, double factor) {
+    return value * factor;
+}
+
+struct scaled {
+    static void eval(hgraph::In<"value", hgraph::TS<double>> value,
+                     hgraph::Scalar<"factor", double> factor,
+                     hgraph::Out<hgraph::TS<double>> out) {
+        out.set(scale(value.value(), factor.value()));
+    }
+};
+```
+
+For this single-input example, the node's activation/readiness policy supplies
+the handler's modified/valid admission. `scale` neither schedules evaluation
+nor emits the result; `scaled` does. A permitted call to `scale` on two
+wiring-time scalar values instead computes a scalar immediately, without
+wiring a node. A temporal port cannot be passed to that helper as a scalar in
+graph composition: there is no current payload to read at wiring time.
+
+### Operators and native implementations
+
+Execution role and implementation language are independent. One nominal
+operator may have temporal and value-level candidates, and either role may
+have HGL or native implementations. A native graph implementation wires a
+graph; a native value implementation directly operates on its admitted
+arguments. Being native does not determine the role.
+
+The call context first constrains candidate eligibility. Selection must retain
+the operator identity, concrete type domain, signature, and applicable
+constraints; it must not depend on a coincidentally equal name or rediscover
+an overload on each tick. The existing hgraph resolver remains the owner of
+temporal candidate matching/ranking. Extending the model to value candidates
+must preserve its shared matching rules, not add an independent dispatcher.
+
+The [fixed symbol-to-name mapping](../operators.md#fixed-symbol-to-name-mapping)
+is unchanged. For example, `*` identifies `mul_`; the context and domain
+determine an eligible implementation. Domain-bound algebraic properties do
+not automatically transfer to a different numerical policy or candidate.
+
+A scalar implementation does not implicitly supply a temporal implementation.
+Any lifting facility must separately define activation, validity, reference
+access, output/delta behavior, and result typing. Conversely, having a temporal
+operator does not make it callable as scalar work inside a node.
+
+The modifier combinations for operator implementations, native declarations,
+and exports are not settled here. Existing source `native fn` value/view
+helpers remain the implemented interface; their migration or compatibility
+with `const fn` is follow-up work, not an immediate syntax change.
+
+## Cache versus recordable state
+
+The language distinguishes semantic history from reconstructible local data:
+
+| HGL concept | Meaning | Current native counterpart | Record/replay |
+| --- | --- | --- | --- |
+| `state` | Persistent data needed to determine subsequent computation | `RecordableState<TSchema>` | Recorded and restored |
+| `cache<T>` | Node-local data reconstructible independently of missing history | `State<T>` | Excluded; rebuilt after restart |
+
+`cache<T>` names the agreed concept. This record does not choose the complete
+declaration or initializer grammar. It does not rename C++ `State` or introduce
+a native `Cache` selector.
+
+Given the same restored inputs and recordable state, restarting with an empty
+or reconstructed cache must preserve subsequent output values, validity,
+ticks, deltas, and semantic side effects. Only the cost of producing them may
+differ. Incremental cache maintenance is fine if the contents can also be
+recovered from authoritative current data without replaying lost history just
+to rebuild the cache. Rebuilding must finish before any evaluation that
+depends on the contents; inputs need not be available during physical
+construction, so a cache may initially be empty and explicitly not ready.
+
+Examples:
+
+- An index derived from the complete current input map is a cache if it can
+  be rebuilt after restoration without changing observable results.
+- A cached REF is suitable when current input connections and a current or
+  restored selection identify its source. A historical selection known only
+  to the cache is semantic state and must instead be recordable.
+- A running total, last-seen value, or queue of unconsumed events is not a
+  cache merely because it is stored privately. When missing history is needed
+  to reconstruct it, use recordable state or an explicit temporal structure.
+
+REF opacity and binding-change semantics remain unchanged. Caching a reference
+does not grant payload access below it, serialize an engine handle, extend a
+borrowed view's lifetime, or keep a handle valid after its owning graph dies.
+
+### Construction and typing
+
+Cache and state storage are both planned and their objects constructed during
+node initialization, before `start`. There is no physical lifetime distinction
+that lets cache allocation or construction be deferred to `start`. Constructing
+the object is separate from populating its logical contents or restoring
+recorded values. Replay-aware state initializers must not overwrite restored
+state; cache reconstruction must use the restored authoritative data.
+
+Normal teardown runs semantic `stop` before destroying the constructed
+objects and releasing their storage. Partial initialization must clean up
+whatever was successfully constructed without assuming `start` completed.
+Detailed failure and rollback rules for native hooks remain to be specified.
+
+Cache follows state's applicable typing and lifetime rules but does not
+require recordability. It may therefore contain admitted native/non-recordable
+types. HGL `state` still requires recordable types; a native type is eligible
+there only if its recordability contract is supplied. Opaque native storage
+does not remove this distinction. Cache is also not a blanket permission to
+own external resources or introduce I/O outside a native lifecycle contract.
+
+A node may need both recordable history and a derived cache. Supporting both
+is the agreed direction. The current
+[C++ static-node API](../../../../include/hgraph/types/static_node.h) explicitly rejects
+combining `State` and `RecordableState`; that restriction, storage planning,
+and their lifecycle integration require implementation work. HGL cache
+declarations and generic native cache construction are not implemented.
+
+For **HGL-MIG-005**, this settles the reconstructible-cache distinction, not
+generic recordable-state construction. Non-default-constructible generic
+state, sparse validity, queues, and windows still require their own accepted
+representation and initialization rules. They must not be relabelled as
+cache to bypass record/replay.
+
+## Language contracts and target mappings
+
+Keep four concerns distinguishable, without prescribing four new source
+declaration forms:
+
+| Concern | Information it owns |
+| --- | --- |
+| Semantic contracts | Nominal type and callable identities, signatures, behavior, execution roles, ownership/effects, and required capabilities |
+| Requirements and use | Which contracts and capabilities a module needs, without naming a provider's implementation spelling |
+| Implementations | Candidates satisfying those contracts, their domains/constraints, and HGL or native bodies |
+| Target mappings | Concrete representations, lifecycle operations, symbols/wrappers, engine APIs, ABI, and build/load dependencies |
+
+A target is more specific than an emitted language: it includes the engine,
+language, and relevant ABI/platform/profile. Two C++ engines may share scalar
+representations and numerical helpers while using different node/view APIs.
+A Rust or Zig realization must preserve the same semantics without pretending
+those C++ types or ownership operations exist there. Mapping reuse and
+overrides need explicit, deterministic compatibility rules; their declaration
+syntax and composition mechanism are still open.
+
+Stable language identity is distinct from a target layout or ABI fingerprint.
+Where a type already exists in hgraph, reuse its canonical identity and
+operations rather than registering a duplicate identity from its HGL name.
+An absent or incompatible mapping/capability must fail during compilation or
+planning, not silently substitute different behavior.
+
+### Native type realization and lifecycle
+
+The discussion's illustrative sketch was:
+
+```hgl
+type SomeType {
+    cpp { some::Type }
+}
+```
+
+This is a design sketch, not accepted parser syntax. `SomeType` would be an
+atomic nominal language type; `some::Type` would be a target mapping, not the
+type's portable meaning. A colocated mapping could be convenient, but the
+model must also permit using the contract with another target's mapping.
+Native fields and layout do not become visible automatically.
+
+A type realization needs an explicit lifecycle protocol covering:
+
+- memory requirements, including size and alignment for a concrete realization;
+- construction in supplied storage and destruction of a live object;
+- supported copying, ownership transfer/move, borrowing, and sharing;
+- who allocates and releases storage, separately from who constructs and
+  destroys an object;
+- optional capabilities such as equality, hashing, ordering, and recordability,
+  required only by contexts that use them.
+
+These are semantic capabilities, not a requirement to imitate every C++
+special member on every target. Destroying an arena-owned object must not free
+the containing arena. Retaining/releasing a Python-backed reference is not
+automatically an independent or deep value copy. Unsupported operations must
+remain unavailable rather than acquire an accidental byte-copy fallback.
+
+Native lifecycle helpers implement this protocol; an ordinary function merely
+named `init` does not become a constructor automatically. Association with the
+type, receiver/result ownership, supported arguments, allowed phases, failure
+handling, and cleanup need explicit contracts. Their source spelling remains
+open. Node `start`/`stop` hooks and type construction/destruction are separate
+layers, even when both ultimately call native functions.
+
+## Implementation boundary and next work
+
+The existing [descriptor model](../../../include/hgl/native_package.h)
+already records native type categories, phase,
+effect, and ownership information, but its `cpp_type`, `cpp_symbol`, headers,
+and build metadata describe the current C++ target. It is a starting point,
+not a completed target-mapping system. The exploratory runtime-contract
+prototype in [PR #796](https://github.com/hhenson/hgraph/pull/796) is related
+design input; this decision neither adopts its entire provisional syntax nor
+claims a specification parser or generator exists.
+
+Extend the existing typed HIR and hgraph semantic IR boundaries deliberately.
+Represent execution roles and required capabilities before emission; perform
+target-specific realization through an explicit mapping boundary. Emitters
+must not invent language semantics or reimplement resolution. The current
+compiler remains hgraph-specific; another engine or language requires a
+separately validated target integration, not just a different output suffix.
+
+Suggested bounded implementation order, not additional syntax decisions:
+
+1. Define execution-role metadata and `const fn` checking/lowering, including
+   value results and diagnostics for illegal cross-phase calls. Settle modifier
+   combinations and compatibility with existing native declarations.
+2. Settle cache declarations and native type-construction contracts. Add the
+   public C++ path for a node containing both state categories, with pre-`start`
+   construction and restart/teardown coverage.
+3. Specify requirements and target mappings with one native cache type and one
+   operator having value-level and temporal implementations. Separate logical
+   identity from target compatibility metadata.
+4. Probe mapping reuse with an alternative C++ engine and portability with a
+   Rust or Zig realization. Use the same semantic conformance scenarios; do
+   not claim backend support from a specification-only example.
+
+Acceptance must cover current-value versus wiring-value calls, no accidental
+temporal lifting, domain-specific operator selection, construction before
+`start`, cache reconstruction after restore, partial initialization cleanup,
+borrowed/REF lifetime rejection, and missing-capability diagnostics. Changes
+to runtime behavior require native C++ tests and matching Python coverage
+where exposed. This documentation change implements none of those extensions.

--- a/language/docs/design/decisions/README.md
+++ b/language/docs/design/decisions/README.md
@@ -12,3 +12,4 @@ syntax unresolved and named as such.
 - [0005: Module-local exact native functions may contain C++](0005-inline-cpp-native-functions.md)
 - [0006: Explicit source parts form one logical module](0006-multi-file-module-parts.md)
 - [0007: Explicit parameter-pack shapes](0007-parameter-packs.md)
+- [0008: Temporal programming, value functions, and target mappings](0008-temporal-contracts-and-target-mappings.md)

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -8,6 +8,12 @@ source behavior. The
 [Developer Guide](../developer-guide/syntax-and-semantics.md) records the
 proposed grammar and compiler boundaries.
 
+HGL is a temporal programming language: values, change, validity, activation,
+and history form its programming model. The agreed direction for value-level
+functions, reconstructible caches, and native type/target contracts is in
+[ADR 0008](decisions/0008-temporal-contracts-and-target-mappings.md). Its
+unimplemented extensions are distinguished from the current model below.
+
 ## Design principles
 
 The language should feel familiar to Python, Rust, and Swift users without
@@ -16,7 +22,7 @@ named arguments, and canonical collection types carry most of the syntax.
 
 The bespoke behavior is semantic:
 
-- ordinary parameters are temporal;
+- ordinary parameters of a temporal `fn` are temporal;
 - `const` parameters are fixed wiring-time values;
 - `let` and `var` distinguish immutable and mutable lexical bindings;
 - canonical types recursively describe hgraph temporal structures;
@@ -83,6 +89,11 @@ The agreed declaration forms are:
 - `export abstract struct` for a public abstract data family;
 - anonymous `fn(...) => expression` values.
 
+The agreed, not-yet-implemented `const fn` extension declares direct
+value-level functions. It does not add `graph` or `node` keywords or alter
+parameter-level `const`. Modifier combinations with `impl`, `native`, and
+`export` remain open; see [value-level functions](../user-guide/functions.md#value-level-functions).
+
 Within a function body, `let` introduces an immutable lexical binding and
 `var` introduces a mutable lexical binding. Neither persists between runtime
 evaluations. Persistent mutable data is declared with `state`; fixed
@@ -94,7 +105,7 @@ ends with its signature, never has a body, and is automatically public.
 
 ## Parameters and results
 
-An ordinary parameter is temporal:
+In an ordinary temporal `fn`, an unmodified parameter is temporal:
 
 ```hgl
 price: f64
@@ -109,8 +120,10 @@ const window: i64 = 20
 const settings: map<str, str>
 ```
 
-Function results are temporal unless the function is outputless. No syntax for
-a returned wiring scalar has been agreed.
+Ordinary temporal `fn` results are temporal unless the function is outputless.
+The agreed `const fn` extension instead returns a value, which may be computed
+at wiring time or inside a runtime node when the helper's phase contract
+permits. It is not yet implemented.
 
 ## Structured values and deltas
 
@@ -649,9 +662,17 @@ All state variables aggregate into one typed state value. State initializers
 lower to replay-aware startup initialization and do not overwrite restored
 state. `state` is by definition a time series and is always recordable: the
 language sets as its default the practice hgraph's own library applies only to
-loopback state. Bespoke non-temporal values, such as cached adaptor handles,
-are not `state`; they belong to a separate global or module-level resource
-concept whose syntax remains future work.
+loopback state. Reconstructible node-local data has the separate agreed
+`cache<T>` concept, mapped to native `State<T>` rather than
+`RecordableState<TSchema>`. It need not be global or module-owned. Cache does
+not require recordability, but rebuilding it must preserve observable
+computation; arbitrary resources still need a native ownership/lifecycle
+contract. Full cache declaration syntax and compiler support remain open.
+Both cache and state storage/objects must be constructed before `start`,
+separately from logical initialization or restore. See
+[ADR 0008](decisions/0008-temporal-contracts-and-target-mappings.md#cache-versus-recordable-state)
+for the reconstruction contract and the current C++ restriction against
+combining both state selectors.
 
 `inject` is a comma-separated function-level declaration of approved runtime
 capabilities. It does not add caller-visible parameters. `out` is a special
@@ -913,7 +934,10 @@ Later decisions must define:
   from temporal values;
 - collection delta literals and the native encoding for explicit optional-field
   clearing;
-- runtime scalar kernels, ephemeral caches, lifecycle output access, and sinks.
+- remaining phase/effect and modifier rules for value-level `const fn`,
+  cache declaration/initializer syntax, native type/target mappings, lifecycle
+  output access, and sinks; the agreed direction is in
+  [ADR 0008](decisions/0008-temporal-contracts-and-target-mappings.md).
 
 ### Open decisions (2026-09-07)
 

--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -20,6 +20,13 @@ source escape is C++ only.
 This interface extends the package and lifecycle model in
 [Modules and native extensions](modules.md). It is not a second module system.
 
+The subsequent agreed direction is recorded in
+[ADR 0008](decisions/0008-temporal-contracts-and-target-mappings.md): value-level
+`const fn`, reconstructible node-local cache, native type lifecycles, and
+semantic contracts separated from target-specific mappings. Those extensions
+are not implemented. The source examples and C++ descriptors below describe
+the existing native-function interface, not a new generalized mapping syntax.
+
 ## Source native C++ functions
 
 An HGL module may define a top-level exact native function and name the headers
@@ -149,10 +156,11 @@ their constraint arena.
 
 ### Hgraph operators
 
-A temporal callable is a normal registered hgraph operator. The descriptor
+A native temporal operator is a normal registered hgraph operator. The descriptor
 exposes its nominal operator contract and provider candidates, and HGL resolves
 it through the shared hgraph resolver. This is the path for graphs, nodes,
-sources, sinks, adaptors, and services that accept temporal arguments.
+sources, sinks, adaptors, and services, including temporal sources whose
+parameters are entirely fixed configuration.
 
 An ordinary C++ scalar function is never lifted implicitly into one node per
 call. A package that wants temporal use supplies and registers the corresponding
@@ -234,10 +242,19 @@ An opaque native type exposes no fields, inheritance, pointer operations, or
 layout to HGL. It may be passed only to native functions that name the same
 descriptor identity.
 
-The first state bridge is an owned RAII value. Construction occurs during
-replay-aware node startup; destruction occurs with the aggregate state after
-the stop phase. A resource that needs observable shutdown exposes a permitted
-stop-phase operation in addition to its destructor.
+The planned first state bridge is an owned RAII value. Storage and objects must
+be constructed during node initialization, before `start`; logical seeding,
+record/replay restoration, and cache reconstruction are distinct from physical
+construction. Normal destruction occurs after the stop phase, with cleanup
+also required for partial initialization. A resource that needs observable
+shutdown exposes a permitted stop-phase operation in addition to its destructor.
+
+Opaque storage is not an exemption from the language's persistence contract.
+Reconstructible non-recordable data belongs in HGL cache (native `State<T>`);
+semantic history belongs in HGL `state` (native `RecordableState<TSchema>`) and
+requires recordable types. The cache/state source and lifecycle bridge remain
+implementation work, including the current native restriction against mixing
+the two selectors in one node.
 
 Borrowed values are confined to the call or evaluation that produced them.
 They cannot be returned, stored in state or output, captured, placed in a

--- a/language/docs/design/operators.md
+++ b/language/docs/design/operators.md
@@ -62,6 +62,31 @@ A local function named `add_` does not change `a + b`. Explicit named calls
 still follow normal local/import lookup. System symbols resolve the native
 identity, not the nearest function with a matching short name.
 
+## Execution role and native implementations
+
+Status: agreed direction, not implemented. The existing symbol mapping and
+domain-property syntax are unchanged.
+
+An operator may have both temporal and value-level implementations, with
+either role implemented in HGL or natively. A graph-construction call can
+select a temporal candidate to compose or wire; a call inside node evaluation
+requires a value-level candidate. A permitted wiring-time value call may also
+use a value-level candidate. Role, concrete signature/domain, and constraints
+determine eligibility; native implementation language alone does not.
+
+`const fn` is the agreed value-function marker. Its combination with operator
+implementation and native declaration syntax remains open. Selection must
+preserve the nominal operator and shared matching rules, without adding
+per-tick overload lookup or a second language-local dispatcher. A value helper
+does not silently become a temporal node: lifting needs an explicit contract
+for activation, validity, REF access, and output/deltas as well as types.
+
+Algebraic properties still require the precise domain, selected candidate,
+and numerical policy before a transformation is legal. Merely supplying both
+execution roles does not prove they satisfy identical laws. See
+[ADR 0008](decisions/0008-temporal-contracts-and-target-mappings.md#operators-and-native-implementations)
+for the full distinction and compatibility boundary with existing `native fn`.
+
 ## Domain-bound declarations
 
 ```hgl

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -341,6 +341,9 @@ today (#767, "Readiness").
 | Explicit optional-field clearing (`field: null` in a `delta<S>`) | blocked | Needs a public hgraph clear-delta operation or encoding distinct from an omitted delta field; `ts_delta.h` has none ([Language model](language-model.md#structured-values-and-deltas)). |
 | Typed `const` generic struct metadata (`Vector<T, const size>`) | blocked | hgraph nominal Bundle `generic_arguments` carry type arguments only; both backends report "const generic struct arguments require typed constant Bundle metadata in hgraph". |
 | `const` parameters, `const` generics, `--set` | implemented | |
+| Value-level `const fn` | provisional | Agreed non-temporal execution role, not compile-time-only or purity; no parser/lowering support. Operator/native/export modifier combinations and compatibility with existing `native fn` remain open ([ADR 0008](decisions/0008-temporal-contracts-and-target-mappings.md)). |
+| Reconstructible node-local `cache<T>` | provisional | Concept and pre-`start` construction agreed; complete declaration/initializer syntax and HGL implementation remain open. Maps to native `State<T>`; HGL `state` remains recordable. Native static nodes currently reject combining `State` and `RecordableState`. Generic recordable-state initialization remains a separate gap ([ADR 0008](decisions/0008-temporal-contracts-and-target-mappings.md#cache-versus-recordable-state)). |
+| Native type lifecycle and target mappings | provisional | Semantic contracts, requirements, implementations, and target realizations must be distinct. Current C++ descriptor metadata is a starting point, not a generalized mapping implementation. Native type/hook syntax, capability contracts, mapping composition, and alternative target support remain open ([ADR 0008](decisions/0008-temporal-contracts-and-target-mappings.md#language-contracts-and-target-mappings)). |
 | `let`, `var`, typed uninitialized `var`, definite assignment | implemented | An assignment cannot change a `var`'s type; a runtime uninitialized local must be scalar. |
 | Graph-phase `for`: `elements`/`items` over fixed lists, independent bodies over maps and unbounded lists | partial | Both backends; maps use `values`/`items` and lists use `elements`/`items`. `for` is phase-neutral. Graph-phase `keys`, predicates, scalar and `const` captures, sets, bundles, reductions, loop results, escaping assignments, and `return` fail closed; `for` in a `test` body is a `phase` diagnostic; dynamic-body tests are structure-only (#767 item 4). |
 | Runtime `for`, `keys`/`values`/`elements`/`items` with predicates, `key_set` | partial | Generated C++ only: the direct backend never evaluates a runtime body, so the scripted path is the C++ backend plus a loaded image. `values` is the keyed/named value projection and `elements` is list/set traversal; they are not aliases. `key_set` inside a runtime body is rejected; unbounded-list added/removed views need a public hgraph view API. |
@@ -619,7 +622,13 @@ Candidates, in risk order:
 - add a public native operation or canonical delta encoding for explicitly
   clearing an optional TSB field without confusing it with an omitted delta;
 - enums and additional canonical temporal structures;
-- explicit ephemeral cache semantics;
+- implement the agreed reconstructible-cache semantics and pre-`start`
+  construction, after settling declaration/initializer syntax and native
+  coexistence with recordable state;
+- value-level `const fn` and phase-eligible HGL/native operator candidates;
+- native type lifecycles and target mappings, staged through the bounded
+  conformance cases in
+  [ADR 0008](decisions/0008-temporal-contracts-and-target-mappings.md#implementation-boundary-and-next-work);
 - additional lifecycle capabilities and output access;
 - higher-order functions and runtime control flow;
 - explicit generic arguments on function/operator calls, generic parameter

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -112,8 +112,11 @@ surface.
 
 ## Current invariants
 
-- `fn` is the only implementation declaration; `operator` declares a bodyless
-  nominal callable contract, and `impl fn` is the only way to implement one.
+- The implemented temporal model uses `fn`; `operator` declares a bodyless
+  nominal callable contract, implemented by `impl fn`. The agreed value-level
+  `const fn` extension is not implemented; see
+  [ADR 0008](../design/decisions/0008-temporal-contracts-and-target-mappings.md)
+  for phase eligibility, cache/state, and target-mapping follow-up work.
 - Every `operator` and non-generic `impl fn` candidate is public by definition;
   generic implementations contribute only their explicit `instantiate`
   materializations, whose `_` arguments may retain resolver slots, and an

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -14,6 +14,13 @@ distinguishing wiring composition from runtime node evaluation. The rule is
 intentionally narrow so it can be refined before the first language edition
 is accepted.
 
+The agreed `const fn` extension identifies non-temporal value functions;
+parameter-level `const` retains its wiring-time meaning. This extension is
+not implemented or included in the grammar below. Cache declarations, native
+type lifecycle forms, and target-mapping declarations also remain outside
+the implemented grammar. Their agreed semantics and open syntax are recorded
+in [ADR 0008](../design/decisions/0008-temporal-contracts-and-target-mappings.md).
+
 ## Lexical rules
 
 Source files are UTF-8. The first lexer slice uses ASCII identifiers:
@@ -2215,14 +2222,16 @@ observation rather than rule, is collected under
   rule;
 - general anonymous capture and type inference beyond inline iterator
   predicates;
-- callable scalar kernels inside runtime functions;
+- remaining phase/effect rules and modifier combinations for the agreed
+  value-level `const fn` extension;
 - collection delta constructors and a first-class public native encoding for
   explicitly clearing an optional TSB field;
 - rolling-window iteration over hgraph's window view (`values`,
   `time_values`, `value_times`, `removed_value`), which both window kinds
   share, and a parameter spelling that accepts either kind (hgraph's
   `TSWAny`);
-- ephemeral caches, lifecycle output access, and runtime sinks;
+- declaration/initializer syntax for reconstructible caches, native type
+  lifecycle and mapping contracts, lifecycle output access, and runtime sinks;
 - runtime scalar error behavior;
 - an explicit end bound and approximate comparison for `eval`, delta
   spellings for set, map, and list harness elements, and tuple construction

--- a/language/docs/user-guide/README.md
+++ b/language/docs/user-guide/README.md
@@ -1,10 +1,11 @@
 # User Guide
 
-This guide describes the emerging source language from an author's point of
-view: how functions and types look, which values change over time, and how
-source calls reach hgraph.
+HGL is a temporal programming language for computations over values that
+evolve through time. This guide describes it from an author's point of view:
+how functions and types look, how change and validity affect computation, and
+how source calls reach hgraph.
 
-> **Design preview:** the current `hgl` command checks these examples and
+> **Design preview:** the current `hgl` command checks the compiler example corpus and
 > runs composition functions directly and, for file-based `hgl test` and
 > `hgl run`, compiles, caches, and loads the documented scalar runtime-node
 > subset on Unix. The REPL uses the same native route and transactionally
@@ -14,8 +15,9 @@ source calls reach hgraph.
 > status of every surface (implemented, partial, provisional, or blocked) in
 > the [roadmap status matrix](../design/roadmap.md#feature-status-matrix-2026-09-07).
 > The documents record syntax agreed during design discussion, not a source
-> compatibility promise; a section marked provisional describes agreed
-> syntax the compiler does not accept yet.
+> compatibility promise. Sections marked provisional or not implemented are
+> design material, not accepted compiler examples; open syntax is identified
+> separately from agreed syntax.
 
 ## Read in this order
 
@@ -42,7 +44,7 @@ frontend checks every example; the scripted backends run the supported subset de
 
 ## Current language shape
 
-The source language uses `fn` for every implementation and does not ask authors
+The current temporal implementation model uses `fn` and does not ask authors
 to declare a `graph` or `node`. A bodyless `operator` declares a nominal,
 generic callable contract whose implementations are supplied by compatible
 `impl fn` definitions. Operators are public by definition; an ordinary
@@ -55,7 +57,8 @@ fn midpoint(
     (tob[0] + tob[1]) / 2.0
 ```
 
-Parameters are temporal by default. `const` marks a wiring-time value:
+In an ordinary `fn`, parameters are temporal by default. Parameter-level
+`const` marks a wiring-time value:
 
 ```hgl
 export fn smooth(
@@ -68,7 +71,14 @@ export fn smooth(
 
 Within a body, `let` introduces an immutable local and `var` introduces a
 mutable local. Runtime `var` values last only for the current block execution;
-persistent values use `state`.
+persistent semantic history uses recordable `state`.
+
+The agreed extension adds [value-level `const fn`](functions.md#value-level-functions)
+for direct computations without independent ticks, and
+[reconstructible caches](functions.md#reconstructible-cache) for node-local
+data excluded from record/replay. Neither source feature is implemented yet.
+`const fn` does not mean compile-time-only or pure; its role is distinct from
+parameter-level `const`.
 
 The current design classifies a function from the constructs used in its body:
 

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -1,9 +1,10 @@
 # Functions
 
-`fn` is the only user-facing implementation declaration. Source does not label
-an implementation as a graph or node. A bodyless `operator` declaration names
+Ordinary `fn` declares a temporal implementation. Source does not label
+it as a graph or node. A bodyless `operator` declaration names
 a generic callable contract whose implementations are supplied by `impl fn`
-definitions.
+definitions. The agreed value-level extension is `const fn`, described below
+with its implementation boundary.
 
 ## Named functions
 
@@ -37,6 +38,39 @@ Calls accept positional arguments followed by named arguments:
 ```hgl
 smooth(tob, window: 50)
 ```
+
+## Value-level functions
+
+Status: `const fn` is agreed syntax, not yet implemented. This example is
+design material rather than an accepted compiler fixture:
+
+```hgl
+const fn scale(value: f64, factor: f64) -> f64 =>
+    value * factor
+```
+
+A value-level function executes on values or explicitly admitted views and
+returns a value, not a temporal connection. It does not wire topology or
+independently tick. A runtime node may call it on current input values; graph
+construction may call it on available scalar values when its phase/effect
+contract permits. There is no implicit reading of a temporal port's payload
+at wiring time.
+
+Function-level `const` does not mean compile-time-only, pure, or immutable.
+Effects, mutation, ownership, and allowed lifecycle phases need separate
+contracts. A value function cannot contain node declarations or handlers, or
+call temporal implementations. Its calls must remain value-level.
+
+Ordinary `fn` still composes a graph or wires a runtime node. A signature with
+only `const` parameters does not imply `const fn`: fixed configuration can
+describe a source that ticks. Parameter-level `const` continues to mean
+wiring-time configuration, not a value argument supplied on each call.
+
+The [design decision](../design/decisions/0008-temporal-contracts-and-target-mappings.md)
+includes an HGL caller and expected C++ lowering. Combinations with `impl`,
+`native`, and `export`, and migration of existing `native fn` helpers, remain
+open syntax/compatibility work. There is no new accepted spelling for them in
+this section.
 
 ## Parameter packs
 
@@ -184,7 +218,7 @@ on an `impl fn`: the binding already supplies its public meaning.
 
 ## Temporal and constant parameters
 
-An unmodified parameter is temporal:
+In an ordinary `fn`, an unmodified parameter is temporal:
 
 ```hgl
 price: f64
@@ -537,8 +571,9 @@ discarding a temporal result is an error.
 
 ## Composition and runtime functions
 
-The current design uses body constructs rather than a declaration keyword to
-classify an `fn`.
+The current design uses body constructs to classify an ordinary temporal
+`fn` as composition or a runtime node. The agreed `const fn` extension
+separately identifies value-level functions; it does not replace this rule.
 
 An ordinary expression body describes composition:
 
@@ -847,13 +882,37 @@ are meant to be skipped.
 
 State declarations are function-level declarations. All state variables in a
 function are aggregated into one typed state value. Initializers run during
-node startup and do not overwrite state restored for record/replay. State that
-affects later ticks is recordable by default.
+node startup and do not overwrite state restored for record/replay. HGL
+`state` is always recordable, mapping to native `RecordableState<TSchema>`.
 
 `let` is an immutable lexical binding and `var` is a mutable lexical binding.
 Either one declared inside `when` exists only for that evaluation; `var` does
-not become persistent merely because it is mutable. Use `state` whenever the
-next evaluation must observe the value.
+not become persistent merely because it is mutable. Use `state` when later
+computation depends on retained history.
+
+### Reconstructible cache
+
+Status: the `cache<T>` concept and lifecycle are agreed; complete declaration
+and initializer syntax and compiler support remain open.
+
+A cache holds node-local data that can be reconstructed from authoritative
+current inputs and restored state without replaying missing history. Starting
+with an empty/rebuilt cache must not change subsequent values, validity,
+ticks, deltas, or semantic side effects. A derived lookup index may qualify;
+a running total or unconsumed event history does not.
+
+HGL cache maps to native `State<T>`, not `RecordableState<TSchema>`. It follows
+state's applicable typing/lifetime rules but may use admitted non-recordable
+native types. HGL `state` retains its recordability requirement. Cache storage
+and objects are constructed during initialization before `start`, just as
+state storage is; rebuilding logical contents is a separate operation.
+
+An implementation may need both cache and recordable state. The C++ static-node
+API currently rejects combining its two state selectors, so this requires
+backend work as well as language support. Cache does not close the separate
+generic-state/default-construction, sparse-validity, queue, or window design
+gaps. See the [cache contract](../design/decisions/0008-temporal-contracts-and-target-mappings.md#cache-versus-recordable-state)
+for restart, REF lifetime, and native construction requirements.
 
 ## Injectables
 
@@ -1031,7 +1090,10 @@ also using an existing node-only construct. The explicit phase-disambiguation
 syntax, if any, remains to be designed.
 
 The exact conditional-expression spelling, structural metadata aggregation,
-ephemeral cache syntax, and calls between runtime functions remain provisional.
+and complete cache declaration syntax remain provisional. Calls to reusable
+value-level helpers use the agreed, unimplemented `const fn` direction; they
+must not be confused with calls that would wire a temporal function during
+node evaluation.
 
 Operator calls are implementation-neutral: after source name resolution chooses
 one nominal contract, hgraph's overload registry may select a graph or native


### PR DESCRIPTION
## Summary

Record the recent language-design agreement in ADR 0008 and align the language entry points, guides, native/operator records, and roadmap.

- Describe HGL as a temporal programming language.
- Define `const fn` as value-level execution, distinct from parameter-level `const`, compile-time execution, purity, and temporal graph/node calls.
- Document phase-eligible HGL/native operator implementations while preserving nominal identities, symbol mappings, and shared resolution rules.
- Define reconstructible `cache<T>` versus recordable `state`, mapping respectively to native `State<T>` and `RecordableState<TSchema>`, with both objects constructed before `start`.
- Separate semantic contracts, requirements, implementations, and target mappings; describe native atomic types and memory/construction/copy/move/destruction capabilities without fixing a mapping DSL.
- Include prospective HGL source followed by its illustrative C++ lowering.

## Design and implementation boundary

Documentation only: no compiler, runtime, grammar, descriptor-format, or accepted example changes. `const fn` is agreed but unimplemented; full cache declarations, native lifecycle syntax, modifier combinations, and mapping composition remain open. The current native restriction against mixing `State` and `RecordableState` is explicitly recorded as follow-up work.

This refines the cache portion of HGL-MIG-005 without declaring generic recordable-state construction, sparse validity, queues, or windows solved. Related: #801 (migration tracking) and #796 (exploratory runtime contracts). Neither branch is modified or superseded by this PR.

Prepared on an isolated branch from main, then rebased onto the newly merged parameter-pack and floating-point conversion work.

## Validation

- `git diff --check origin/main...HEAD` passed.
- All 159 local Markdown links/anchors across the 14 edited documents passed; fenced blocks and private-path exclusions checked.
- Extracted the illustrative C++ block and compiled it, including static-node signature instantiation, against current headers with warnings as errors.
- Confirmed the existing native state-selector restriction and C++-specific descriptor metadata against implementation.
- Full native/Python runtime suites not run: documentation-only change. Prospective HGL snippets are explicitly not compiler acceptance fixtures.
- Remote CI not checked.
